### PR TITLE
Add flags to suggested docker run command

### DIFF
--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -146,7 +146,7 @@ impl<'a> AppBuilder<'a> {
         self.logger.log_section("Successfully Built!");
 
         println!("\nRun:");
-        println!("  docker run {}", name);
+        println!("  docker run -i -t {}", name);
 
         Ok(())
     }

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -146,7 +146,7 @@ impl<'a> AppBuilder<'a> {
         self.logger.log_section("Successfully Built!");
 
         println!("\nRun:");
-        println!("  docker run -i -t {}", name);
+        println!("  docker run -it {}", name);
 
         Ok(())
     }


### PR DESCRIPTION
From Docker's [documentation](https://docs.docker.com/engine/reference/run/#detached-vs-foreground), they suggest adding `-i` (keep STDIN open) and `-t` (Allocate a pseudo-tty so that `CTRL+c` works) when running containers in the foreground.