### PR TITLE
Add support for more rust targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
         formula-name: nixpacks
         formula-path: nixpacks.rb
         homebrew-tap: railwayapp/homebrew-tap
-        download-url: https://github.com/railwayapp/nixpacks/releases/download/${{ needs.create-release.outputs.nixpacks_version }}/nixpacks-x86_64-apple-darwin.tar.gz
+        download-url: https://github.com/railwayapp/nixpacks/releases/latest/download/nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-x86_64-apple-darwin.tar.gz
       env:
         COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+env:
+  MACOSX_DEPLOYMENT_TARGET: 10.7
 
 jobs:
   create-release:
@@ -48,17 +50,55 @@ jobs:
   build-release:
     name: Build Release Assets
     needs: ['create-release']
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
-        config:
-        # Linux
-        - { os: ubuntu-latest, build: linux_amd64, toolchain: stable, target: x86_64-unknown-linux-musl, cross: true }
-        - { os: ubuntu-latest, build: linux_arm64, toolchain: stable, target: arm-unknown-linux-gnueabihf, cross: true }
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            name: nixpacks-x86_64-unknown-linux-gnu.tar.gz
 
-        # Macos
-        - { os: macos-latest, build: darwin_amd64, toolchain: stable, target: x86_64-apple-darwin, cross: false }
-        - { os: macos-latest, build: darwin_arm64, toolchain: stable, target: aarch64-apple-darwin, cross: true }
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            name: nixpacks-x86_64-unknown-linux-musl.tar.gz
+
+          - target: i686-unknown-linux-musl
+            os: ubuntu-latest
+            name: nixpacks-i686-unknown-linux-musl.tar.gz
+
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            name: nixpacks-aarch64-unknown-linux-musl.tar.gz
+
+          - target: arm-unknown-linux-musleabihf
+            os: ubuntu-latest
+            name: nixpacks-arm-unknown-linux-musleabihf.tar.gz
+
+          - target: x86_64-apple-darwin
+            os: macOS-latest
+            name: nixpacks-x86_64-apple-darwin.tar.gz
+
+          - target: aarch64-apple-darwin
+            os: macOS-latest
+            name: nixpacks-aarch64-apple-darwin.tar.gz
+
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            name: nixpacks-x86_64-pc-windows-msvc.zip
+
+          - target: i686-pc-windows-msvc
+            os: windows-latest
+            name: nixpacks-i686-pc-windows-msvc.zip
+
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            name: nixpacks-aarch64-pc-windows-msvc.zip
+
+          - target: x86_64-unknown-freebsd
+            os: ubuntu-latest
+            name: nixpacks-x86_64-unknown-freebsd.tar.gz
 
     steps:
     - name: Checkout repository
@@ -69,33 +109,36 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: ${{ matrix.config.toolchain }}
-        target: ${{ matrix.config.target }}
+        toolchain: stable
+        target: ${{ matrix.target }}
         profile: minimal
         override: true
-        default: true
-
-    - name: Install cross
-      uses: actions-rs/cargo@v1
-      if: ${{ matrix.config.cross }}
-      with:
-        command: install
-        args: cross
 
     - name: Build release binary
       uses: actions-rs/cargo@v1
       with:
-        use-cross: ${{ matrix.config.cross }}
         command: build
-        args: --release --target ${{ matrix.config.target }}
+        args: --release --locked --target ${{ matrix.target }}
+        use-cross: ${{ matrix.os == 'ubuntu-latest' }}
 
-    - name: Pack binaries if unix
-      if: matrix.config.os != 'windows-latest'
-      run: tar -C ./target/${{ matrix.config.target }}/release -czvf nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.config.build }}.tar.gz nixpacks nixpacks
+    - name: Prepare binaries [Windows]
+      if: matrix.os == 'windows-latest'
+      run: |
+        cd target/${{ matrix.target }}/release
+        strip nixpacks.exe
+        7z a ../../../${{ matrix.name }} nixpacks.exe
+        cd -
 
-    - name: Pack binaries if windows
-      if: matrix.config.os == 'windows-latest'
-      run: compress-archive ./target/${{ matrix.config.build }}/release/nixpacks.exe, ./target/${{ matrix.config.target }}/release/nixpacks.exe nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.config.target }}-${{ matrix.config.target_cpu }}.zip
+    - name: Prepare binaries [-nix]
+      if: matrix.os != 'windows-latest'
+      run: |
+        cd target/${{ matrix.target }}/release
+        strip nixpacks || true
+        tar czvf ../../../${{ matrix.name }} nixpacks
+        cd -
+
+    - name: Add Checksums
+      run: for file in nixpacks-*/nixpacks-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done
 
     - name: Upload release archive
       uses: softprops/action-gh-release@v1
@@ -103,8 +146,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ needs.create-release.outputs.nixpacks_version }}
-        files: |
-          nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.config.build }}.tar.gz
+        files: nixpacks-*/nixpacks-*
 
     - name: Set SHA
       if: matrix.config.os == 'macos-latest'
@@ -114,12 +156,12 @@ jobs:
 
     - name: Update homebrew tap
       uses: mislav/bump-homebrew-formula-action@v1
-      if: "matrix.config.build == 'darwin_amd64' && !contains(github.ref, '-')"
+      if: "matrix.target == 'x86_64-apple-darwin' && !contains(github.ref, '-')"
       with:
         formula-name: nixpacks
         formula-path: nixpacks.rb
         homebrew-tap: railwayapp/homebrew-tap
-        download-url: https://github.com/railwayapp/nixpacks/releases/download/${{ needs.create-release.outputs.nixpacks_version }}/nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.config.build }}.tar.gz
+        download-url: https://github.com/railwayapp/nixpacks/releases/download/${{ needs.create-release.outputs.nixpacks_version }}/nixpacks-x86_64-apple-darwin.tar.gz
       env:
         COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,47 +58,36 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            name: nixpacks-x86_64-unknown-linux-gnu.tar.gz
 
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            name: nixpacks-x86_64-unknown-linux-musl.tar.gz
 
           - target: i686-unknown-linux-musl
             os: ubuntu-latest
-            name: nixpacks-i686-unknown-linux-musl.tar.gz
 
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
-            name: nixpacks-aarch64-unknown-linux-musl.tar.gz
 
           - target: arm-unknown-linux-musleabihf
             os: ubuntu-latest
-            name: nixpacks-arm-unknown-linux-musleabihf.tar.gz
 
           - target: x86_64-apple-darwin
             os: macOS-latest
-            name: nixpacks-x86_64-apple-darwin.tar.gz
 
           - target: aarch64-apple-darwin
             os: macOS-latest
-            name: nixpacks-aarch64-apple-darwin.tar.gz
 
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            name: nixpacks-x86_64-pc-windows-msvc.zip
 
           - target: i686-pc-windows-msvc
             os: windows-latest
-            name: nixpacks-i686-pc-windows-msvc.zip
 
           - target: aarch64-pc-windows-msvc
             os: windows-latest
-            name: nixpacks-aarch64-pc-windows-msvc.zip
 
           - target: x86_64-unknown-freebsd
             os: ubuntu-latest
-            name: nixpacks-x86_64-unknown-freebsd.tar.gz
 
     steps:
     - name: Checkout repository
@@ -126,7 +115,7 @@ jobs:
       run: |
         cd target/${{ matrix.target }}/release
         strip nixpacks.exe
-        7z a ../../../${{ matrix.name }} nixpacks.exe
+        7z a ../../../nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.target }}.zip nixpacks.exe
         cd -
 
     - name: Prepare binaries [-nix]
@@ -134,7 +123,7 @@ jobs:
       run: |
         cd target/${{ matrix.target }}/release
         strip nixpacks || true
-        tar czvf ../../../${{ matrix.name }} nixpacks
+        tar czvf ../../../nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.target }}.tar.gz nixpacks
         cd -
 
     - name: Add Checksums

--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ At the moment Nixpacks supports the following languages out of the box
 
 # Installation
 
-Nixpacks only works on MacOS and Linux machines.
-
 ## Homebrew
 
 Install Nixpacks with [Homebrew](https://brew.sh/) (MacOS Only)

--- a/install.sh
+++ b/install.sh
@@ -1,179 +1,479 @@
-#!/bin/sh
-set -e
+#!/usr/bin/env sh
 
+# Adapted from https://github.com/starship/starship/blob/master/install/install.sh
+
+help_text="# Options
 #
-# Nixpacks
+#   -V, --verbose
+#     Enable verbose output for the installer
 #
-# This script is meant for quick installs via sh
-#   sh -c "$(curl -sSL https://raw.githubusercontent.com/railwayapp/nixpacks/master/install.sh)"
+#   -f, -y, --force, --yes
+#     Skip the confirmation prompt during installation
 #
+#   -p, --platform
+#     Override the platform identified by the installer
+#
+#   -b, --bin-dir
+#     Override the bin installation directory
+#
+#   -a, --arch
+#     Override the architecture identified by the installer
+#
+#   -B, --base-url
+#     Override the base URL used for downloading releases
+#   -r, --remove
+#     Uninstall nixpacks
+#   -h, --help
+#     Get some help
+#
+"
 
-INSTALL_DIR=${INSTALL_DIR:-"/usr/local/bin"}
-BINARY_NAME=${BINARY_NAME:-"nixpacks"}
+set -eu
+printf '\n'
 
-REPO_NAME="railwayapp/nixpacks"
-ISSUE_URL="https://github.com/railwayapp/nixpacks/issues/new"
+BOLD="$(tput bold 2>/dev/null || printf '')"
+GREY="$(tput setaf 0 2>/dev/null || printf '')"
+UNDERLINE="$(tput smul 2>/dev/null || printf '')"
+RED="$(tput setaf 1 2>/dev/null || printf '')"
+GREEN="$(tput setaf 2 2>/dev/null || printf '')"
+YELLOW="$(tput setaf 3 2>/dev/null || printf '')"
+BLUE="$(tput setaf 4 2>/dev/null || printf '')"
+MAGENTA="$(tput setaf 5 2>/dev/null || printf '')"
+NO_COLOR="$(tput sgr0 2>/dev/null || printf '')"
 
-# Usage
-# get_latest_release "railwayapp/nixpacks"
-get_latest_release() {
-  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
-    grep '"tag_name":' |                                            # Get tag line
-    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
+SUPPORTED_TARGETS="x86_64-unknown-linux-gnu x86_64-unknown-linux-musl \
+                  i686-unknown-linux-musl aarch64-unknown-linux-musl \
+                  arm-unknown-linux-musleabihf x86_64-apple-darwin \
+                  aarch64-apple-darwin x86_64-pc-windows-msvc \
+                  i686-pc-windows-msvc aarch64-pc-windows-msvc \
+                  x86_64-unknown-freebsd"
+
+info() {
+  printf '%s\n' "${BOLD}${GREY}>${NO_COLOR} $*"
 }
 
-get_asset_name() {
-  echo "nixpacks-v$1-$2_$3.tar.gz"
+warn() {
+  printf '%s\n' "${YELLOW}! $*${NO_COLOR}"
 }
 
-get_download_url() {
-  local asset_name=$(get_asset_name $1 $2 $3)
-  echo "https://github.com/${REPO_NAME}/releases/download/v$1/${asset_name}"
+error() {
+  printf '%s\n' "${RED}x $*${NO_COLOR}" >&2
 }
 
-command_exists() {
-  command -v "$@" >/dev/null 2>&1
+completed() {
+  printf '%s\n' "${GREEN}✓${NO_COLOR} $*"
 }
 
-fmt_error() {
-  echo ${RED}"Error: $@"${RESET} >&2
+has() {
+  command -v "$1" 1>/dev/null 2>&1
 }
 
-fmt_warning() {
-  echo ${YELLOW}"Warning: $@"${RESET} >&2
-}
-
-fmt_underline() {
-  echo "$(printf '\033[4m')$@$(printf '\033[24m')"
-}
-
-fmt_code() {
-  echo "\`$(printf '\033[38;5;247m')$@${RESET}\`"
-}
-
-setup_color() {
-  # Only use colors if connected to a terminal
-  if [ -t 1 ]; then
-    RED=$(printf '\033[31m')
-    GREEN=$(printf '\033[32m')
-    YELLOW=$(printf '\033[33m')
-    BLUE=$(printf '\033[34m')
-    MAGENTA=$(printf '\033[35m')
-    BOLD=$(printf '\033[1m')
-    RESET=$(printf '\033[m')
+# Gets path to a temporary file, even if
+get_tmpfile() {
+  local suffix
+  suffix="$1"
+  if has mktemp; then
+    printf "%s%s.%s.%s" "$(mktemp)" "-nixpacks" "${RANDOM}" "${suffix}"
   else
-    RED=""
-    GREEN=""
-    YELLOW=""
-    BLUE=""
-    MAGENTA=""
-    BOLD=""
-    RESET=""
+    # No really good options here--let's pick a default + hope
+    printf "/tmp/nixpacks.%s" "${suffix}"
   fi
 }
 
-get_os() {
-  case "$(uname -s)" in
-    *linux* ) echo "linux" ;;
-    *Linux* ) echo "linux" ;;
-    *darwin* ) echo "darwin" ;;
-    *Darwin* ) echo "darwin" ;;
-  esac
-}
-
-get_machine() {
-  case "$(uname -m)" in
-    "x86_64"|"amd64"|"x64")
-      echo "amd64" ;;
-    "i386"|"i86pc"|"x86"|"i686")
-      echo "i386" ;;
-    "arm64"|"armv6l"|"aarch64")
-      echo "arm64"
-  esac
-}
-
-get_tmp_dir() {
-  echo $(mktemp -d)
-}
-
-do_checksum() {
-  checksum_url=$(get_checksum_url $version)
-  expected_checksum=$(curl -sL $checksum_url | grep $asset_name | awk '{print $1}')
-
-  if command_exists sha256sum; then
-    checksum=$(sha256sum $asset_name | awk '{print $1}')
-  elif command_exists shasum; then
-    checksum=$(shasum -a 256 $asset_name | awk '{print $1}')
-  else
-    fmt_warning "Could not find a checksum program. Install shasum or sha256sum to validate checksum."
+# Test if a location is writeable by trying to write to it. Windows does not let
+# you test writeability other than by writing: https://stackoverflow.com/q/1999988
+test_writeable() {
+  local path
+  path="${1:-}/test.txt"
+  if touch "${path}" 2>/dev/null; then
+    rm "${path}"
     return 0
+  else
+    return 1
+  fi
+}
+
+download() {
+  file="$1"
+  url="$2"
+  touch "$file"
+  printf "%s" "$file"
+
+  if has curl; then
+    cmd="curl --fail --silent --location --output $file $url"
+  elif has wget; then
+    cmd="wget --quiet --output-document=$file $url"
+  elif has fetch; then
+    cmd="fetch --quiet --output=$file $url"
+  else
+    error "No HTTP download program (curl, wget, fetch) found, exiting…"
+    return 1
   fi
 
-  if [ "$checksum" != "$expected_checksum" ]; then
-    fmt_error "Checksums do not match"
+  $cmd && return 0 || rc=$?
+
+  error "Command failed (exit code $rc): ${BLUE}${cmd}${NO_COLOR}"
+  printf "\n" >&2
+  info "This is likely due to nixpacks not yet supporting your configuration."
+  info "If you would like to see a build for your configuration,"
+  info "please create an issue requesting a build for ${MAGENTA}${TARGET}${NO_COLOR}:"
+  info "${BOLD}${UNDERLINE}https://github.com/railwayapp/nixpacks/issues/new/${NO_COLOR}"
+  return $rc
+}
+
+unpack() {
+  local archive=$1
+  local bin_dir=$2
+  local sudo=${3-}
+
+  case "$archive" in
+    *.tar.gz)
+      flags=$(test -n "${VERBOSE-}" && echo "-v" || echo "")
+      ${sudo} tar "${flags}" -xzf "${archive}" -C "${bin_dir}"
+      return 0
+      ;;
+    *.zip)
+      flags=$(test -z "${VERBOSE-}" && echo "-qq" || echo "")
+      UNZIP="${flags}" ${sudo} unzip "${archive}" -d "${bin_dir}"
+      return 0
+      ;;
+  esac
+
+  error "Unknown package extension."
+  printf "\n"
+  info "This almost certainly results from a bug in this script--please file a"
+  info "bug report at https://github.com/railwayapp/nixpacks/issues"
+  return 1
+}
+
+elevate_priv() {
+  if ! has sudo; then
+    error 'Could not find the command "sudo", needed to get permissions for install.'
+    info "If you are on Windows, please run your shell as an administrator, then"
+    info "rerun this script. Otherwise, please run this script as root, or install"
+    info "sudo."
+    exit 1
+  fi
+  if ! sudo -v; then
+    error "Superuser not granted, aborting installation"
     exit 1
   fi
 }
 
-do_install_binary() {
-  asset_name=$(get_asset_name $version $os $machine)
-  download_url=$(get_download_url $version $os $machine)
+install() {
+  local msg
+  local sudo
+  local archive
+  local ext="$1"
 
-  command_exists curl || {
-    fmt_error "curl is not installed"
-    exit 1
-  }
+  if test_writeable "${BIN_DIR}"; then
+    sudo=""
+    msg="Installing nixpacks, please wait…"
+  else
+    warn "Escalated permissions are required to install to ${BIN_DIR}"
+    elevate_priv
+    sudo="sudo"
+    msg="Installing nixpacks as root, please wait…"
+  fi
+  info "$msg"
 
-  command_exists tar || {
-    fmt_error "tar is not installed"
-    exit 1
-  }
+  archive=$(get_tmpfile "$ext")
 
-  local tmp_dir=$(get_tmp_dir)
+  # download to the temp file
+  download "${archive}" "${URL}"
 
-  # Download tar.gz to tmp directory
-  echo "Downloading $download_url"
-  (cd $tmp_dir && curl -sL -O "$download_url")
+  # unpack the temp file to the bin dir, using sudo if required
+  unpack "${archive}" "${BIN_DIR}" "${sudo}"
 
-  # (cd $tmp_dir && do_checksum)
+  # remove tempfile
 
-  # Extract download
-  (cd $tmp_dir && tar -xzf "$asset_name")
-
-  # Install binary
-  sudo mv "$tmp_dir/$BINARY_NAME" $INSTALL_DIR
-  echo "Installed railway to $INSTALL_DIR"
-
-  # Cleanup
-  rm -rf $tmp_dir
+  rm "${archive}"
 }
 
-main() {
-  setup_color
+# Currently supporting:
+#   - win (Git Bash)
+#   - darwin
+#   - linux
+#   - linux_musl (Alpine)
+#   - freebsd
+detect_platform() {
+  local platform
+  platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
-  latest_tag=$(get_latest_release $REPO_NAME)
-  latest_version=$(echo $latest_tag | sed 's/v//')
-  version=${VERSION:-$latest_version}
+  case "${platform}" in
+    msys_nt*) platform="pc-windows-msvc" ;;
+    cygwin_nt*) platform="pc-windows-msvc";;
+    # mingw is Git-Bash
+    mingw*) platform="pc-windows-msvc" ;;
+    # use the statically compiled musl bins on linux to avoid linking issues.
+    linux) platform="unknown-linux-musl" ;;
+    darwin) platform="apple-darwin" ;;
+    freebsd) platform="unknown-freebsd" ;;
+  esac
 
-  os=$(get_os)
-  if test -z "$os"; then
-    fmt_error "$(uname -s) os type is not supported"
-    echo "Please create an issue so we can add support. $ISSUE_URL"
+  printf '%s' "${platform}"
+}
+
+# Currently supporting:
+#   - x86_64
+#   - i386
+detect_arch() {
+  local arch
+  arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
+
+  case "${arch}" in
+    amd64) arch="x86_64" ;;
+    armv*) arch="arm" ;;
+    arm64) arch="aarch64" ;;
+  esac
+
+  # `uname -m` in some cases mis-reports 32-bit OS as 64-bit, so double check
+  if [ "${arch}" = "x86_64" ] && [ "$(getconf LONG_BIT)" -eq 32 ]; then
+    arch=i686
+  elif [ "${arch}" = "aarch64" ] && [ "$(getconf LONG_BIT)" -eq 32 ]; then
+    arch=arm
+  fi
+
+  printf '%s' "${arch}"
+}
+
+detect_target() {
+  local arch="$1"
+  local platform="$2"
+  local target="$arch-$platform"
+
+  if [ "${target}" = "arm-unknown-linux-musl" ]; then
+    target="${target}eabihf"
+  fi
+
+  printf '%s' "${target}"
+}
+
+
+confirm() {
+  if [ -z "${FORCE-}" ]; then
+    printf "%s " "${MAGENTA}?${NO_COLOR} $* ${BOLD}[y/N]${NO_COLOR}"
+    set +e
+    read -r yn </dev/tty
+    rc=$?
+    set -e
+    if [ $rc -ne 0 ]; then
+      error "Error reading from prompt (please re-run with the '--yes' option)"
+      exit 1
+    fi
+    if [ "$yn" != "y" ] && [ "$yn" != "yes" ]; then
+      error 'Aborting (please answer "yes" to continue)'
+      exit 1
+    fi
+  fi
+}
+
+check_bin_dir() {
+  local bin_dir="$1"
+
+  if [ ! -d "$BIN_DIR" ]; then
+    error "Installation location $BIN_DIR does not appear to be a directory"
+    info "Make sure the location exists and is a directory, then try again."
     exit 1
   fi
 
-  machine=$(get_machine)
-  if test -z "$machine"; then
-    fmt_error "$(uname -m) machine type is not supported"
-    echo "Please create an issue so we can add support. $ISSUE_URL"
+  # https://stackoverflow.com/a/11655875
+  local good
+  good=$(
+    IFS=:
+    for path in $PATH; do
+      if [ "${path}" = "${bin_dir}" ]; then
+        printf 1
+        break
+      fi
+    done
+  )
+
+  if [ "${good}" != "1" ]; then
+    warn "Bin directory ${bin_dir} is not in your \$PATH"
+  fi
+}
+
+is_build_available() {
+  local arch="$1"
+  local platform="$2"
+  local target="$3"
+
+  local good
+
+  good=$(
+    IFS=" "
+    for t in $SUPPORTED_TARGETS; do
+      if [ "${t}" = "${target}" ]; then
+        printf 1
+        break
+      fi
+    done
+  )
+
+  if [ "${good}" != "1" ]; then
+    error "${arch} builds for ${platform} are not yet available for nixpacks"
+    printf "\n" >&2
+    info "If you would like to see a build for your configuration,"
+    info "please create an issue requesting a build for ${MAGENTA}${target}${NO_COLOR}:"
+    info "${BOLD}${UNDERLINE}https://github.com/railwayapp/nixpacks/issues/new/${NO_COLOR}"
+    printf "\n"
     exit 1
   fi
+}
+UNINSTALL=0
+HELP=0
+CARGOTOML="$(curl -fsSL https://raw.githubusercontent.com/railwayapp/nixpacks/master/Cargo.toml)"
+ALL_VERSIONS="$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' <<< "$CARGOTOML")"
+IFS=$'\n' read -r -a VERSION <<< "$ALL_VERSIONS"
+# defaults
+if [ -z "${PLATFORM-}" ]; then
+  PLATFORM="$(detect_platform)"
+fi
 
-  do_install_binary
+if [ -z "${BIN_DIR-}" ]; then
+  BIN_DIR=/usr/local/bin
+fi
 
-  printf "$GREEN"
+if [ -z "${ARCH-}" ]; then
+  ARCH="$(detect_arch)"
+fi
+
+if [ -z "${BASE_URL-}" ]; then
+  BASE_URL="https://github.com/railwayapp/nixpacks/releases"
+fi
+
+# parse argv variables
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  -p | --platform)
+    PLATFORM="$2"
+    shift 2
+    ;;
+  -b | --bin-dir)
+    BIN_DIR="$2"
+    shift 2
+    ;;
+  -a | --arch)
+    ARCH="$2"
+    shift 2
+    ;;
+  -B | --base-url)
+    BASE_URL="$2"
+    shift 2
+    ;;
+
+  -V | --verbose)
+    VERBOSE=1
+    shift 1
+    ;;
+  -f | -y | --force | --yes)
+    FORCE=1
+    shift 1
+    ;;
+  -r | --remove | --uninstall)
+    UNINSTALL=1
+    shift 1
+    ;;
+  -h | --help)
+    HELP=1
+    shift 1
+    ;;
+  -p=* | --platform=*)
+    PLATFORM="${1#*=}"
+    shift 1
+    ;;
+  -b=* | --bin-dir=*)
+    BIN_DIR="${1#*=}"
+    shift 1
+    ;;
+  -a=* | --arch=*)
+    ARCH="${1#*=}"
+    shift 1
+    ;;
+  -B=* | --base-url=*)
+    BASE_URL="${1#*=}"
+    shift 1
+    ;;
+  -V=* | --verbose=*)
+    VERBOSE="${1#*=}"
+    shift 1
+    ;;
+  -f=* | -y=* | --force=* | --yes=*)
+    FORCE="${1#*=}"
+    shift 1
+    ;;
+
+  *)
+    error "Unknown option: $1"
+    exit 1
+    ;;
+  esac
+done
+if [ $UNINSTALL == 1 ]; then
+  confirm "Are you sure you want to uninstall nixpacks?"
+
+  msg=""
+  sudo=""
+
+  info "REMOVING nixpacks"
+
+  if test_writeable "$(dirname "$(which nixpacks)")"; then
+    sudo=""
+    msg="Removing nixpacks, please wait…"
+  else
+    warn "Escalated permissions are required to install to ${BIN_DIR}"
+    elevate_priv
+    sudo="sudo"
+    msg="Removing nixpacks as root, please wait…"
+  fi
+
+  info "$msg"
+  ${sudo} rm "$(which nixpacks)"
+  ${sudo} rm /tmp/nixpacks
+
+  info "Removed nixpacks"
+  exit 0
+  
+ fi
+if [ $HELP == 1 ]; then
+    echo "${help_text}"
+    exit 0
+fi
+TARGET="$(detect_target "${ARCH}" "${PLATFORM}")"
+
+is_build_available "${ARCH}" "${PLATFORM}" "${TARGET}"
+
+printf "  %s\n" "${UNDERLINE}Configuration${NO_COLOR}"
+info "${BOLD}Bin directory${NO_COLOR}: ${GREEN}${BIN_DIR}${NO_COLOR}"
+info "${BOLD}Platform${NO_COLOR}:      ${GREEN}${PLATFORM}${NO_COLOR}"
+info "${BOLD}Arch${NO_COLOR}:          ${GREEN}${ARCH}${NO_COLOR}"
+info "${BOLD}Version${NO_COLOR}:       ${GREEN}${VERSION[0]}${NO_COLOR}"
+
+# non-empty VERBOSE enables verbose untarring
+if [ -n "${VERBOSE-}" ]; then
+  VERBOSE=v
+  info "${BOLD}Verbose${NO_COLOR}: yes"
+else
+  VERBOSE=
+fi
+
+printf '\n'
+
+EXT=tar.gz
+if [ "${PLATFORM}" = "pc-windows-msvc" ]; then
+  EXT=zip
+fi
+
+URL="${BASE_URL}/latest/download/nixpacks-${TARGET}.${EXT}"
+info "Tarball URL: ${UNDERLINE}${BLUE}${URL}${NO_COLOR}"
+confirm "Install nixpacks ${GREEN}${VERSION[0]}${NO_COLOR} to ${BOLD}${GREEN}${BIN_DIR}${NO_COLOR}?"
+check_bin_dir "${BIN_DIR}"
+
+install "${EXT}"
+
+printf "$GREEN"
   cat <<'EOF'
-
       +--------------+
      /|             /|
     / |            / |
@@ -185,10 +485,5 @@ main() {
    | /            | /
    |/             |/
    *--------------*
-
 EOF
-  printf "$RESET"
-
-}
-
-main
+printf "$NO_COLOR"

--- a/install.sh
+++ b/install.sh
@@ -465,7 +465,7 @@ if [ "${PLATFORM}" = "pc-windows-msvc" ]; then
   EXT=zip
 fi
 
-URL="${BASE_URL}/latest/download/nixpacks-${TARGET}.${EXT}"
+URL="${BASE_URL}/latest/download/nixpacks-v${VERSION[0]}-${TARGET}.${EXT}"
 info "Tarball URL: ${UNDERLINE}${BLUE}${URL}${NO_COLOR}"
 confirm "Install nixpacks ${GREEN}${VERSION[0]}${NO_COLOR} to ${BOLD}${GREEN}${BIN_DIR}${NO_COLOR}?"
 check_bin_dir "${BIN_DIR}"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,6 +1,3 @@
-INSTALL_DIR="/usr/local/bin"
-BINARY_NAME="nixpacks"
-
-sudo rm "$INSTALL_DIR/$BINARY_NAME"
+rm "$(command -v 'nixpacks')"
 
 echo "Uninstalled Nixpacks"


### PR DESCRIPTION
This pull request adds support for more rust targets (e.g. `x86_64-unknown-freebsd`, `i686-pc-windows-msvc`, etc.). I've also adjusted the install script to work with that.