### PR TITLE
Configure libraries using variables

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,14 @@ fn main() -> Result<()> {
                 .global(true),
         )
         .arg(
+            Arg::new("libs")
+                .long("libs")
+                .help("Provide additional nix libraries to install in the environment")
+                .takes_value(true)
+                .multiple_values(true)
+                .global(true),
+        )
+        .arg(
             Arg::new("pin")
                 .long("pin")
                 .help("Pin the nixpkgs")
@@ -118,6 +126,15 @@ fn main() -> Result<()> {
         Some(values) => values.map(Pkg::new).collect::<Vec<_>>(),
         None => Vec::new(),
     };
+    let libs = matches
+        .value_of("libs")
+        .map(|lib_string| {
+            lib_string
+                .split(' ')
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>()
+        })
+        .unwrap_or_default();
     let pin_pkgs = matches.is_present("pin");
 
     let envs: Vec<_> = match matches.values_of("env") {
@@ -132,6 +149,7 @@ fn main() -> Result<()> {
         custom_start_cmd: start_cmd,
         custom_build_cmd: build_cmd,
         custom_pkgs: pkgs,
+        custom_libs: libs,
         pin_pkgs,
         plan_path,
     };

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -47,12 +47,11 @@ impl SetupPhase {
         self.archive = Some(archive);
     }
 
-    pub fn add_library(&mut self, lib: String) {
-        if let Some(mut libraries) = self.libraries.clone() {
-            libraries.push(lib);
-            self.libraries = Some(libraries);
+    pub fn add_library(&mut self, lib: Vec<String>) {
+        if let Some(libraries) = self.libraries.clone() {
+            self.libraries = Some([libraries, lib].concat());
         } else {
-            self.libraries = Some(vec![lib]);
+            self.libraries = Some(lib);
         }
     }
 }

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -47,7 +47,7 @@ impl SetupPhase {
         self.archive = Some(archive);
     }
 
-    pub fn add_library(&mut self, lib: Vec<String>) {
+    pub fn add_libraries(&mut self, lib: Vec<String>) {
         if let Some(libraries) = self.libraries.clone() {
             self.libraries = Some([libraries, lib].concat());
         } else {

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -22,6 +22,7 @@ pub struct GeneratePlanOptions {
     pub custom_build_cmd: Option<String>,
     pub custom_start_cmd: Option<String>,
     pub custom_pkgs: Vec<Pkg>,
+    pub custom_libs: Vec<String>,
     pub pin_pkgs: bool,
     pub plan_path: Option<String>,
 }
@@ -116,6 +117,19 @@ impl<'a> NixpacksBuildPlanGenerator<'a> {
         let mut pkgs = [self.options.custom_pkgs.clone(), env_var_pkgs].concat();
         setup_phase.add_pkgs(&mut pkgs);
 
+        let env_var_libs = environment
+            .get_config_variable("LIBS")
+            .map(|lib_string| {
+                lib_string
+                    .split(' ')
+                    .map(|s| s.to_string())
+                    .collect::<Vec<String>>()
+            })
+            .unwrap_or_default();
+
+        // Add custom user libraries
+        let libs = [self.options.custom_libs.clone(), env_var_libs].concat();
+        setup_phase.add_library(libs);
         if self.options.pin_pkgs {
             setup_phase.set_archive(NIXPKGS_ARCHIVE.to_string())
         }

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -129,7 +129,7 @@ impl<'a> NixpacksBuildPlanGenerator<'a> {
 
         // Add custom user libraries
         let libs = [self.options.custom_libs.clone(), env_var_libs].concat();
-        setup_phase.add_library(libs);
+        setup_phase.add_libraries(libs);
         if self.options.pin_pkgs {
             setup_phase.set_archive(NIXPKGS_ARCHIVE.to_string())
         }

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -38,7 +38,7 @@ impl Provider for NodeProvider {
         let packages = NodeProvider::get_nix_packages(app, env)?;
         let mut setup_phase = SetupPhase::new(packages);
         if NodeProvider::uses_canvas(app) {
-            setup_phase.add_library(vec!["libuuid".to_string(), "libGL".to_string()]);
+            setup_phase.add_libraries(vec!["libuuid".to_string(), "libGL".to_string()]);
         }
         Ok(Some(setup_phase))
     }

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -38,8 +38,7 @@ impl Provider for NodeProvider {
         let packages = NodeProvider::get_nix_packages(app, env)?;
         let mut setup_phase = SetupPhase::new(packages);
         if NodeProvider::uses_canvas(app) {
-            setup_phase.add_library("libuuid".to_string());
-            setup_phase.add_library("libGL".to_string());
+            setup_phase.add_library(vec!["libuuid".to_string(), "libGL".to_string()]);
         }
         Ok(Some(setup_phase))
     }


### PR DESCRIPTION
Libraries can now be configured via `NIXPACKS_LIBS` variable or the `--libs` argument.