### PR TITLE
Automate GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  create-release:
+    name: create-release
+    runs-on: ubuntu-latest
+    outputs:
+      nixpacks_version: ${{ env.NIXPACKS_VERSION }}
+
+    steps:
+      - name: Get the release version from the tag
+        shell: bash
+        if: env.NIXPACKS_VERSION == ''
+        run: |
+          # Apparently, this is the right way to get a tag name. Really?
+          #
+          # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+          echo "NIXPACKS_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "version is: ${{ env.NIXPACKS_VERSION }}"
+
+      - name: Build Changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v2.9.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        id: release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.NIXPACKS_VERSION }}
+          release_name: ${{ env.NIXPACKS_VERSION }}
+          body: ${{steps.build_changelog.outputs.changelog}}
+
+  build-release:
+    name: Build release assets
+    needs: ['create-release']
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+        # Linux
+        - { os: ubuntu-latest, build: linux, toolchain: stable, target: x86_64-unknown-linux-musl, cross: true }
+        - { os: ubuntu-latest, build: linux-arm, toolchain: stable, target: arm-unknown-linux-gnueabihf, cross: true }
+
+        # Macos
+        - { os: macos-latest, build: macos, toolchain: stable, target: x86_64-apple-darwin, cross: false }
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.config.toolchain }}
+        target: ${{ matrix.config.target }}
+        profile: minimal
+        override: true
+        default: true
+
+    - name: Install cross
+      uses: actions-rs/cargo@v1
+      if: ${{ matrix.config.cross }}
+      with:
+        command: install
+        args: cross
+
+    - name: Build release binary
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ matrix.config.cross }}
+        command: build
+        args: --release --target ${{ matrix.config.target }}
+
+    - name: Pack binaries if unix
+      if: matrix.config.os != 'windows-latest'
+      run: tar -C ./target/${{ matrix.config.target }}/release -czvf nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.config.build }}.tar.gz nixpacks nixpacks
+
+    - name: Pack binaries if windows
+      if: matrix.config.os == 'windows-latest'
+      run: compress-archive ./target/${{ matrix.config.build }}/release/nixpacks.exe, ./target/${{ matrix.config.target }}/release/nixpacks.exe nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.config.target }}-${{ matrix.config.target_cpu }}.zip
+
+    - name: Upload release archive
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ needs.create-release.outputs.nixpacks_version }}
+        files: |
+          nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.config.build }}.tar.gz
+
+    - name: Set SHA
+      if: matrix.config.os == 'macos-latest'
+      id: shasum
+      run: |
+        echo ::set-output name=sha::"$(shasum -a 256 ./release/gitui-mac.tar.gz | awk '{printf $1}')"
+
+    - name: Update homebrew tap
+      uses: mislav/bump-homebrew-formula-action@v1
+      if: "matrix.config.os == 'macos-latest' && !contains(github.ref, '-')"
+      with:
+        formula-name: nixpacks
+        formula-path: nixpacks.rb
+        homebrew-tap: railwayapp/homebrew-tap
+        download-url: https://github.com/railwayapp/nixpacks/releases/download/${{ needs.create-release.outputs.nixpacks_version }}/nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.config.build }}.tar.gz
+      env:
+        COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "nixpacks"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "nixpacks"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+license = "MIT"
+authors = ["Railway <contact@railway.app>"]
+description = "Generate an OCI compliant image based off app source"
+readme = "README.md"
+homepage = "https://github.com/railwayapp/nixpacks"
+repository = "https://github.com/railwayapp/nixpacks"
 
 [[bin]]
 name = "nixpacks"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,12 @@ use anyhow::Result;
 use clap::{arg, Arg, Command};
 
 fn main() -> Result<()> {
-    let matches = Command::new("bb")
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+    let matches = Command::new("nixpacks")
         .subcommand_required(true)
         .arg_required_else_help(true)
+        .version(VERSION)
         .subcommand(
             Command::new("plan")
                 .about("Generate a build plan for an app")


### PR DESCRIPTION
- GitHub action that runs on every tag increment
  * Creates a GitHub releases with Changelog based on PRs
  * Publishes to brew (https://github.com/railwayapp/homebrew-tap)

The process for getting the action to run is by running `cargo release patch`
