### PR TITLE
Specify apt packages in setup phase

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,24 +134,14 @@ fn main() -> Result<()> {
         Some(values) => values.map(Pkg::new).collect::<Vec<_>>(),
         None => Vec::new(),
     };
-    let libs = matches
-        .value_of("libs")
-        .map(|lib_string| {
-            lib_string
-                .split(' ')
-                .map(|s| s.to_string())
-                .collect::<Vec<String>>()
-        })
-        .unwrap_or_default();
-    let apt_pkgs = matches
-        .value_of("apt")
-        .map(|lib_string| {
-            lib_string
-                .split(' ')
-                .map(|s| s.to_string())
-                .collect::<Vec<String>>()
-        })
-        .unwrap_or_default();
+    let libs = match matches.values_of("libs") {
+        Some(values) => values.map(String::from).collect::<Vec<String>>(),
+        None => Vec::new(),
+    };
+    let apt_pkgs = match matches.values_of("apt") {
+        Some(values) => values.map(String::from).collect::<Vec<String>>(),
+        None => Vec::new(),
+    };
     let pin_pkgs = matches.is_present("pin");
 
     let envs: Vec<_> = match matches.values_of("env") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,14 @@ fn main() -> Result<()> {
                 .global(true),
         )
         .arg(
+            Arg::new("apt")
+                .long("apt")
+                .help("Provide additional apt packages to install in the environment")
+                .takes_value(true)
+                .multiple_values(true)
+                .global(true),
+        )
+        .arg(
             Arg::new("libs")
                 .long("libs")
                 .help("Provide additional nix libraries to install in the environment")
@@ -135,6 +143,15 @@ fn main() -> Result<()> {
                 .collect::<Vec<String>>()
         })
         .unwrap_or_default();
+    let apt_pkgs = matches
+        .value_of("apt")
+        .map(|lib_string| {
+            lib_string
+                .split(' ')
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>()
+        })
+        .unwrap_or_default();
     let pin_pkgs = matches.is_present("pin");
 
     let envs: Vec<_> = match matches.values_of("env") {
@@ -150,6 +167,7 @@ fn main() -> Result<()> {
         custom_build_cmd: build_cmd,
         custom_pkgs: pkgs,
         custom_libs: libs,
+        custom_apt_pkgs: apt_pkgs,
         pin_pkgs,
         plan_path,
     };

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -198,6 +198,7 @@ impl DockerBuilder {
         let mut apt_get_cmd = "".to_string();
         if !setup_phase.apt_pkgs.clone().unwrap_or_default().is_empty() {
             let apt_pkgs = setup_phase.apt_pkgs.unwrap_or_default().join(" ");
+            println!("WARNING: Using apt for installing packages will break build reproducibility.");
             apt_get_cmd = format!("RUN apt-get update && apt-get install -y {}", apt_pkgs);
         }
 

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -195,6 +195,9 @@ impl DockerBuilder {
         }
         let setup_copy_cmd = format!("COPY {} {}", setup_files.join(" "), app_dir);
 
+        let apt_pkgs = setup_phase.apt_pkgs.unwrap_or_default().join(" ");
+        let apt_get_cmd = format!("RUN apt-get update && apt-get install -y {}", apt_pkgs);
+
         // -- Static Assets
         let assets_copy_cmd = if !static_assets.is_empty() {
             static_assets
@@ -285,6 +288,7 @@ impl DockerBuilder {
           # Setup
           {setup_copy_cmd}
           RUN nix-env -if environment.nix
+          {apt_get_cmd}
           {assets_copy_cmd}
 
           # Load environment variables

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -198,7 +198,9 @@ impl DockerBuilder {
         let mut apt_get_cmd = "".to_string();
         if !setup_phase.apt_pkgs.clone().unwrap_or_default().is_empty() {
             let apt_pkgs = setup_phase.apt_pkgs.unwrap_or_default().join(" ");
-            println!("WARNING: Using apt for installing packages will break build reproducibility.");
+            println!(
+                "WARNING: Using apt for installing packages will break build reproducibility."
+            );
             apt_get_cmd = format!("RUN apt-get update && apt-get install -y {}", apt_pkgs);
         }
 

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -195,8 +195,11 @@ impl DockerBuilder {
         }
         let setup_copy_cmd = format!("COPY {} {}", setup_files.join(" "), app_dir);
 
-        let apt_pkgs = setup_phase.apt_pkgs.unwrap_or_default().join(" ");
-        let apt_get_cmd = format!("RUN apt-get update && apt-get install -y {}", apt_pkgs);
+        let mut apt_get_cmd = "".to_string();
+        if !setup_phase.apt_pkgs.clone().unwrap_or_default().is_empty() {
+            let apt_pkgs = setup_phase.apt_pkgs.unwrap_or_default().join(" ");
+            apt_get_cmd = format!("RUN apt-get update && apt-get install -y {}", apt_pkgs);
+        }
 
         // -- Static Assets
         let assets_copy_cmd = if !static_assets.is_empty() {

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -11,6 +11,7 @@ pub struct SetupPhase {
     pub pkgs: Vec<Pkg>,
     pub archive: Option<String>,
     pub libraries: Option<Vec<String>>,
+    pub apt_pkgs: Option<Vec<String>>,
 
     #[serde(rename = "onlyIncludeFiles")]
     pub only_include_files: Option<Vec<String>>,
@@ -24,6 +25,7 @@ impl SetupPhase {
         Self {
             pkgs,
             libraries: None,
+            apt_pkgs: None,
             archive: None,
             only_include_files: None,
             base_image: DEFAULT_BASE_IMAGE.to_string(),
@@ -54,6 +56,15 @@ impl SetupPhase {
             self.libraries = Some(lib);
         }
     }
+
+    pub fn add_apt_pkgs(&mut self, apt_pkgs: Vec<String>) {
+        println!("{:?}",apt_pkgs);
+        if let Some(apt_packages) = self.apt_pkgs.clone() {
+            self.apt_pkgs = Some([apt_packages, apt_pkgs].concat());
+        } else {
+            self.apt_pkgs = Some(apt_pkgs);
+        }
+    }
 }
 
 impl Default for SetupPhase {
@@ -61,6 +72,7 @@ impl Default for SetupPhase {
         Self {
             pkgs: Default::default(),
             libraries: Default::default(),
+            apt_pkgs: Default::default(),
             archive: Default::default(),
             only_include_files: Default::default(),
             base_image: DEFAULT_BASE_IMAGE.to_string(),

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -58,7 +58,6 @@ impl SetupPhase {
     }
 
     pub fn add_apt_pkgs(&mut self, apt_pkgs: Vec<String>) {
-        println!("{:?}",apt_pkgs);
         if let Some(apt_packages) = self.apt_pkgs.clone() {
             self.apt_pkgs = Some([apt_packages, apt_pkgs].concat());
         } else {

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -142,7 +142,7 @@ impl<'a> NixpacksBuildPlanGenerator<'a> {
             })
             .unwrap_or_default();
 
-        // Add custom user libraries
+        // Add custom apt packages
         let apt_pkgs = [self.options.custom_apt_pkgs.clone(), env_var_apt_pkgs].concat();
         setup_phase.add_apt_pkgs(apt_pkgs);
 

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -23,6 +23,7 @@ pub struct GeneratePlanOptions {
     pub custom_start_cmd: Option<String>,
     pub custom_pkgs: Vec<Pkg>,
     pub custom_libs: Vec<String>,
+    pub custom_apt_pkgs: Vec<String>,
     pub pin_pkgs: bool,
     pub plan_path: Option<String>,
 }
@@ -130,6 +131,21 @@ impl<'a> NixpacksBuildPlanGenerator<'a> {
         // Add custom user libraries
         let libs = [self.options.custom_libs.clone(), env_var_libs].concat();
         setup_phase.add_libraries(libs);
+
+        let env_var_apt_pkgs = environment
+            .get_config_variable("APT_PKGS")
+            .map(|apt_pkgs_string| {
+                apt_pkgs_string
+                    .split(' ')
+                    .map(|s| s.to_string())
+                    .collect::<Vec<String>>()
+            })
+            .unwrap_or_default();
+
+        // Add custom user libraries
+        let apt_pkgs = [self.options.custom_apt_pkgs.clone(), env_var_apt_pkgs].concat();
+        setup_phase.add_apt_pkgs(apt_pkgs);
+
         if self.options.pin_pkgs {
             setup_phase.set_archive(NIXPKGS_ARCHIVE.to_string())
         }


### PR DESCRIPTION
This PR adds an API to the setup phase that can be used to install apt packages. 
- Providers can use `add_apt_pkgs` method for specifying packages.
- Users can use `--apt` argument or `NIXPACKS_APT_PKGS` variable.