### PR TITLE
Python virtualenvs and provider paths

### DIFF
--- a/examples/python/Procfile
+++ b/examples/python/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn main:app

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -32,7 +32,7 @@ const NIX_PACKS_VERSION: &str = env!("CARGO_PKG_VERSION");
 static NIXPKGS_ARCHIVE: &str = "30d3d79b7d3607d56546dd2a6b49e156ba0ec634";
 
 // Debian 11
-static BASE_IMAGE: &str = "debian:buster-slim";
+static BASE_IMAGE: &str = "debian:bullseye-slim";
 
 #[derive(Debug)]
 pub struct AppBuilderOptions {

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -428,6 +428,12 @@ impl<'a> AppBuilder<'a> {
             .map(|cmd| format!("RUN {}", cmd))
             .unwrap_or_else(|| "".to_string());
 
+        let path_env = if let Some(paths) = install_phase.paths {
+            format!("ENV PATH {}:$PATH", paths.join(":"))
+        } else {
+            "".to_string()
+        };
+
         // Files to copy for install phase
         // If none specified, copy over the entire app
         let install_files = install_phase
@@ -500,6 +506,7 @@ impl<'a> AppBuilder<'a> {
           # Install
           {install_copy_cmd}
           {install_cmd}
+          {path_env}
 
           # Build
           {build_copy_cmd}
@@ -514,6 +521,7 @@ impl<'a> AppBuilder<'a> {
         args_string=args_string,
         install_copy_cmd=get_copy_command(&install_files, app_dir),
         install_cmd=install_cmd,
+        path_env=path_env,
         build_copy_cmd=get_copy_command(&build_files, app_dir),
         build_cmd=build_cmd,
         start_copy_cmd=get_copy_command(&start_files, app_dir),

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -46,6 +46,8 @@ pub struct InstallPhase {
 
     #[serde(rename = "onlyIncludeFiles")]
     pub only_include_files: Option<Vec<String>>,
+
+    pub paths: Option<Vec<String>>,
 }
 
 impl InstallPhase {
@@ -53,6 +55,7 @@ impl InstallPhase {
         Self {
             cmd: Some(cmd),
             only_include_files: None,
+            paths: None,
         }
     }
 
@@ -62,6 +65,15 @@ impl InstallPhase {
             self.only_include_files = Some(files);
         } else {
             self.only_include_files = Some(vec![file]);
+        }
+    }
+
+    pub fn add_path(&mut self, path: String) {
+        if let Some(mut paths) = self.paths.clone() {
+            paths.push(path);
+            self.paths = Some(paths);
+        } else {
+            self.paths = Some(vec![path]);
         }
     }
 }

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -36,17 +36,28 @@ impl Provider for PythonProvider {
     }
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {
+        let env_loc = "/opt/venv";
+        let create_env = format!("python -m venv {}", env_loc);
+        let activate_env = format!(". {}/bin/activate", env_loc);
+
         if app.includes_file("requirements.txt") {
-            let mut install_phase = InstallPhase::new(
-                "python -m ensurepip && python -m pip install -r requirements.txt".to_string(),
-            );
+            let mut install_phase = InstallPhase::new(format!(
+                "{} && {} && pip install -r requirements.txt",
+                create_env, activate_env
+            ));
             install_phase.add_file_dependency("requirements.txt".to_string());
+            install_phase.add_path(format!("{}/bin", env_loc));
             return Ok(Some(install_phase));
         } else if app.includes_file("pyproject.toml") {
-            let mut install_phase =InstallPhase::new("python -m ensurepip && python -m pip install --upgrade build setuptools && python -m pip install .".to_string());
+            let mut install_phase = InstallPhase::new(format!(
+                "{} && {} && pip install --upgrade build setuptools && pip install .",
+                create_env, activate_env
+            ));
             install_phase.add_file_dependency("pyproject.toml".to_string());
+            install_phase.add_path(format!("{}/bin", env_loc));
             return Ok(Some(install_phase));
         }
+
         Ok(None)
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -216,9 +216,12 @@ pub fn test_python() -> Result<()> {
     assert_eq!(plan.build.unwrap().cmd, None);
     assert_eq!(
         plan.install.unwrap().cmd,
-        Some("python -m ensurepip && python -m pip install -r requirements.txt".to_string())
+        Some("python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt".to_string())
     );
-    assert_eq!(plan.start.unwrap().cmd, Some("python main.py".to_string()));
+    assert_eq!(
+        plan.start.unwrap().cmd,
+        Some("gunicorn main:app".to_string())
+    );
 
     Ok(())
 }


### PR DESCRIPTION
The previous python provider was not adding any binaries installed with `pip` to the global path. This was because they were installed to a location on the Nix store not already on the PATH. Also, there were a bunch of warnings that recommended not installing global packages with pip with the root user.

This PR fixes the above by creating a virtualenv and installing all pip packages there instead of globally. A new provider API capability was also added so that the installation phase can modify locations on the `PATH`. This allows packages specific binaries to be available for the build and start phases.

To summarize, the Python provider now works by
1. Creating a virtual env
2. Activating the env and installing all packages with pip
3. Adding the virtualenvs binary location onto the Path so it is available for future phases