### PR TITLE
Make variables available at runtime

### DIFF
--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -394,14 +394,23 @@ impl<'a> AppBuilder<'a> {
         let variables = plan.variables.clone().unwrap_or_default();
 
         // -- Variables
-        let args_string = format!(
-            "ARG {}",
-            variables
-                .iter()
-                .map(|var| var.0.to_string())
-                .collect::<Vec<_>>()
-                .join(" ")
-        );
+        let args_string = if variables.len() > 0 {
+            format!(
+                "ARG {}\nENV {}",
+                variables
+                    .iter()
+                    .map(|var| var.0.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                variables
+                    .iter()
+                    .map(|var| format!("{}=${}", var.0, var.0))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            )
+        } else {
+            "".to_string()
+        };
 
         // -- Setup
         let mut setup_files: Vec<String> = vec!["environment.nix".to_string()];

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -394,7 +394,7 @@ impl<'a> AppBuilder<'a> {
         let variables = plan.variables.clone().unwrap_or_default();
 
         // -- Variables
-        let args_string = if variables.len() > 0 {
+        let args_string = if !variables.is_empty() {
             format!(
                 "ARG {}\nENV {}",
                 // Pull the variables in from docker `--build-arg`

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -397,11 +397,13 @@ impl<'a> AppBuilder<'a> {
         let args_string = if variables.len() > 0 {
             format!(
                 "ARG {}\nENV {}",
+                // Pull the variables in from docker `--build-arg`
                 variables
                     .iter()
                     .map(|var| var.0.to_string())
                     .collect::<Vec<_>>()
                     .join(" "),
+                // Make the variables available at runtime
                 variables
                     .iter()
                     .map(|var| format!("{}=${}", var.0, var.0))


### PR DESCRIPTION
Previously defined (`--env`) provided by the user or language providers (e.g. `NODE_ENV`) were not available at runtime. This PR changes that so that these variables are available at runtime.
