### PR TITLE
install npm/yarn dependencies from lockfile

### DIFF
--- a/src/providers/npm.rs
+++ b/src/providers/npm.rs
@@ -24,7 +24,7 @@ impl Provider for NpmProvider {
     }
 
     fn install_cmd(&self, _app: &App, _env: &Environment) -> Result<Option<String>> {
-        Ok(Some("npm install".to_string()))
+        Ok(Some("npm ci".to_string()))
     }
 
     fn suggested_build_cmd(&self, app: &App, _env: &Environment) -> Result<Option<String>> {

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -21,7 +21,7 @@ impl Provider for YarnProvider {
     }
 
     fn install_cmd(&self, _app: &App, _env: &Environment) -> Result<Option<String>> {
-        Ok(Some("yarn".to_string()))
+        Ok(Some("yarn install --frozen-lockfile".to_string()))
     }
 
     fn suggested_build_cmd(&self, app: &App, _env: &Environment) -> Result<Option<String>> {


### PR DESCRIPTION
- Install NPM deps with `npm ci`
- Install Yarn deps with `yarn install --frozen-lockfile`

In both cases this will install deps from the lockfile directly and will not update the lockfile with changes.
