### PR TITLE
Allow specifying tags on output Docker image

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub fn gen_plan(
         pin_pkgs,
         out_dir: None,
         plan_path: None,
+        tags: Vec::new(),
     };
 
     let app = App::new(path)?;
@@ -68,6 +69,7 @@ pub fn build(
     envs: Vec<&str>,
     plan_path: Option<String>,
     out_dir: Option<String>,
+    tags: Vec<&str>,
 ) -> Result<()> {
     let logger = Logger::new();
     let providers = get_providers();
@@ -79,6 +81,7 @@ pub fn build(
         pin_pkgs,
         out_dir,
         plan_path,
+        tags: tags.iter().map(|s| s.to_string()).collect(),
     };
 
     let app = App::new(path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,14 @@ fn main() -> Result<()> {
                         .short('o')
                         .help("Save output directory instead of building it with Docker")
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::new("tag")
+                        .long("tag")
+                        .short('t')
+                        .help("Additional tags to add to the output image")
+                        .takes_value(true)
+                        .multiple_values(true),
                 ),
         )
         .arg(
@@ -108,8 +116,13 @@ fn main() -> Result<()> {
             let plan_path = matches.value_of("plan").map(|n| n.to_string());
             let output_dir = matches.value_of("out").map(|n| n.to_string());
 
+            let tags: Vec<_> = match matches.values_of("tag") {
+                Some(values) => values.collect(),
+                None => Vec::new(),
+            };
+
             build(
-                path, name, pkgs, build_cmd, start_cmd, pin_pkgs, envs, plan_path, output_dir,
+                path, name, pkgs, build_cmd, start_cmd, pin_pkgs, envs, plan_path, output_dir, tags,
             )?;
         }
         _ => eprintln!("Invalid command"),


### PR DESCRIPTION
Allow tagging the resulting Docker image with additional tags. This behaviour is needed to deploy on Railway and matches the behaviour seen with `pack`.
