### PR TITLE
Add Deno provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,7 +188,9 @@ dependencies = [
  "clap",
  "colored",
  "fs_extra",
+ "glob",
  "indoc",
+ "regex",
  "serde",
  "serde_json",
  "tempdir",
@@ -269,6 +286,23 @@ checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ anyhow = "1.0.56"
 clap = { version = "3.1.6", features = ["derive"] }
 colored = "2.0.0"
 fs_extra = "1.2.0"
+glob = "0.3.0"
 indoc = "1.0.4"
+regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 tempdir = "0.3.7"

--- a/examples/deno/src/index.ts
+++ b/examples/deno/src/index.ts
@@ -1,0 +1,10 @@
+// Foo
+import { serve } from "https://deno.land/std@0.114.0/http/server.ts";
+
+const port = parseInt(Deno.env.get("PORT") ?? "8000");
+serve(
+  () => new Response("Choo Choo! Welcome to your Deno app\n"),
+  { addr: `:${port}` },
+).catch(err => console.log("Failed to serve", err));
+
+console.log(`http://localhost:${port}/`);

--- a/examples/deno/src/index.ts
+++ b/examples/deno/src/index.ts
@@ -1,4 +1,3 @@
-// Foo
 import { serve } from "https://deno.land/std@0.114.0/http/server.ts";
 
 const port = parseInt(Deno.env.get("PORT") ?? "8000");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@ use std::fs;
 use crate::{
     nixpacks::{app::App, logger::Logger, plan::BuildPlan, AppBuilder, AppBuilderOptions},
     providers::{
-        go::GolangProvider, npm::NpmProvider, rust::RustProvider, yarn::YarnProvider, deno::DenoProvider, Pkg,
+        deno::DenoProvider, go::GolangProvider, npm::NpmProvider, rust::RustProvider,
+        yarn::YarnProvider, Pkg,
     },
 };
 use anyhow::{Context, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use std::fs;
 use crate::{
     nixpacks::{app::App, logger::Logger, plan::BuildPlan, AppBuilder, AppBuilderOptions},
     providers::{
-        go::GolangProvider, npm::NpmProvider, rust::RustProvider, yarn::YarnProvider, Pkg,
+        go::GolangProvider, npm::NpmProvider, rust::RustProvider, yarn::YarnProvider, deno::DenoProvider, Pkg,
     },
 };
 use anyhow::{Context, Result};
@@ -18,6 +18,7 @@ pub fn get_providers() -> Vec<&'static dyn Provider> {
         &NpmProvider {},
         &GolangProvider {},
         &RustProvider {},
+        &DenoProvider {},
     ]
 }
 

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -63,8 +63,7 @@ impl App {
 
             if let Some(p) = path_buf.to_str() {
                 let f = self.read_file(p)?;
-                let matches = re.find(f.as_str());
-                if matches.is_some() {
+                if re.find(f.as_str()).is_some() {
                     return Ok(true);
                 }
             }

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -183,11 +183,16 @@ mod tests {
     fn test_find_files() -> Result<()> {
         let app = App::new("./examples/monorepo")?;
         let m = app.find_files("**/*.tsx").unwrap();
+        let dir = env::current_dir().unwrap();
         assert_eq!(
             m,
             vec![
-                "packages/client/pages/_app.tsx",
-                "packages/client/pages/index.tsx"
+                dir.join("examples/monorepo/packages/client/pages/_app.tsx")
+                    .to_str()
+                    .unwrap(),
+                dir.join("examples/monorepo/packages/client/pages/index.tsx")
+                    .to_str()
+                    .unwrap(),
             ]
         );
         Ok(())

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::{env, fs, path::PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use glob::glob;
 use regex::Regex;
 use serde::de::DeserializeOwned;
@@ -93,7 +93,7 @@ impl App {
     pub fn strip_source_path(&self, abs: &str) -> Result<String> {
         let source_str = match self.source.to_str() {
             Some(s) => s,
-            None => return Err(anyhow::Error::msg("Failed to parse source path")),
+            None => bail!("Failed to parse source path"),
         };
         let abs_path = Path::new(abs);
 
@@ -106,7 +106,7 @@ impl App {
         // Convert path to string
         return match stripped.to_str() {
             Some(v) => Ok(v.to_string()),
-            None => Err(anyhow::Error::msg("Failed to convert path to string")),
+            None => bail!("Failed to convert path to string"),
         };
     }
 }

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -52,8 +52,8 @@ impl App {
     }
 
     pub fn read_json<T>(&self, name: &str) -> Result<T>
-        where
-            T: DeserializeOwned,
+    where
+        T: DeserializeOwned,
     {
         let contents = self.read_file(name)?;
         let value: T = serde_json::from_str(contents.as_str())?;
@@ -61,8 +61,8 @@ impl App {
     }
 
     pub fn read_toml<T>(&self, name: &str) -> Result<T>
-        where
-            T: DeserializeOwned,
+    where
+        T: DeserializeOwned,
     {
         let contents = self.read_file(name)?;
         let toml_file = toml::from_str(contents.as_str())?;

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -40,10 +40,7 @@ impl App {
         let relative_paths = glob(pattern_str)?
             .filter_map(|p| p.ok()) // Remove bad ones
             .filter_map(|p| self.strip_source_path(p).ok()) // Make relative
-            .filter_map(|p| match p.to_str() {
-                Some(p) => Some(p.to_string()),
-                None => None,
-            })
+            .filter_map(|p| p.to_str().map(|p| p.to_string()))
             .collect();
 
         Ok(relative_paths)
@@ -115,10 +112,9 @@ impl App {
 mod tests {
     use std::collections::HashMap;
 
+    use super::*;
     use serde::{Deserialize, Serialize};
     use serde_json::{Map, Value};
-
-    use super::*;
 
     #[derive(Serialize, Deserialize)]
     struct TestPackageJson {

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -39,8 +39,8 @@ impl App {
         };
 
         let relative_paths = glob(pattern_str)?
-            .filter_map(|p| p.ok()) // Remove bad ones
-            .filter_map(|p| p.to_str().map(|p| p.to_string())) // convert to string
+            .filter_map(|result| result.ok()) // Remove bad ones
+            .filter_map(|path| path.to_str().map(|p| p.to_string())) // convert to string
             .collect();
 
         Ok(relative_paths)

--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -1,0 +1,37 @@
+use super::Provider;
+use crate::{nixpacks::app::App, providers::Pkg};
+use anyhow::{Result};
+use regex::Regex;
+
+pub struct DenoProvider {}
+
+impl Provider for DenoProvider {
+    fn name(&self) -> &str {
+        "deno"
+    }
+
+    fn detect(&self, app: &App) -> Result<bool> {
+        if !app.includes_file("src/index.ts") {
+            false;
+        }
+
+        let re = Regex::new(r##"(?m)^import .+ from "https://deno.land/[^"]+\.ts";?$"##).unwrap();
+        Ok(app.find_match(&re, "**/*.ts"))
+    }
+
+    fn pkgs(&self, _app: &App) -> Vec<Pkg> {
+        vec![Pkg::new("pkgs.stdenv"), Pkg::new("pkgs.deno")]
+    }
+
+    fn install_cmd(&self, _app: &App) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    fn suggested_build_cmd(&self, _app: &App) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    fn suggested_start_command(&self, _app: &App) -> Result<Option<String>> {
+        Ok(Some("deno run src/index.ts".to_string()))
+    }
+}

--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -1,6 +1,6 @@
 use super::Provider;
 use crate::{nixpacks::app::App, providers::Pkg};
-use anyhow::{Result};
+use anyhow::Result;
 use regex::Regex;
 
 pub struct DenoProvider {}

--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -35,6 +35,10 @@ impl Provider for DenoProvider {
             None => return Ok(None),
         };
 
-        return Ok(Some(format!("deno run --allow-all {}", path_to_index)));
+        let relative_path_to_index = app.strip_source_path(&path_to_index)?;
+        return Ok(Some(format!(
+            "deno run --allow-all {}",
+            relative_path_to_index
+        )));
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,11 +2,11 @@ use crate::nixpacks::app::App;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
+pub mod deno;
 pub mod go;
 pub mod npm;
 pub mod rust;
 pub mod yarn;
-pub mod deno;
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Pkg {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -6,6 +6,7 @@ pub mod go;
 pub mod npm;
 pub mod rust;
 pub mod yarn;
+pub mod deno;
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Pkg {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -50,7 +50,10 @@ fn test_go() -> Result<()> {
 fn test_deno() -> Result<()> {
     let plan = gen_plan("./examples/deno", Vec::new(), None, None, false)?;
     assert_eq!(plan.build_cmd, None);
-    assert_eq!(plan.start_cmd, Some("deno run src/index.ts".to_string()));
+    assert_eq!(
+        plan.start_cmd,
+        Some("deno run --allow-all src/index.ts".to_string())
+    );
 
     Ok(())
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -47,6 +47,15 @@ fn test_go() -> Result<()> {
 }
 
 #[test]
+fn test_deno() -> Result<()> {
+    let plan = gen_plan("./examples/deno", Vec::new(), None, None, false)?;
+    assert_eq!(plan.build_cmd, None);
+    assert_eq!(plan.start_cmd, Some("deno run src/index.ts".to_string()));
+
+    Ok(())
+}
+
+#[test]
 fn test_procfile() -> Result<()> {
     let plan = gen_plan("./examples/procfile", Vec::new(), None, None, false)?;
     assert_eq!(plan.start_cmd, Some("node index.js".to_string()));


### PR DESCRIPTION
This PR adds support for [Deno](https://deno.land/). Since Deno projects don't have any specific files we can use for detection, this PR adds a new `find_match` fn which will scan a glob of files and match a regular expression against the content for Deno-style imports.

_Note: this is my first experience with Rust so let me know if the code is trash!_