### PR TITLE
Cache deno deps

### DIFF
--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -3,7 +3,7 @@ use crate::nixpacks::{
     app::App,
     environment::Environment,
     nix::Pkg,
-    phase::{SetupPhase, StartPhase},
+    phase::{BuildPhase, SetupPhase, StartPhase},
 };
 use anyhow::Result;
 use regex::Regex;
@@ -24,7 +24,27 @@ impl Provider for DenoProvider {
         Ok(Some(SetupPhase::new(vec![Pkg::new("deno")])))
     }
 
+    fn build(&self, app: &App, _env: &Environment) -> Result<Option<BuildPhase>> {
+        match DenoProvider::get_start_file(app)? {
+            Some(start_file) => Ok(Some(BuildPhase::new(format!("deno cache {}", start_file)))),
+            None => Ok(None),
+        }
+    }
+
     fn start(&self, app: &App, _env: &Environment) -> Result<Option<StartPhase>> {
+        match DenoProvider::get_start_file(app)? {
+            Some(start_file) => Ok(Some(StartPhase::new(format!(
+                "deno run --allow-all {}",
+                start_file
+            )))),
+            None => Ok(None),
+        }
+    }
+}
+
+impl DenoProvider {
+    // Find the first index.ts or index.js file to run
+    fn get_start_file(app: &App) -> Result<Option<String>> {
         // Find the first index.ts or index.js file to run
         let matches = app.find_files("**/index.[tj]s")?;
         let path_to_index = match matches.first() {
@@ -33,9 +53,6 @@ impl Provider for DenoProvider {
         };
 
         let relative_path_to_index = app.strip_source_path(&path_to_index)?;
-        return Ok(Some(StartPhase::new(format!(
-            "deno run --allow-all {}",
-            relative_path_to_index
-        ))));
+        Ok(Some(relative_path_to_index))
     }
 }

--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -17,7 +17,9 @@ impl Provider for DenoProvider {
 
     fn detect(&self, app: &App, _env: &Environment) -> Result<bool> {
         let re = Regex::new(r##"(?m)^import .+ from "https://deno.land/[^"]+\.ts";?$"##).unwrap();
-        app.find_match(&re, "**/*.ts")
+        Ok(app.includes_file("deno.json")
+            || app.includes_file("deno.jsonc")
+            || app.find_match(&re, "**/*.ts")?)
     }
 
     fn setup(&self, _app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {

--- a/tests/generate_plan_tests.rs
+++ b/tests/generate_plan_tests.rs
@@ -127,7 +127,10 @@ fn test_go_mod() -> Result<()> {
 #[test]
 fn test_deno() -> Result<()> {
     let plan = gen_plan("./examples/deno", Vec::new(), None, None, Vec::new(), false)?;
-    assert_eq!(plan.build.unwrap().cmd, None);
+    assert_eq!(
+        plan.build.unwrap().cmd,
+        Some("deno cache src/index.ts".to_string())
+    );
     assert_eq!(
         plan.start.unwrap().cmd,
         Some("deno run --allow-all src/index.ts".to_string())


### PR DESCRIPTION
Download all Deno dependencies at build time instead of installing at runtime.

Closes https://github.com/railwayapp/nixpacks/issues/33