### PR TITLE
remove extra DenoProvider

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ pub fn get_providers() -> Vec<&'static dyn Provider> {
         &NodeProvider {},
         &RustProvider {},
         &PythonProvider {},
-        &DenoProvider {},
     ]
 }
 


### PR DESCRIPTION
`DenoProvider` is mentioned twice in `get_providers()`