### PR TITLE
remove `--production=false` from yarn

### DIFF
--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -168,7 +168,7 @@ impl NodeProvider {
             if app.includes_file(".yarnrc.yml") {
                 install_cmd = "yarn set version berry && yarn install --immutable --check-cache";
             } else {
-                install_cmd = "yarn install --frozen-lockfile --production=false";
+                install_cmd = "yarn install --frozen-lockfile";
             }
         } else if app.includes_file("package-lock.json") {
             install_cmd = "npm ci";


### PR DESCRIPTION
Revert #102 
`--production=false` isn't needed as yarn auto-install devDependencies when `NPM_CONFIG_PRODUCTION` is set to false. ([reference](https://github.com/yarnpkg/yarn/pull/2057))
