### PR TITLE
Smaller final Rust image sizes

### DIFF
--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -130,6 +130,9 @@ pub struct StartPhase {
 
     #[serde(rename = "runImage")]
     pub run_image: Option<String>,
+
+    #[serde(rename = "onlyIncludeFiles")]
+    pub only_include_files: Option<Vec<String>>,
 }
 
 impl StartPhase {
@@ -137,6 +140,7 @@ impl StartPhase {
         Self {
             cmd: Some(cmd),
             run_image: None,
+            only_include_files: None,
         }
     }
 
@@ -146,5 +150,14 @@ impl StartPhase {
 
     pub fn run_in_default_image(&mut self) {
         self.run_image = Some(DEFAULT_BASE_IMAGE.to_string());
+    }
+
+    pub fn add_file_dependency(&mut self, file: String) {
+        if let Some(mut files) = self.only_include_files.clone() {
+            files.push(file);
+            self.only_include_files = Some(files);
+        } else {
+            self.only_include_files = Some(vec![file]);
+        }
     }
 }


### PR DESCRIPTION
This PR builds Rust apps with the `{arch}-unknown-linux-musl` target by default. This creates a static binary which is then copied over to a fresh debian slim image resulting in a significantly smaller image size (~3GB -> 85MB).

Related discussion: https://github.com/railwayapp/nixpacks/discussions/139

![image](https://user-images.githubusercontent.com/3044853/168551280-dda5275c-770a-4fd8-af77-8cccdd696360.png)

_PR still a draft as I clean it up and make it configurable_

## Todo

- [ ] Detect parent arch and make rust target arch dynamic
- [ ] Allow opting out of musl builds with an env var
- [ ] Providers shouldn't need to know about the "app" directory
- [ ] Handle rust apps with a rust-toolchain file