### PR TITLE
update to bullseye image

### DIFF
--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -32,7 +32,7 @@ const NIX_PACKS_VERSION: &str = env!("CARGO_PKG_VERSION");
 static NIXPKGS_ARCHIVE: &str = "30d3d79b7d3607d56546dd2a6b49e156ba0ec634";
 
 // Debian 11
-static BASE_IMAGE: &str = "debian:buster-slim";
+static BASE_IMAGE: &str = "debian:bullseye-slim";
 
 #[derive(Debug)]
 pub struct AppBuilderOptions {


### PR DESCRIPTION
Use debian 11 as a base image instead of 10
