### PR TITLE
Add make to base image

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-20220509-slim
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y upgrade \
-  && apt-get install --no-install-recommends -y sudo locales curl xz-utils ca-certificates openssl build-essential \
+  && apt-get install --no-install-recommends -y sudo locales curl xz-utils ca-certificates openssl make \
   && apt-get clean && rm -rf /var/lib/apt/lists/* \
   && mkdir -m 0755 /nix && mkdir -m 0755 /etc/nix && groupadd -r nixbld && chown root /nix \
   && printf 'sandbox = false \nfilter-syscalls = false' > /etc/nix/nix.conf \

--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-20220509-slim
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y upgrade \
-  && apt-get install --no-install-recommends -y sudo locales curl xz-utils ca-certificates openssl \
+  && apt-get install --no-install-recommends -y sudo locales curl xz-utils ca-certificates openssl build-essential \
   && apt-get clean && rm -rf /var/lib/apt/lists/* \
   && mkdir -m 0755 /nix && mkdir -m 0755 /etc/nix && groupadd -r nixbld && chown root /nix \
   && printf 'sandbox = false \nfilter-syscalls = false' > /etc/nix/nix.conf \


### PR DESCRIPTION
I've been going back and forth on this. Preferrably packages are installed through Nix, but in reality a lot of language and framework dependencies assume/expect the standard GCC/make toolchain to be available. This is the case for some Node, Python, and Ruby packages. For the reason I think adding `build-essential` to the default packages available on Debian makes sense.
