### PR TITLE
Provider assets

### DIFF
--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -8,6 +8,8 @@ use regex::Regex;
 use serde::de::DeserializeOwned;
 use walkdir::WalkDir;
 
+pub static ASSETS_DIR: &str = "/assets/";
+
 #[derive(Debug, Clone)]
 pub struct App {
     pub source: PathBuf,
@@ -135,6 +137,11 @@ impl App {
 
         // Convert path to PathBuf
         Ok(stripped.to_owned())
+    }
+    
+    /// Get the path in the container to an asset defined in `static_assets`.
+    pub fn asset_path(name: &str) -> String {
+        format!("{ASSETS_DIR}{name}")
     }
 }
 

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -138,7 +138,7 @@ impl App {
         // Convert path to PathBuf
         Ok(stripped.to_owned())
     }
-    
+
     /// Get the path in the container to an asset defined in `static_assets`.
     pub fn asset_path(&self, name: &str) -> String {
         format!("{ASSETS_DIR}{name}")
@@ -258,14 +258,11 @@ mod tests {
         );
         Ok(())
     }
-    
+
     #[test]
     fn test_static_asset_path() -> Result<()> {
         let app = App::new("./examples/npm")?;
-        assert_eq!(
-            &app.asset_path("hi.txt"),
-            "/assets/hi.txt"
-        );
+        assert_eq!(&app.asset_path("hi.txt"), "/assets/hi.txt");
         Ok(())
     }
 }

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use std::collections::HashMap;
 use std::path::Path;
 use std::{env, fs, path::PathBuf};
 
@@ -9,6 +10,7 @@ use serde::de::DeserializeOwned;
 use walkdir::WalkDir;
 
 pub static ASSETS_DIR: &str = "/assets/";
+pub type StaticAssets = HashMap<String, String>;
 
 #[derive(Debug, Clone)]
 pub struct App {

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -140,7 +140,7 @@ impl App {
     }
     
     /// Get the path in the container to an asset defined in `static_assets`.
-    pub fn asset_path(name: &str) -> String {
+    pub fn asset_path(&self, name: &str) -> String {
         format!("{ASSETS_DIR}{name}")
     }
 }
@@ -255,6 +255,16 @@ mod tests {
         assert_eq!(
             &app.strip_source_path(Path::new("no/prefix.txt"))?,
             Path::new("no/prefix.txt")
+        );
+        Ok(())
+    }
+    
+    #[test]
+    fn test_static_asset_path() -> Result<()> {
+        let app = App::new("./examples/npm")?;
+        assert_eq!(
+            &app.asset_path("hi.txt"),
+            "/assets/hi.txt"
         );
         Ok(())
     }

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -100,7 +100,9 @@ impl<'a> AppBuilder<'a> {
         let build_phase = self.get_build_phase().context("Generating build phase")?;
         let start_phase = self.get_start_phase().context("Generating start phase")?;
         let variables = self.get_variables().context("Getting plan variables")?;
-        let static_assets = self.get_static_assets().context("Getting provider assets")?;
+        let static_assets = self
+            .get_static_assets()
+            .context("Getting provider assets")?;
 
         let plan = BuildPlan {
             version: Some(NIX_PACKS_VERSION.to_string()),
@@ -109,7 +111,7 @@ impl<'a> AppBuilder<'a> {
             build: Some(build_phase),
             start: Some(start_phase),
             variables: Some(variables),
-            static_assets: Some(static_assets)
+            static_assets: Some(static_assets),
         };
 
         Ok(plan)
@@ -344,8 +346,10 @@ impl<'a> AppBuilder<'a> {
 
     fn get_static_assets(&self) -> Result<StaticAssets> {
         let static_assets = match self.provider {
-            Some(provider) => provider.static_assets(self.app, self.environment)?.unwrap_or_default(),
-            None => StaticAssets::new()
+            Some(provider) => provider
+                .static_assets(self.app, self.environment)?
+                .unwrap_or_default(),
+            None => StaticAssets::new(),
         };
 
         Ok(static_assets)
@@ -391,14 +395,17 @@ impl<'a> AppBuilder<'a> {
         let dockerfile_path = PathBuf::from(dest).join(PathBuf::from("Dockerfile"));
         File::create(dockerfile_path.clone()).context("Creating Dockerfile file")?;
         fs::write(dockerfile_path, dockerfile).context("Writing Dockerfile")?;
-        
+
         let static_assets_path = PathBuf::from(dest).join(PathBuf::from("assets"));
         fs::create_dir_all(&static_assets_path).context("Creating static assets folder")?;
-        
+
         if let Some(assets) = &plan.static_assets {
             for (name, content) in assets {
-                let mut file = File::create(PathBuf::from(&static_assets_path).join(PathBuf::from(&name))).context(format!("Creating asset file for {name}"))?;
-                file.write_all(content.as_bytes()).context(format!("Writing asset {name}"))?;
+                let mut file =
+                    File::create(PathBuf::from(&static_assets_path).join(PathBuf::from(&name)))
+                        .context(format!("Creating asset file for {name}"))?;
+                file.write_all(content.as_bytes())
+                    .context(format!("Writing asset {name}"))?;
             }
         }
 
@@ -463,7 +470,7 @@ impl<'a> AppBuilder<'a> {
     pub fn gen_dockerfile(plan: &BuildPlan) -> Result<String> {
         let app_dir = "/app/";
         let assets_dir = app::ASSETS_DIR;
-        
+
         let setup_phase = plan.setup.clone().unwrap_or_default();
         let install_phase = plan.install.clone().unwrap_or_default();
         let build_phase = plan.build.clone().unwrap_or_default();
@@ -497,7 +504,7 @@ impl<'a> AppBuilder<'a> {
             setup_files.append(&mut setup_file_deps);
         }
         let setup_copy_cmd = format!("COPY {} {}", setup_files.join(" "), app_dir);
-        
+
         // -- Static Assets
         let assets_copy_cmd = format!("COPY assets {}", assets_dir);
 

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -17,10 +17,10 @@ pub mod nix;
 pub mod phase;
 pub mod plan;
 
-use crate::providers::{Provider, StaticAssets};
+use crate::providers::{Provider};
 
 use self::{
-    app::App,
+    app::{App, StaticAssets},
     environment::{Environment, EnvironmentVariables},
     logger::Logger,
     nix::Pkg,

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -515,7 +515,7 @@ impl<'a> AppBuilder<'a> {
         let assets_copy_cmd = if !static_assets.is_empty() {
             static_assets
                 .into_keys()
-                .map(|name| format!("COPY assets/{} {}", name, assets_dir))
+                .map(|name| format!("COPY assets/{} {}{}", name, assets_dir, name))
                 .collect::<Vec<String>>()
                 .join("\n")
         } else {
@@ -640,17 +640,27 @@ fn get_copy_command(files: &[String], app_dir: &str) -> String {
 
 fn get_copy_from_command(from: &str, files: &[String], app_dir: &str) -> String {
     if files.is_empty() {
-        format!("COPY --from=0 {} {}", app_dir, app_dir)
+        format!(
+            "
+COPY --from=0 {} {}
+RUN true
+COPY --from=0 /assets /assets
+",
+            app_dir, app_dir
+        )
     } else {
         format!(
-            "COPY --from={} {} {}",
+            "COPY --from={} {} {}
+            RUN true
+            COPY --from={} /assets /assets",
             from,
             files
                 .iter()
                 .map(|f| f.replace("./", app_dir))
                 .collect::<Vec<_>>()
                 .join(" "),
-            app_dir
+            app_dir,
+            from
         )
     }
 }

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -404,10 +404,10 @@ impl<'a> AppBuilder<'a> {
                 for (name, content) in assets {
                     let path = Path::new(&static_assets_path).join(name);
                     let parent = path.parent().unwrap();
-                    fs::create_dir_all(parent).context(format!("Creating parent directory for {}", name))?;
+                    fs::create_dir_all(parent)
+                        .context(format!("Creating parent directory for {}", name))?;
                     let mut file =
-                        File::create(path)
-                            .context(format!("Creating asset file for {name}"))?;
+                        File::create(path).context(format!("Creating asset file for {name}"))?;
                     file.write_all(content.as_bytes())
                         .context(format!("Writing asset {name}"))?;
                 }

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -402,8 +402,11 @@ impl<'a> AppBuilder<'a> {
                 fs::create_dir_all(&static_assets_path).context("Creating static assets folder")?;
 
                 for (name, content) in assets {
+                    let path = Path::new(&static_assets_path).join(name);
+                    let parent = path.parent().unwrap();
+                    fs::create_dir_all(parent).context(format!("Creating parent directory for {}", name))?;
                     let mut file =
-                        File::create(PathBuf::from(&static_assets_path).join(PathBuf::from(&name)))
+                        File::create(path)
                             .context(format!("Creating asset file for {name}"))?;
                     file.write_all(content.as_bytes())
                         .context(format!("Writing asset {name}"))?;

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -17,7 +17,7 @@ pub mod nix;
 pub mod phase;
 pub mod plan;
 
-use crate::providers::Provider;
+use crate::providers::{Provider, StaticAssets};
 
 use self::{
     app::App,
@@ -338,6 +338,15 @@ impl<'a> AppBuilder<'a> {
         };
 
         Ok(new_variables)
+    }
+
+    fn get_static_assets(&self) -> Result<StaticAssets> {
+        let static_assets = match self.provider {
+            Some(provider) => provider.static_assets(self.app, self.environment)?.unwrap_or_default(),
+            None => StaticAssets::new()
+        };
+
+        Ok(static_assets)
     }
 
     fn detect(&mut self, providers: Vec<&'a dyn Provider>) -> Result<()> {

--- a/src/nixpacks/plan.rs
+++ b/src/nixpacks/plan.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     environment::EnvironmentVariables,
     phase::{BuildPhase, InstallPhase, SetupPhase, StartPhase},
-    StaticAssets
+    StaticAssets,
 };
 
 #[serde_with::skip_serializing_none]

--- a/src/nixpacks/plan.rs
+++ b/src/nixpacks/plan.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     environment::EnvironmentVariables,
     phase::{BuildPhase, InstallPhase, SetupPhase, StartPhase},
+    StaticAssets
 };
 
 #[serde_with::skip_serializing_none]
@@ -15,6 +16,7 @@ pub struct BuildPlan {
     pub build: Option<BuildPhase>,
     pub start: Option<StartPhase>,
     pub variables: Option<EnvironmentVariables>,
+    pub static_assets: Option<StaticAssets>,
 }
 
 impl BuildPlan {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::nixpacks::{
     app::App,
     environment::{Environment, EnvironmentVariables},
@@ -13,6 +15,8 @@ pub mod node;
 pub mod python;
 pub mod rust;
 
+pub type StaticAssets = HashMap<String, String>;
+
 pub trait Provider {
     fn name(&self) -> &str;
     fn detect(&self, app: &App, _env: &Environment) -> Result<bool>;
@@ -26,6 +30,9 @@ pub trait Provider {
         Ok(None)
     }
     fn start(&self, _app: &App, _env: &Environment) -> Result<Option<StartPhase>> {
+        Ok(None)
+    }
+    fn static_assets(&self, _app: &App, _env: &Environment) -> Result<Option<StaticAssets>> {
         Ok(None)
     }
     fn environment_variables(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-
 use crate::nixpacks::{
-    app::App,
+    app::{App, StaticAssets},
     environment::{Environment, EnvironmentVariables},
     phase::{BuildPhase, InstallPhase, SetupPhase, StartPhase},
 };
@@ -14,8 +12,6 @@ pub mod haskell;
 pub mod node;
 pub mod python;
 pub mod rust;
-
-pub type StaticAssets = HashMap<String, String>;
 
 pub trait Provider {
     fn name(&self) -> &str;


### PR DESCRIPTION
This pull request adds static assets support for providers. It uses a new `static_assets` method in `Provider` that returns a `HashMap` with filenames as keys and file contents as values. It puts files into `/assets` in the Docker container, and you can get the path to an asset by calling `app.asset_path(name: &str)`.

See #158