### PR TITLE
Custom changelog configuration

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,0 +1,11 @@
+{
+  "categories": [
+    {
+      "title": "## Changes",
+      "labels": [],
+      "exhaustive": false
+    }
+  ],
+  "template": "${{CHANGELOG}}\n",
+  "pr_template": "- #${{NUMBER}} ${{TITLE}}"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
           echo "NIXPACKS_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           echo "version is: ${{ env.NIXPACKS_VERSION }}"
 
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
       - name: Build Changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v2.9.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Build Changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v2.9.0
+        with:
+          configuration: ".github/changelog-configuration.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Add a configuration file for https://github.com/mikepenz/release-changelog-builder-action so that all PRs (even without a label) show up in the auto generated release changelog.
