### PR TITLE
support main files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
-          command: clippy
+          command: clippy --all-targets --all-features

--- a/src/providers/npm.rs
+++ b/src/providers/npm.rs
@@ -55,4 +55,5 @@ impl Provider for NpmProvider {
 pub struct PackageJson {
     pub name: String,
     pub scripts: Option<HashMap<String, String>>,
+    pub main: Option<String>,
 }

--- a/src/providers/npm.rs
+++ b/src/providers/npm.rs
@@ -43,8 +43,12 @@ impl Provider for NpmProvider {
             }
         }
 
-        if app.includes_file("index.js") {
-            return Ok(Some("node index.js".to_string()));
+        if let Some(main) = package_json.main {
+            if app.includes_file(&main) {
+                return Ok(Some(format!("node {}", main)));
+            }
+        } else if app.includes_file("index.js") {
+            return Ok(Some(String::from("node index.js")));
         }
 
         Ok(None)

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -40,8 +40,12 @@ impl Provider for YarnProvider {
             }
         }
 
-        if app.includes_file("index.js") {
-            return Ok(Some("node index.js".to_string()));
+        if let Some(main) = package_json.main {
+            if app.includes_file(&main) {
+                return Ok(Some(format!("node {}", main)));
+            }
+        } else if app.includes_file("index.js") {
+            return Ok(Some(String::from("node index.js")))
         }
 
         Ok(None)

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -45,7 +45,7 @@ impl Provider for YarnProvider {
                 return Ok(Some(format!("node {}", main)));
             }
         } else if app.includes_file("index.js") {
-            return Ok(Some(String::from("node index.js")))
+            return Ok(Some(String::from("node index.js")));
         }
 
         Ok(None)


### PR DESCRIPTION
When using NPM/Yarn, in the package.json you can have the main entry. This now checks for that field, checks if the file exists and uses that as a start command if all else fails.