### PR TITLE
Add build environment variables in base image

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -22,6 +22,9 @@ ENV \
   NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
   NIX_PATH=/nix/var/nix/profiles/per-user/root/channels \
   NIXPKGS_ALLOW_BROKEN=1 \
-  LD_LIBRARY_PATH=/usr/lib
+  LD_LIBRARY_PATH=/usr/lib \
+  CPATH=~/.nix-profile/include:$CPATH \
+  LIBRARY_PATH=~/.nix-profile/lib:$LIBRARY_PATH \
+  QTDIR=~/.nix-profile:$QTDIR
 
 RUN nix-channel --update


### PR DESCRIPTION
ref: https://nixos.wiki/wiki/Nix_vs._Linux_Standard_Base#Build_and_install_from_Source