### PR TITLE
Flag to add additional labels to resulting image

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub fn gen_plan(
         out_dir: None,
         plan_path: None,
         tags: Vec::new(),
+        labels: Vec::new(),
         quiet: false,
     };
 
@@ -72,6 +73,7 @@ pub fn build(
     plan_path: Option<String>,
     out_dir: Option<String>,
     tags: Vec<&str>,
+    labels: Vec<&str>,
     quiet: bool,
 ) -> Result<()> {
     let logger = Logger::new();
@@ -85,6 +87,7 @@ pub fn build(
         out_dir,
         plan_path,
         tags: tags.iter().map(|s| s.to_string()).collect(),
+        labels: labels.iter().map(|s| s.to_string()).collect(),
         quiet,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,14 @@ fn main() -> Result<()> {
                         .help("Additional tags to add to the output image")
                         .takes_value(true)
                         .multiple_values(true),
+                )
+                .arg(
+                    Arg::new("label")
+                        .long("label")
+                        .short('l')
+                        .help("Additional labels to add to the output image")
+                        .takes_value(true)
+                        .multiple_values(true),
                 ),
         )
         .arg(
@@ -116,14 +124,19 @@ fn main() -> Result<()> {
             let plan_path = matches.value_of("plan").map(|n| n.to_string());
             let output_dir = matches.value_of("out").map(|n| n.to_string());
 
-            let tags: Vec<_> = match matches.values_of("tag") {
-                Some(values) => values.collect(),
-                None => Vec::new(),
-            };
+            let tags = matches
+                .values_of("tag")
+                .map(|values| values.collect())
+                .unwrap_or_default();
+
+            let labels = matches
+                .values_of("label")
+                .map(|values| values.collect())
+                .unwrap_or_default();
 
             build(
                 path, name, pkgs, build_cmd, start_cmd, pin_pkgs, envs, plan_path, output_dir,
-                tags, false,
+                tags, labels, false,
             )?;
         }
         _ => eprintln!("Invalid command"),

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -42,6 +42,7 @@ pub struct AppBuilderOptions {
     pub out_dir: Option<String>,
     pub plan_path: Option<String>,
     pub tags: Vec<String>,
+    pub labels: Vec<String>,
     pub quiet: bool,
 }
 
@@ -55,6 +56,7 @@ impl AppBuilderOptions {
             out_dir: None,
             plan_path: None,
             tags: Vec::new(),
+            labels: Vec::new(),
             quiet: false,
         }
     }
@@ -173,10 +175,15 @@ impl<'a> AppBuilder<'a> {
                     .arg(format!("{}={}", name, value));
             }
 
-            // Add user defined tags to the image
+            // Add user defined tags and labels to the image
             for t in self.options.tags.clone() {
                 docker_build_cmd.arg("-t").arg(t);
             }
+            for l in self.options.labels.clone() {
+                docker_build_cmd.arg("--label").arg(l);
+            }
+
+            println!("{:?}", docker_build_cmd);
 
             let build_result = docker_build_cmd.spawn()?.wait().context("Building image")?;
 

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -100,6 +100,7 @@ fn simple_build(path: &str) -> String {
         None,
         None,
         Vec::new(),
+        Vec::new(),
         true,
     )
     .unwrap();
@@ -190,6 +191,7 @@ fn test_rust_custom_version() {
         None,
         None,
         Vec::new(),
+        Vec::new(),
         true,
     )
     .unwrap();
@@ -232,6 +234,7 @@ fn test_cowsay() {
         Vec::new(),
         None,
         None,
+        Vec::new(),
         Vec::new(),
         true,
     )


### PR DESCRIPTION
New flag to add additional labels to the resulting Docker image. For example,

```
nixpacks build examples/XXX --label one two three
```

![screenshot-2022-05-26-11 42 02](https://user-images.githubusercontent.com/3044853/170523604-c04eedf0-e266-4e99-ad2b-9f4cfd256b11.png)

Closes #142 