### PR TITLE
Fix go runtime image

### DIFF
--- a/src/nixpacks/images.rs
+++ b/src/nixpacks/images.rs
@@ -1,0 +1,3 @@
+pub static DEFAULT_BASE_IMAGE: &str = "ghcr.io/railwayapp/nixpacks:debian-1652414952";
+
+pub static DEBIAN_SLIM_IMAGE: &str = "debian:bullseye-slim";

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 use walkdir::WalkDir;
 pub mod app;
 pub mod environment;
+pub mod images;
 pub mod logger;
 pub mod nix;
 pub mod phase;
@@ -519,6 +520,7 @@ impl<'a> AppBuilder<'a> {
         }
 
         let run_image_setup = start_phase.run_image.map(|run_image| {
+            // RUN true to prevent a Docker bug https://github.com/moby/moby/issues/37965#issuecomment-426853382
             formatdoc! {"
                 FROM {run_image}
                 WORKDIR {app_dir}

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-use super::nix::Pkg;
-
-// Debian 11
-static DEFAULT_BASE_IMAGE: &str = "ghcr.io/railwayapp/nixpacks:debian-1652414952";
+use super::{
+    images::{DEBIAN_SLIM_IMAGE, DEFAULT_BASE_IMAGE},
+    nix::Pkg,
+};
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -146,5 +146,9 @@ impl StartPhase {
 
     pub fn run_in_default_image(&mut self) {
         self.run_image = Some(DEFAULT_BASE_IMAGE.to_string());
+    }
+
+    pub fn run_in_slim_image(&mut self) {
+        self.run_image = Some(DEBIAN_SLIM_IMAGE.to_string());
     }
 }

--- a/src/providers/go.rs
+++ b/src/providers/go.rs
@@ -55,7 +55,7 @@ impl Provider for GolangProvider {
 
         // Only run in a new image if CGO_ENABLED=0 (default)
         if cgo != "1" {
-            start_phase.run_in_default_image();
+            start_phase.run_in_slim_image();
         }
 
         Ok(Some(start_phase))


### PR DESCRIPTION
Run go code in debian slim, not the nixpacks debian image
