### PR TITLE
include nodejs in the yarn provider

### DIFF
--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -31,7 +31,7 @@ impl Provider for YarnProvider {
             yarn_pkg = yarn_pkg.set_override("nodejs", node_pkg.name.as_str());
         }
 
-        Ok(Some(SetupPhase::new(vec![yarn_pkg])))
+        Ok(Some(SetupPhase::new(vec![node_pkg, yarn_pkg])))
     }
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {


### PR DESCRIPTION
If not included then the `node` binary is only avaiable through `yarn`. To make `node` avaiable to the top level (e.g. for a Procfile) it must be added as a Nix package.
