### PR TITLE
publish custom images to ghcr

### DIFF
--- a/.github/workflows/publish_debian.yml
+++ b/.github/workflows/publish_debian.yml
@@ -1,0 +1,43 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'base/debian/*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'base/debian/*'
+
+name: Publish Docker Images
+
+jobs:
+  debian:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +%s)"
+      - 
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: base/debian
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/railwayapp/nixpacks:debian, ghcr.io/railwayapp/nixpacks:latest, ghcr.io/railwayapp/nixpacks:debian-${{ steps.date.outputs.date }}

--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:bullseye-20220509-slim
+
+RUN apt-get update && apt-get -y upgrade \
+  && apt-get install --no-install-recommends -y locales curl xz-utils ca-certificates openssl \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && mkdir -m 0755 /nix && mkdir -m 0755 /etc/nix && groupadd -r nixbld && chown root /nix \
+  && echo 'sandbox = false' > /etc/nix/nix.conf \
+  && for n in $(seq 1 10); do useradd -c "Nix build user $n" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(command -v nologin)" "nixbld$n"; done
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN set -o pipefail && curl -L https://nixos.org/nix/install | bash \
+    && /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-old
+
+ENV \
+  ENV=/etc/profile \
+  USER=root \
+  PATH=/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:/bin:/sbin:/usr/bin:/usr/sbin \
+  GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt \
+  NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+  NIX_PATH=/nix/var/nix/profiles/per-user/root/channels
+
+RUN nix-channel --update


### PR DESCRIPTION
Builds & pushes `base/debian/Dockerfile` to `ghrc.io/railwayapp/nixpacks` as discussed [here](https://canary.discord.com/channels/713503345364697088/974023264143831060).