### PR TITLE
Auto-bump base image using github actions

### DIFF
--- a/.github/workflows/publish_debian.yml
+++ b/.github/workflows/publish_debian.yml
@@ -16,7 +16,8 @@ jobs:
   debian:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
       packages: write
       id-token: write
 
@@ -47,5 +48,23 @@ jobs:
         with:
           context: base/debian
           platforms: linux/arm64, linux/amd64, linux/386
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/railwayapp/nixpacks:debian, ghcr.io/railwayapp/nixpacks:latest, ghcr.io/railwayapp/nixpacks:debian-${{ steps.date.outputs.date }}
+      -
+        name: Bump base image
+        push: ${{ github.event_name == 'push' }}
+        run: |
+          sed -i 's/nixpacks:debian-.*/nixpacks:debian-${{ steps.date.outputs.date }}";/g' src/nixpacks/images.rs
+      - 
+        name: Create Pull Request
+        push: ${{ github.event_name == 'push' }}
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: bump base to debian-${{ steps.date.outputs.date }}
+          branch: debian-${{ steps.date.outputs.date }}
+          delete-branch: true
+          title: Bump base image to debian-${{ steps.date.outputs.date }}
+
+

--- a/.github/workflows/publish_debian.yml
+++ b/.github/workflows/publish_debian.yml
@@ -52,12 +52,12 @@ jobs:
           tags: ghcr.io/railwayapp/nixpacks:debian, ghcr.io/railwayapp/nixpacks:latest, ghcr.io/railwayapp/nixpacks:debian-${{ steps.date.outputs.date }}
       -
         name: Bump base image
-        push: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           sed -i 's/nixpacks:debian-.*/nixpacks:debian-${{ steps.date.outputs.date }}";/g' src/nixpacks/images.rs
       - 
         name: Create Pull Request
-        push: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         uses: peter-evans/create-pull-request@v4
         with:
           base: main

--- a/.github/workflows/publish_debian.yml
+++ b/.github/workflows/publish_debian.yml
@@ -38,25 +38,25 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Get current date
+      
+      - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +%s)"
-      - 
-        name: Build and push
+      
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: base/debian
           platforms: linux/arm64, linux/amd64, linux/386
           push: ${{ github.event_name == 'push' }}
           tags: ghcr.io/railwayapp/nixpacks:debian, ghcr.io/railwayapp/nixpacks:latest, ghcr.io/railwayapp/nixpacks:debian-${{ steps.date.outputs.date }}
-      -
-        name: Bump base image
+      
+      - name: Bump base image
         if: ${{ github.event_name == 'push' }}
         run: |
           sed -i 's/nixpacks:debian-.*/nixpacks:debian-${{ steps.date.outputs.date }}";/g' src/nixpacks/images.rs
-      - 
-        name: Create Pull Request
+      
+      - name: Create Pull Request
         if: ${{ github.event_name == 'push' }}
         uses: peter-evans/create-pull-request@v4
         with:
@@ -66,5 +66,3 @@ jobs:
           branch: debian-${{ steps.date.outputs.date }}
           delete-branch: true
           title: Bump base image to debian-${{ steps.date.outputs.date }}
-
-

--- a/.github/workflows/publish_debian.yml
+++ b/.github/workflows/publish_debian.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           base: main
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: bump base to debian-${{ steps.date.outputs.date }}
+          commit-message: Bump base image
           branch: debian-${{ steps.date.outputs.date }}
           delete-branch: true
           title: Bump base image to `debian-${{ steps.date.outputs.date }}`

--- a/.github/workflows/publish_debian.yml
+++ b/.github/workflows/publish_debian.yml
@@ -65,4 +65,4 @@ jobs:
           commit-message: bump base to debian-${{ steps.date.outputs.date }}
           branch: debian-${{ steps.date.outputs.date }}
           delete-branch: true
-          title: Bump base image to debian-${{ steps.date.outputs.date }}
+          title: Bump base image to `debian-${{ steps.date.outputs.date }}`


### PR DESCRIPTION
This PR adds a new step in [`Publish Docker Images`](https://github.com/railwayapp/nixpacks/actions/workflows/publish_debian.yml) workflow which will update debian image to latest tag whenever a new release is published.