### PR TITLE
Fix `clippy::needless_borrow`

### DIFF
--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -63,7 +63,7 @@ impl DenoProvider {
             None => return Ok(None),
         };
 
-        let relative_path_to_index = app.strip_source_path(&path_to_index)?;
+        let relative_path_to_index = app.strip_source_path(path_to_index)?;
         Ok(Some(relative_path_to_index))
     }
 }


### PR DESCRIPTION
```sh
❯ cargo clippy
    Checking nixpacks v0.0.10 (/home/tomio/projects/nixpacks)
warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/providers/deno.rs:66:60
   |
66 |         let relative_path_to_index = app.strip_source_path(&path_to_index)?;
   |                                                            ^^^^^^^^^^^^^^ help: change this to: `path_to_index`
   |
   = note: `#[warn(clippy::needless_borrow)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: `nixpacks` (lib) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.96s
```

This PR fixes this error.