### PR TITLE
install with `--production=false` for yarn

### DIFF
--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -65,7 +65,7 @@ impl Provider for NodeProvider {
             if app.includes_file(".yarnrc.yml") {
                 install_cmd = "yarn set version berry && yarn install --immutable --check-cache"
             } else {
-                install_cmd = "yarn install --frozen-lockfile"
+                install_cmd = "yarn install --frozen-lockfile --production=false"
             }
         } else if app.includes_file("package-lock.json") {
             install_cmd = "npm ci"


### PR DESCRIPTION
This ensures that dev deps will be installed even if `NODE_ENV=production`.

https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-production-true-false
