### PR TITLE
check for `django` frameworks

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -156,7 +156,11 @@ enum EntryPoint {
 
 impl PythonProvider {
     fn is_django(app: &App, _env: &Environment) -> Result<bool> {
-        Ok(app.includes_file("manage.py") && app.read_file("requirements.txt")?.to_lowercase().contains("django"))
+        Ok(app.includes_file("manage.py")
+            && app
+                .read_file("requirements.txt")?
+                .to_lowercase()
+                .contains("django"))
     }
 
     fn is_using_postgres(app: &App, _env: &Environment) -> Result<bool> {

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -156,7 +156,7 @@ enum EntryPoint {
 
 impl PythonProvider {
     fn is_django(app: &App, _env: &Environment) -> Result<bool> {
-        Ok(app.includes_file("manage.py") && app.read_file("requirements.txt")?.contains("Django"))
+        Ok(app.includes_file("manage.py") && app.read_file("requirements.txt")?.to_lowercase().contains("django"))
     }
 
     fn is_using_postgres(app: &App, _env: &Environment) -> Result<bool> {


### PR DESCRIPTION
This PR fixes a bug in Nixpacks which fails to detect Django frameworks that are lower-cased.

MRE - [django-rest-framework](https://github.com/railwayapp-starters/django-rest-framework)