### PR TITLE
fix(npm): fallback to `npm install`

### DIFF
--- a/src/providers/npm.rs
+++ b/src/providers/npm.rs
@@ -42,7 +42,7 @@ impl Provider for NpmProvider {
     }
 
     fn install(&self, _app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {
-        let install_phase = InstallPhase::new("npm ci".to_string());
+        let install_phase = InstallPhase::new("npm ci || npm install".to_string());
         Ok(Some(install_phase))
     }
 


### PR DESCRIPTION
Falls back to `npm install` if `npm ci` fails.
