### PR TITLE
Cleanup build plan to match RFC

### DIFF
--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -26,7 +26,7 @@ use self::{
     plan::BuildPlan,
 };
 
-static NIX_PACKS_VERSION: &str = "0.0.1";
+const NIX_PACKS_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // https://status.nixos.org/
 static NIXPKGS_ARCHIVE: &str = "30d3d79b7d3607d56546dd2a6b49e156ba0ec634";
@@ -96,12 +96,12 @@ impl<'a> AppBuilder<'a> {
         let variables = self.get_variables().context("Getting plan variables")?;
 
         let plan = BuildPlan {
-            version: NIX_PACKS_VERSION.to_string(),
-            setup: setup_phase,
-            install: install_phase,
-            build: build_phase,
-            start: start_phase,
-            variables,
+            version: Some(NIX_PACKS_VERSION.to_string()),
+            setup: Some(setup_phase),
+            install: Some(install_phase),
+            build: Some(build_phase),
+            start: Some(start_phase),
+            variables: Some(variables),
         };
 
         Ok(plan)
@@ -192,18 +192,18 @@ impl<'a> AppBuilder<'a> {
 
     fn get_setup_phase(&self) -> Result<SetupPhase> {
         let mut setup_phase: SetupPhase = match self.provider {
-            Some(provider) => provider.setup(self.app, self.environment)?,
+            Some(provider) => provider
+                .setup(self.app, self.environment)?
+                .unwrap_or_default(),
             None => SetupPhase::default(),
         };
 
         // Add custom user packages
         let mut pkgs = self.options.custom_pkgs.clone();
-        setup_phase.nix_config.add_pkgs(&mut pkgs);
+        setup_phase.nix.add_pkgs(&mut pkgs);
 
         if self.options.pin_pkgs {
-            setup_phase
-                .nix_config
-                .set_archive(NIXPKGS_ARCHIVE.to_string())
+            setup_phase.nix.set_archive(NIXPKGS_ARCHIVE.to_string())
         }
 
         Ok(setup_phase)
@@ -211,7 +211,9 @@ impl<'a> AppBuilder<'a> {
 
     fn get_install_phase(&self) -> Result<InstallPhase> {
         let install_phase = match self.provider {
-            Some(provider) => provider.install(self.app, self.environment)?,
+            Some(provider) => provider
+                .install(self.app, self.environment)?
+                .unwrap_or_default(),
             None => InstallPhase::default(),
         };
 
@@ -220,7 +222,9 @@ impl<'a> AppBuilder<'a> {
 
     fn get_build_phase(&self) -> Result<BuildPhase> {
         let mut build_phase = match self.provider {
-            Some(provider) => provider.build(self.app, self.environment)?,
+            Some(provider) => provider
+                .build(self.app, self.environment)?
+                .unwrap_or_default(),
             None => BuildPhase::default(),
         };
 
@@ -235,7 +239,9 @@ impl<'a> AppBuilder<'a> {
         let procfile_cmd = self.parse_procfile()?;
 
         let mut start_phase = match self.provider {
-            Some(provider) => provider.start(self.app, self.environment)?,
+            Some(provider) => provider
+                .start(self.app, self.environment)?
+                .unwrap_or_default(),
             None => StartPhase::default(),
         };
 
@@ -259,8 +265,9 @@ impl<'a> AppBuilder<'a> {
         let new_variables = match self.provider {
             Some(provider) => {
                 // Merge provider variables
-                let provider_variables =
-                    provider.environment_variables(self.app, self.environment)?;
+                let provider_variables = provider
+                    .environment_variables(self.app, self.environment)?
+                    .unwrap_or_default();
                 provider_variables.into_iter().chain(variables).collect()
             }
             None => variables,
@@ -314,16 +321,17 @@ impl<'a> AppBuilder<'a> {
     }
 
     pub fn gen_nix(plan: &BuildPlan) -> Result<String> {
-        let nixpkgs = plan
-            .setup
-            .nix_config
+        let setup_phase = plan.setup.clone().unwrap_or_default();
+
+        let nixpkgs = setup_phase
+            .nix
             .pkgs
             .iter()
             .map(|p| p.to_nix_string())
             .collect::<Vec<String>>()
             .join(" ");
 
-        let nix_archive = plan.setup.nix_config.nixpkgs_archive.clone();
+        let nix_archive = setup_phase.nix.archive.clone();
         let pkg_import = match nix_archive {
             Some(archive) => format!(
                 "import (fetchTarball \"https://github.com/NixOS/nixpkgs/archive/{}.tar.gz\")",
@@ -332,10 +340,13 @@ impl<'a> AppBuilder<'a> {
             None => "import <nixpkgs>".to_string(),
         };
 
-        let overlays = plan
-            .setup
-            .nix_config
-            .overlays
+        let mut overlays: Vec<String> = Vec::new();
+        for pkg in &setup_phase.nix.pkgs {
+            if let Some(overlay) = &pkg.overlay {
+                overlays.push(overlay.to_string());
+            }
+        }
+        let overlays_string = overlays
             .iter()
             .map(|url| format!("(import (builtins.fetchTarball \"{}\"))", url))
             .collect::<Vec<String>>()
@@ -360,7 +371,7 @@ impl<'a> AppBuilder<'a> {
         ",
         pkg_import=pkg_import,
         pkgs=nixpkgs,
-        overlays=overlays};
+        overlays=overlays_string};
 
         Ok(nix_expression)
     }
@@ -368,9 +379,14 @@ impl<'a> AppBuilder<'a> {
     pub fn gen_dockerfile(plan: &BuildPlan) -> Result<String> {
         let app_dir = "/app";
 
+        let setup_phase = plan.setup.clone().unwrap_or_default();
+        let install_phase = plan.install.clone().unwrap_or_default();
+        let build_phase = plan.build.clone().unwrap_or_default();
+        let start_phase = plan.start.clone().unwrap_or_default();
+        let variables = plan.variables.clone().unwrap_or_default();
+
         // -- Variables
-        let args_string = plan
-            .variables
+        let args_string = variables
             .iter()
             .map(|var| format!("ENV {}='{}'", var.0, var.1))
             .collect::<Vec<String>>()
@@ -378,14 +394,13 @@ impl<'a> AppBuilder<'a> {
 
         // -- Setup
         let mut setup_files: Vec<String> = vec!["environment.nix".to_string()];
-        if let Some(mut setup_file_deps) = plan.setup.file_dependencies.clone() {
+        if let Some(mut setup_file_deps) = setup_phase.only_include_files.clone() {
             setup_files.append(&mut setup_file_deps);
         }
         let setup_copy_cmd = format!("COPY {} {}", setup_files.join(" "), app_dir);
 
         // -- Install
-        let install_cmd = plan
-            .install
+        let install_cmd = install_phase
             .cmd
             .clone()
             .map(|cmd| format!("RUN {}", cmd))
@@ -393,23 +408,21 @@ impl<'a> AppBuilder<'a> {
 
         // Files to copy for install phase
         // If none specified, copy over the entire app
-        let install_files = plan
-            .install
-            .file_dependencies
+        let install_files = install_phase
+            .only_include_files
             .clone()
             .unwrap_or_else(|| vec![".".to_string()]);
 
         // -- Build
-        let build_cmd = plan
-            .build
+        let build_cmd = build_phase
             .cmd
             .clone()
             .map(|cmd| format!("RUN {}", cmd))
             .unwrap_or_else(|| "".to_string());
 
-        let build_files = plan.build.file_dependencies.clone().unwrap_or_else(|| {
+        let build_files = build_phase.only_include_files.clone().unwrap_or_else(|| {
             // Only copy over the entire app if we haven't already in the install phase
-            if plan.install.file_dependencies.is_none() {
+            if install_phase.only_include_files.is_none() {
                 Vec::new()
             } else {
                 vec![".".to_string()]
@@ -417,8 +430,7 @@ impl<'a> AppBuilder<'a> {
         });
 
         // -- Start
-        let start_cmd = plan
-            .start
+        let start_cmd = start_phase
             .cmd
             .clone()
             .map(|cmd| format!("CMD {}", cmd))
@@ -426,7 +438,7 @@ impl<'a> AppBuilder<'a> {
 
         // If we haven't yet copied over the entire app, do that before starting
         let mut start_files: Vec<String> = Vec::new();
-        if plan.build.file_dependencies.is_some() {
+        if build_phase.only_include_files.is_some() {
             start_files.push(".".to_string());
         }
 

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -431,7 +431,6 @@ impl<'a> AppBuilder<'a> {
         // -- Start
         let start_cmd = start_phase
             .cmd
-            
             .map(|cmd| format!("CMD {}", cmd))
             .unwrap_or_else(|| "".to_string());
 

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -200,10 +200,10 @@ impl<'a> AppBuilder<'a> {
 
         // Add custom user packages
         let mut pkgs = self.options.custom_pkgs.clone();
-        setup_phase.nix.add_pkgs(&mut pkgs);
+        setup_phase.add_pkgs(&mut pkgs);
 
         if self.options.pin_pkgs {
-            setup_phase.nix.set_archive(NIXPKGS_ARCHIVE.to_string())
+            setup_phase.set_archive(NIXPKGS_ARCHIVE.to_string())
         }
 
         Ok(setup_phase)
@@ -324,14 +324,13 @@ impl<'a> AppBuilder<'a> {
         let setup_phase = plan.setup.clone().unwrap_or_default();
 
         let nixpkgs = setup_phase
-            .nix
             .pkgs
             .iter()
             .map(|p| p.to_nix_string())
             .collect::<Vec<String>>()
             .join(" ");
 
-        let nix_archive = setup_phase.nix.archive.clone();
+        let nix_archive = setup_phase.archive.clone();
         let pkg_import = match nix_archive {
             Some(archive) => format!(
                 "import (fetchTarball \"https://github.com/NixOS/nixpkgs/archive/{}.tar.gz\")",
@@ -341,7 +340,7 @@ impl<'a> AppBuilder<'a> {
         };
 
         let mut overlays: Vec<String> = Vec::new();
-        for pkg in &setup_phase.nix.pkgs {
+        for pkg in &setup_phase.pkgs {
             if let Some(overlay) = &pkg.overlay {
                 overlays.push(overlay.to_string());
             }
@@ -394,7 +393,7 @@ impl<'a> AppBuilder<'a> {
 
         // -- Setup
         let mut setup_files: Vec<String> = vec!["environment.nix".to_string()];
-        if let Some(mut setup_file_deps) = setup_phase.only_include_files.clone() {
+        if let Some(mut setup_file_deps) = setup_phase.only_include_files {
             setup_files.append(&mut setup_file_deps);
         }
         let setup_copy_cmd = format!("COPY {} {}", setup_files.join(" "), app_dir);
@@ -432,7 +431,7 @@ impl<'a> AppBuilder<'a> {
         // -- Start
         let start_cmd = start_phase
             .cmd
-            .clone()
+            
             .map(|cmd| format!("CMD {}", cmd))
             .unwrap_or_else(|| "".to_string());
 

--- a/src/nixpacks/nix.rs
+++ b/src/nixpacks/nix.rs
@@ -2,44 +2,57 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Pkg {
     pub name: String,
-    pub overrides: HashMap<String, String>,
+    pub overlay: Option<String>,
+    pub overrides: Option<HashMap<String, String>>,
 }
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, PartialEq, Clone, Default, Debug)]
 pub struct NixConfig {
     pub pkgs: Vec<Pkg>,
-    pub overlays: Vec<String>,
-    pub nixpkgs_archive: Option<String>,
+    pub archive: Option<String>,
 }
 
 impl Pkg {
     pub fn new(name: &str) -> Pkg {
         Pkg {
             name: name.to_string(),
-            overrides: HashMap::default(),
+            overrides: None,
+            overlay: None,
         }
     }
 
     pub fn to_nix_string(&self) -> String {
-        if self.overrides.is_empty() {
-            self.name.clone()
-        } else {
-            let override_string = self
-                .overrides
-                .iter()
-                .map(|(name, value)| format!("{} = {};", name, value))
-                .collect::<Vec<_>>()
-                .join(" ");
-            format!("({}.override {{ {} }})", self.name, override_string)
+        match &self.overrides {
+            Some(overrides) => {
+                let override_string = overrides
+                    .iter()
+                    .map(|(name, value)| format!("{} = {};", name, value))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                format!("({}.override {{ {} }})", self.name, override_string)
+            }
+            None => self.name.clone(),
         }
     }
 
     pub fn set_override(mut self, name: &str, pkg: &str) -> Self {
-        self.overrides.insert(name.to_string(), pkg.to_string());
+        if let Some(mut overrides) = self.overrides {
+            overrides.insert(name.to_string(), pkg.to_string());
+            self.overrides = Some(overrides);
+        } else {
+            self.overrides = Some(HashMap::from([(name.to_string(), pkg.to_string())]));
+        }
+
+        self
+    }
+
+    pub fn from_overlay(mut self, overlay: &str) -> Self {
+        self.overlay = Some(overlay.to_string());
         self
     }
 }
@@ -48,8 +61,7 @@ impl NixConfig {
     pub fn new(pkgs: Vec<Pkg>) -> Self {
         NixConfig {
             pkgs,
-            overlays: Vec::new(),
-            nixpkgs_archive: None,
+            archive: None,
         }
     }
 
@@ -57,12 +69,8 @@ impl NixConfig {
         self.pkgs.append(new_pkgs);
     }
 
-    pub fn add_overlay(&mut self, overlay: String) {
-        self.overlays.push(overlay);
-    }
-
     pub fn set_archive(&mut self, archive: String) {
-        self.nixpkgs_archive = Some(archive);
+        self.archive = Some(archive);
     }
 }
 

--- a/src/nixpacks/nix.rs
+++ b/src/nixpacks/nix.rs
@@ -57,23 +57,6 @@ impl Pkg {
     }
 }
 
-impl NixConfig {
-    pub fn new(pkgs: Vec<Pkg>) -> Self {
-        NixConfig {
-            pkgs,
-            archive: None,
-        }
-    }
-
-    pub fn add_pkgs(&mut self, new_pkgs: &mut Vec<Pkg>) {
-        self.pkgs.append(new_pkgs);
-    }
-
-    pub fn set_archive(&mut self, archive: String) {
-        self.archive = Some(archive);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -1,20 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use super::nix::NixConfig;
+use super::nix::Pkg;
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct SetupPhase {
-    pub nix: NixConfig,
+    pub pkgs: Vec<Pkg>,
+    pub archive: Option<String>,
 
     #[serde(rename = "onlyIncludeFiles")]
     pub only_include_files: Option<Vec<String>>,
 }
 
 impl SetupPhase {
-    pub fn new(nix: NixConfig) -> Self {
+    pub fn new(pkgs: Vec<Pkg>) -> Self {
         Self {
-            nix,
+            pkgs,
+            archive: None,
             only_include_files: None,
         }
     }
@@ -26,6 +28,14 @@ impl SetupPhase {
         } else {
             self.only_include_files = Some(vec![file]);
         }
+    }
+
+    pub fn add_pkgs(&mut self, new_pkgs: &mut Vec<Pkg>) {
+        self.pkgs.append(new_pkgs);
+    }
+
+    pub fn set_archive(&mut self, archive: String) {
+        self.archive = Some(archive);
     }
 }
 

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -3,82 +3,88 @@ use serde::{Deserialize, Serialize};
 use super::nix::NixConfig;
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct SetupPhase {
-    pub nix_config: NixConfig,
-    pub file_dependencies: Option<Vec<String>>,
+    pub nix: NixConfig,
+
+    #[serde(rename = "onlyIncludeFiles")]
+    pub only_include_files: Option<Vec<String>>,
 }
 
 impl SetupPhase {
-    pub fn new(nix_config: NixConfig) -> Self {
+    pub fn new(nix: NixConfig) -> Self {
         Self {
-            nix_config,
-            file_dependencies: None,
+            nix,
+            only_include_files: None,
         }
     }
 
     pub fn add_file_dependency(&mut self, file: String) {
-        if let Some(mut files) = self.file_dependencies.clone() {
+        if let Some(mut files) = self.only_include_files.clone() {
             files.push(file);
-            self.file_dependencies = Some(files);
+            self.only_include_files = Some(files);
         } else {
-            self.file_dependencies = Some(vec![file]);
+            self.only_include_files = Some(vec![file]);
         }
     }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct InstallPhase {
     pub cmd: Option<String>,
-    pub file_dependencies: Option<Vec<String>>,
+
+    #[serde(rename = "onlyIncludeFiles")]
+    pub only_include_files: Option<Vec<String>>,
 }
 
 impl InstallPhase {
     pub fn new(cmd: String) -> Self {
         Self {
             cmd: Some(cmd),
-            file_dependencies: None,
+            only_include_files: None,
         }
     }
 
     pub fn add_file_dependency(&mut self, file: String) {
-        if let Some(mut files) = self.file_dependencies.clone() {
+        if let Some(mut files) = self.only_include_files.clone() {
             files.push(file);
-            self.file_dependencies = Some(files);
+            self.only_include_files = Some(files);
         } else {
-            self.file_dependencies = Some(vec![file]);
+            self.only_include_files = Some(vec![file]);
         }
     }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct BuildPhase {
     pub cmd: Option<String>,
-    pub file_dependencies: Option<Vec<String>>,
+
+    #[serde(rename = "onlyIncludeFiles")]
+    pub only_include_files: Option<Vec<String>>,
 }
 
 impl BuildPhase {
     pub fn new(cmd: String) -> Self {
         Self {
             cmd: Some(cmd),
-            file_dependencies: None,
+            only_include_files: None,
         }
     }
 
     pub fn add_file_dependency(&mut self, file: String) {
-        if let Some(mut files) = self.file_dependencies.clone() {
+        if let Some(mut files) = self.only_include_files.clone() {
             files.push(file);
-            self.file_dependencies = Some(files);
+            self.only_include_files = Some(files);
         } else {
-            self.file_dependencies = Some(vec![file]);
+            self.only_include_files = Some(vec![file]);
         }
     }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Default, Debug)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct StartPhase {
     pub cmd: Option<String>,
 }

--- a/src/nixpacks/plan.rs
+++ b/src/nixpacks/plan.rs
@@ -8,10 +8,10 @@ use super::{
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BuildPlan {
-    pub version: String,
-    pub setup: SetupPhase,
-    pub install: InstallPhase,
-    pub build: BuildPhase,
-    pub start: StartPhase,
-    pub variables: EnvironmentVariables,
+    pub version: Option<String>,
+    pub setup: Option<SetupPhase>,
+    pub install: Option<InstallPhase>,
+    pub build: Option<BuildPhase>,
+    pub start: Option<StartPhase>,
+    pub variables: Option<EnvironmentVariables>,
 }

--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -2,7 +2,7 @@ use super::Provider;
 use crate::nixpacks::{
     app::App,
     environment::Environment,
-    nix::{Pkg},
+    nix::Pkg,
     phase::{SetupPhase, StartPhase},
 };
 use anyhow::Result;
@@ -21,10 +21,7 @@ impl Provider for DenoProvider {
     }
 
     fn setup(&self, _app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {
-        Ok(Some(SetupPhase::new(vec![
-            Pkg::new("pkgs.stdenv"),
-            Pkg::new("pkgs.deno"),
-        ])))
+        Ok(Some(SetupPhase::new(vec![Pkg::new("deno")])))
     }
 
     fn start(&self, app: &App, _env: &Environment) -> Result<Option<StartPhase>> {

--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -20,25 +20,25 @@ impl Provider for DenoProvider {
         app.find_match(&re, "**/*.ts")
     }
 
-    fn setup(&self, _app: &App, _env: &Environment) -> Result<SetupPhase> {
-        Ok(SetupPhase::new(NixConfig::new(vec![
+    fn setup(&self, _app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {
+        Ok(Some(SetupPhase::new(NixConfig::new(vec![
             Pkg::new("pkgs.stdenv"),
             Pkg::new("pkgs.deno"),
-        ])))
+        ]))))
     }
 
-    fn start(&self, app: &App, _env: &Environment) -> Result<StartPhase> {
+    fn start(&self, app: &App, _env: &Environment) -> Result<Option<StartPhase>> {
         // Find the first index.ts or index.js file to run
         let matches = app.find_files("**/index.[tj]s")?;
         let path_to_index = match matches.first() {
             Some(m) => m.to_string(),
-            None => return Ok(StartPhase::default()),
+            None => return Ok(None),
         };
 
         let relative_path_to_index = app.strip_source_path(&path_to_index)?;
-        return Ok(StartPhase::new(format!(
+        return Ok(Some(StartPhase::new(format!(
             "deno run --allow-all {}",
             relative_path_to_index
-        )));
+        ))));
     }
 }

--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -2,7 +2,7 @@ use super::Provider;
 use crate::nixpacks::{
     app::App,
     environment::Environment,
-    nix::{NixConfig, Pkg},
+    nix::{Pkg},
     phase::{SetupPhase, StartPhase},
 };
 use anyhow::Result;
@@ -21,10 +21,10 @@ impl Provider for DenoProvider {
     }
 
     fn setup(&self, _app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {
-        Ok(Some(SetupPhase::new(NixConfig::new(vec![
+        Ok(Some(SetupPhase::new(vec![
             Pkg::new("pkgs.stdenv"),
             Pkg::new("pkgs.deno"),
-        ]))))
+        ])))
     }
 
     fn start(&self, app: &App, _env: &Environment) -> Result<Option<StartPhase>> {

--- a/src/providers/go.rs
+++ b/src/providers/go.rs
@@ -2,7 +2,7 @@ use super::Provider;
 use crate::nixpacks::{
     app::App,
     environment::Environment,
-    nix::{NixConfig, Pkg},
+    nix::{Pkg},
     phase::{InstallPhase, SetupPhase, StartPhase},
 };
 use anyhow::Result;
@@ -19,10 +19,10 @@ impl Provider for GolangProvider {
     }
 
     fn setup(&self, _app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {
-        Ok(Some(SetupPhase::new(NixConfig::new(vec![
+        Ok(Some(SetupPhase::new(vec![
             Pkg::new("pkgs.stdenv"),
             Pkg::new("pkgs.go"),
-        ]))))
+        ])))
     }
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {

--- a/src/providers/go.rs
+++ b/src/providers/go.rs
@@ -18,21 +18,21 @@ impl Provider for GolangProvider {
         Ok(app.includes_file("main.go"))
     }
 
-    fn setup(&self, _app: &App, _env: &Environment) -> Result<SetupPhase> {
-        Ok(SetupPhase::new(NixConfig::new(vec![
+    fn setup(&self, _app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {
+        Ok(Some(SetupPhase::new(NixConfig::new(vec![
             Pkg::new("pkgs.stdenv"),
             Pkg::new("pkgs.go"),
-        ])))
+        ]))))
     }
 
-    fn install(&self, app: &App, _env: &Environment) -> Result<InstallPhase> {
+    fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {
         if app.includes_file("go.mod") {
-            return Ok(InstallPhase::new("go get".to_string()));
+            return Ok(Some(InstallPhase::new("go get".to_string())));
         }
-        Ok(InstallPhase::default())
+        Ok(None)
     }
 
-    fn start(&self, _app: &App, _env: &Environment) -> Result<StartPhase> {
-        Ok(StartPhase::new("go run main.go".to_string()))
+    fn start(&self, _app: &App, _env: &Environment) -> Result<Option<StartPhase>> {
+        Ok(Some(StartPhase::new("go run main.go".to_string())))
     }
 }

--- a/src/providers/go.rs
+++ b/src/providers/go.rs
@@ -2,7 +2,7 @@ use super::Provider;
 use crate::nixpacks::{
     app::App,
     environment::Environment,
-    nix::{Pkg},
+    nix::Pkg,
     phase::{InstallPhase, SetupPhase, StartPhase},
 };
 use anyhow::Result;
@@ -19,10 +19,7 @@ impl Provider for GolangProvider {
     }
 
     fn setup(&self, _app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {
-        Ok(Some(SetupPhase::new(vec![
-            Pkg::new("pkgs.stdenv"),
-            Pkg::new("pkgs.go"),
-        ])))
+        Ok(Some(SetupPhase::new(vec![Pkg::new("go")])))
     }
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -15,23 +15,23 @@ pub mod yarn;
 pub trait Provider {
     fn name(&self) -> &str;
     fn detect(&self, app: &App, _env: &Environment) -> Result<bool>;
-    fn setup(&self, _app: &App, _env: &Environment) -> Result<SetupPhase> {
-        Ok(SetupPhase::default())
+    fn setup(&self, _app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {
+        Ok(None)
     }
-    fn install(&self, _app: &App, _env: &Environment) -> Result<InstallPhase> {
-        Ok(InstallPhase::default())
+    fn install(&self, _app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {
+        Ok(None)
     }
-    fn build(&self, _app: &App, _env: &Environment) -> Result<BuildPhase> {
-        Ok(BuildPhase::default())
+    fn build(&self, _app: &App, _env: &Environment) -> Result<Option<BuildPhase>> {
+        Ok(None)
     }
-    fn start(&self, _app: &App, _env: &Environment) -> Result<StartPhase> {
-        Ok(StartPhase::default())
+    fn start(&self, _app: &App, _env: &Environment) -> Result<Option<StartPhase>> {
+        Ok(None)
     }
     fn environment_variables(
         &self,
         _app: &App,
         _env: &Environment,
-    ) -> Result<EnvironmentVariables> {
-        Ok(EnvironmentVariables::default())
+    ) -> Result<Option<EnvironmentVariables>> {
+        Ok(None)
     }
 }

--- a/src/providers/npm.rs
+++ b/src/providers/npm.rs
@@ -4,7 +4,7 @@ use super::Provider;
 use crate::nixpacks::{
     app::App,
     environment::{Environment, EnvironmentVariables},
-    nix::{NixConfig, Pkg},
+    nix::{Pkg},
     phase::{BuildPhase, InstallPhase, SetupPhase, StartPhase},
 };
 use anyhow::{bail, Result};
@@ -38,10 +38,10 @@ impl Provider for NpmProvider {
         let package_json: PackageJson = app.read_json("package.json")?;
         let node_pkg = NpmProvider::get_nix_node_pkg(&package_json)?;
 
-        Ok(Some(SetupPhase::new(NixConfig::new(vec![
+        Ok(Some(SetupPhase::new(vec![
             Pkg::new("pkgs.stdenv"),
             node_pkg,
-        ]))))
+        ])))
     }
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {

--- a/src/providers/npm.rs
+++ b/src/providers/npm.rs
@@ -4,7 +4,7 @@ use super::Provider;
 use crate::nixpacks::{
     app::App,
     environment::{Environment, EnvironmentVariables},
-    nix::{Pkg},
+    nix::Pkg,
     phase::{BuildPhase, InstallPhase, SetupPhase, StartPhase},
 };
 use anyhow::{bail, Result};
@@ -12,7 +12,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 const AVAILABLE_NODE_VERSIONS: &[u32] = &[10, 12, 14, 16, 17];
-const DEFAULT_NODE_PKG_NAME: &'static &str = &"pkgs.nodejs";
+pub const DEFAULT_NODE_PKG_NAME: &'static &str = &"nodejs";
 
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub struct PackageJson {
@@ -38,10 +38,7 @@ impl Provider for NpmProvider {
         let package_json: PackageJson = app.read_json("package.json")?;
         let node_pkg = NpmProvider::get_nix_node_pkg(&package_json)?;
 
-        Ok(Some(SetupPhase::new(vec![
-            Pkg::new("pkgs.stdenv"),
-            node_pkg,
-        ])))
+        Ok(Some(SetupPhase::new(vec![node_pkg])))
     }
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -32,7 +32,7 @@ impl Provider for PythonProvider {
         _app: &App,
         _env: &crate::nixpacks::environment::Environment,
     ) -> Result<Option<SetupPhase>> {
-        Ok(Some(SetupPhase::new(vec![Pkg::new("pkgs.python38")])))
+        Ok(Some(SetupPhase::new(vec![Pkg::new("python38")])))
     }
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -8,7 +8,6 @@ use crate::{
     nixpacks::{
         app::App,
         environment::Environment,
-        nix::NixConfig,
         phase::{InstallPhase, SetupPhase, StartPhase},
     },
     Pkg,
@@ -33,9 +32,7 @@ impl Provider for PythonProvider {
         _app: &App,
         _env: &crate::nixpacks::environment::Environment,
     ) -> Result<Option<SetupPhase>> {
-        Ok(Some(SetupPhase::new(NixConfig::new(vec![Pkg::new(
-            "pkgs.python38",
-        )]))))
+        Ok(Some(SetupPhase::new(vec![Pkg::new("pkgs.python38")])))
     }
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -32,44 +32,44 @@ impl Provider for PythonProvider {
         &self,
         _app: &App,
         _env: &crate::nixpacks::environment::Environment,
-    ) -> Result<SetupPhase> {
-        Ok(SetupPhase::new(NixConfig::new(vec![Pkg::new(
+    ) -> Result<Option<SetupPhase>> {
+        Ok(Some(SetupPhase::new(NixConfig::new(vec![Pkg::new(
             "pkgs.python38",
-        )])))
+        )]))))
     }
 
-    fn install(&self, app: &App, _env: &Environment) -> Result<InstallPhase> {
+    fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {
         if app.includes_file("requirements.txt") {
             let mut install_phase = InstallPhase::new(
                 "python -m ensurepip && python -m pip install -r requirements.txt".to_string(),
             );
             install_phase.add_file_dependency("requirements.txt".to_string());
-            return Ok(install_phase);
+            return Ok(Some(install_phase));
         } else if app.includes_file("pyproject.toml") {
             let mut install_phase =InstallPhase::new("python -m ensurepip && python -m pip install --upgrade build setuptools && python -m pip install .".to_string());
             install_phase.add_file_dependency("pyproject.toml".to_string());
-            return Ok(install_phase);
+            return Ok(Some(install_phase));
         }
-        Ok(InstallPhase::default())
+        Ok(None)
     }
 
-    fn start(&self, app: &App, _env: &Environment) -> Result<StartPhase> {
+    fn start(&self, app: &App, _env: &Environment) -> Result<Option<StartPhase>> {
         if app.includes_file("pyproject.toml") {
             if let Ok(meta) = self.parse_pyproject(app) {
                 if let Some(entry_point) = meta.entry_point {
-                    return Ok(StartPhase::new(match entry_point {
+                    return Ok(Some(StartPhase::new(match entry_point {
                         EntryPoint::Command(cmd) => cmd,
                         EntryPoint::Module(module) => format!("python -m {}", module),
-                    }));
+                    })));
                 }
             }
         }
         // falls through
         if app.includes_file("main.py") {
-            return Ok(StartPhase::new("python main.py".to_string()));
+            return Ok(Some(StartPhase::new("python main.py".to_string())));
         }
 
-        Ok(StartPhase::default())
+        Ok(None)
     }
 }
 

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -2,7 +2,7 @@ use super::Provider;
 use crate::nixpacks::{
     app::App,
     environment::{Environment, EnvironmentVariables},
-    nix::{NixConfig, Pkg},
+    nix::Pkg,
     phase::{BuildPhase, SetupPhase, StartPhase},
 };
 use anyhow::{Context, Result};
@@ -38,13 +38,11 @@ impl Provider for RustProvider {
     fn setup(&self, app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {
         let rust_pkg: Pkg = self.get_rust_pkg(app)?;
 
-        let nix_config = NixConfig::new(vec![
+        let mut setup_phase = SetupPhase::new(vec![
             Pkg::new("pkgs.stdenv"),
             Pkg::new("pkgs.gcc"),
             rust_pkg.from_overlay(RUST_OVERLAY),
         ]);
-
-        let mut setup_phase = SetupPhase::new(nix_config);
 
         // Include the rust toolchain file so we can install that rust version with Nix
         if let Some(toolchain_file) = self.get_rust_toolchain_file(app)? {

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -38,11 +38,8 @@ impl Provider for RustProvider {
     fn setup(&self, app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {
         let rust_pkg: Pkg = self.get_rust_pkg(app)?;
 
-        let mut setup_phase = SetupPhase::new(vec![
-            Pkg::new("pkgs.stdenv"),
-            Pkg::new("pkgs.gcc"),
-            rust_pkg.from_overlay(RUST_OVERLAY),
-        ]);
+        let mut setup_phase =
+            SetupPhase::new(vec![Pkg::new("gcc"), rust_pkg.from_overlay(RUST_OVERLAY)]);
 
         // Include the rust toolchain file so we can install that rust version with Nix
         if let Some(toolchain_file) = self.get_rust_toolchain_file(app)? {

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::nixpacks::{
     app::App,
     environment::{Environment, EnvironmentVariables},
-    nix::{NixConfig, Pkg},
+    nix::{Pkg},
     phase::{BuildPhase, InstallPhase, SetupPhase, StartPhase},
 };
 use anyhow::Result;
@@ -25,10 +25,10 @@ impl Provider for YarnProvider {
         let package_json: PackageJson = app.read_json("package.json")?;
         let node_pkg = NpmProvider::get_nix_node_pkg(&package_json)?;
 
-        Ok(Some(SetupPhase::new(NixConfig::new(vec![
+        Ok(Some(SetupPhase::new(vec![
             Pkg::new("pkgs.stdenv"),
             Pkg::new("pkgs.yarn").set_override("nodejs", node_pkg.name.as_str()),
-        ]))))
+        ])))
     }
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -27,7 +27,7 @@ impl Provider for YarnProvider {
         let mut yarn_pkg = Pkg::new("yarn");
 
         // Only override the node package if not the default one
-        if node_pkg.name != DEFAULT_NODE_PKG_NAME.to_string() {
+        if node_pkg.name != *DEFAULT_NODE_PKG_NAME {
             yarn_pkg = yarn_pkg.set_override("nodejs", node_pkg.name.as_str());
         }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -53,10 +53,7 @@ fn test_node_custom_version() -> Result<()> {
         Vec::new(),
         false,
     )?;
-    assert_eq!(
-        plan.setup.unwrap().pkgs,
-        vec![Pkg::new("pkgs.stdenv"), Pkg::new("nodejs-12_x")]
-    );
+    assert_eq!(plan.setup.unwrap().pkgs, vec![Pkg::new("nodejs-12_x")]);
 
     Ok(())
 }
@@ -90,10 +87,7 @@ fn test_yarn_custom_version() -> Result<()> {
     )?;
     assert_eq!(
         plan.setup.unwrap().pkgs,
-        vec![
-            Pkg::new("pkgs.stdenv"),
-            Pkg::new("pkgs.yarn").set_override("nodejs", "nodejs-14_x")
-        ]
+        vec![Pkg::new("yarn").set_override("nodejs", "nodejs-14_x")]
     );
 
     Ok(())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -54,7 +54,7 @@ fn test_node_custom_version() -> Result<()> {
         false,
     )?;
     assert_eq!(
-        plan.setup.unwrap().nix.pkgs,
+        plan.setup.unwrap().pkgs,
         vec![Pkg::new("pkgs.stdenv"), Pkg::new("nodejs-12_x")]
     );
 
@@ -89,7 +89,7 @@ fn test_yarn_custom_version() -> Result<()> {
         false,
     )?;
     assert_eq!(
-        plan.setup.unwrap().nix.pkgs,
+        plan.setup.unwrap().pkgs,
         vec![
             Pkg::new("pkgs.stdenv"),
             Pkg::new("pkgs.yarn").set_override("nodejs", "nodejs-14_x")
@@ -145,7 +145,7 @@ fn test_custom_pkgs() -> Result<()> {
         Vec::new(),
         false,
     )?;
-    assert_eq!(plan.setup.unwrap().nix.pkgs, vec![Pkg::new("cowsay")]);
+    assert_eq!(plan.setup.unwrap().pkgs, vec![Pkg::new("cowsay")]);
     assert_eq!(plan.start.unwrap().cmd, Some("./start.sh".to_string()));
 
     Ok(())
@@ -154,7 +154,7 @@ fn test_custom_pkgs() -> Result<()> {
 #[test]
 fn test_pin_archive() -> Result<()> {
     let plan = gen_plan("./examples/hello", Vec::new(), None, None, Vec::new(), true)?;
-    assert!(plan.setup.unwrap().nix.archive.is_some());
+    assert!(plan.setup.unwrap().archive.is_some());
 
     Ok(())
 }
@@ -176,7 +176,6 @@ fn test_custom_rust_version() -> Result<()> {
     assert_eq!(
         plan.setup
             .unwrap()
-            .nix
             .pkgs
             .iter()
             .filter(|p| p.name.contains("1.56.0"))


### PR DESCRIPTION
Closes #47 

Implement the updated build plan format. This involved
- Phases are optional so that we can deserialize if they do not exist
- Nix overlays are attached to the package
- Improved naming of fields in plan
- Add the version of nixpacks that was used to build the plan

![image](https://user-images.githubusercontent.com/3044853/164544050-ef3d8b77-32e3-4f1a-8834-f7b68a9f09c5.png)


![image](https://user-images.githubusercontent.com/3044853/164544023-09662a49-7687-4065-8d73-11a49c814af8.png)

