### PR TITLE
Ability to specify libraries to dynamically link in setup phase

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -21,6 +21,7 @@ ENV \
   GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt \
   NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
   NIX_PATH=/nix/var/nix/profiles/per-user/root/channels \
-  NIXPKGS_ALLOW_BROKEN=1
+  NIXPKGS_ALLOW_BROKEN=1 \
+  LD_LIBRARY_PATH=/usr/lib
 
 RUN nix-channel --update

--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -9,9 +9,10 @@ RUN apt-get update && apt-get -y upgrade \
   && printf 'sandbox = false \nfilter-syscalls = false' > /etc/nix/nix.conf \
   && for n in $(seq 1 10); do useradd -c "Nix build user $n" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(command -v nologin)" "nixbld$n"; done
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-ol", "pipefail", "-c"]
 RUN set -o pipefail && curl -L https://nixos.org/nix/install | bash \
-    && /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-old
+    && /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-old \
+    && printf 'if [ -d $HOME/.nix-profile/etc/profile.d ]; then\n for i in $HOME/.nix-profile/etc/profile.d/*.sh; do\n if [ -r $i ]; then\n . $i\n fi\n done\n fi' >> /root/.profile
 
 ENV \
   ENV=/etc/profile \

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -10,6 +10,7 @@ use super::{
 pub struct SetupPhase {
     pub pkgs: Vec<Pkg>,
     pub archive: Option<String>,
+    pub libraries: Option<Vec<String>>,
 
     #[serde(rename = "onlyIncludeFiles")]
     pub only_include_files: Option<Vec<String>>,
@@ -22,6 +23,7 @@ impl SetupPhase {
     pub fn new(pkgs: Vec<Pkg>) -> Self {
         Self {
             pkgs,
+            libraries: None,
             archive: None,
             only_include_files: None,
             base_image: DEFAULT_BASE_IMAGE.to_string(),
@@ -44,12 +46,22 @@ impl SetupPhase {
     pub fn set_archive(&mut self, archive: String) {
         self.archive = Some(archive);
     }
+
+    pub fn add_library(&mut self, lib: String) {
+        if let Some(mut libraries) = self.libraries.clone() {
+            libraries.push(lib);
+            self.libraries = Some(libraries);
+        } else {
+            self.libraries = Some(vec![lib]);
+        }
+    }
 }
 
 impl Default for SetupPhase {
     fn default() -> Self {
         Self {
             pkgs: Default::default(),
+            libraries: Default::default(),
             archive: Default::default(),
             only_include_files: Default::default(),
             base_image: DEFAULT_BASE_IMAGE.to_string(),


### PR DESCRIPTION
This PR adds an API to the setup phase so that providers can specify Nix libraries that will be appended to the `LD_LIBRARY_PATH` variable. It is related to the https://github.com/railwayapp/nixpacks/pull/195 which adds a special case for the node-canvas NPM package. To accomplish this a few things were changed

- [Base image]: Specify `-l` when starting the container so that `~/.profile` is sourced
- [Setup phase]: new `add_library` method that allows providers to specify which Nix libraries are available. The library paths are calculated with `lib.makeLibraryPath` from the Nix standard library
- [Nix generation]: When generating the `environment.nix` file, create a `libraries.sh` file with the new `LD_LIBRARY_PATH` variable that is copied to the Nix profile which will be sourced on startup

## Example

If the Node provider setup phase is

<img width="605" alt="image" src="https://user-images.githubusercontent.com/3044853/172915342-f8cd1b78-7278-4eb8-8764-8a1d2b4e4a68.png">

when printing `process.env` we see

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/3044853/172915511-efdabeb3-d586-4443-abb1-e66574691f27.png">


## References

- https://discourse.nixos.org/t/node2nix-issues/10762/2