### PR TITLE
BuildKit override flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,6 @@ fn main() -> Result<()> {
                 .arg(
                     Arg::new("buildkit")
                         .long("buildkit")
-                        .short('k')
                         .help("Forces docker to use buildkit")
                         .takes_value(false),
                 ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,13 @@ fn main() -> Result<()> {
                         .help("Additional labels to add to the output image")
                         .takes_value(true)
                         .multiple_values(true),
+                )
+                .arg(
+                    Arg::new("buildkit")
+                        .long("buildkit")
+                        .short('k')
+                        .help("Forces docker to use buildkit")
+                        .takes_value(false),
                 ),
         )
         .arg(
@@ -185,11 +192,14 @@ fn main() -> Result<()> {
                 .map(|values| values.map(|s| s.to_string()).collect::<Vec<_>>())
                 .unwrap_or_default();
 
+            let force_buildkit = matches.is_present("buildkit");
+
             let build_options = &DockerBuilderOptions {
                 name,
                 tags,
                 labels,
                 out_dir,
+                force_buildkit,
                 quiet: false,
             };
 

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -1,4 +1,5 @@
 use std::{
+    char::CharTryFromError,
     fs::{self, File},
     io::Write,
     path::{Path, PathBuf},
@@ -19,6 +20,7 @@ pub struct DockerBuilderOptions {
     pub tags: Vec<String>,
     pub labels: Vec<String>,
     pub quiet: bool,
+    pub force_buildkit: bool,
 }
 
 pub struct DockerBuilder {
@@ -84,6 +86,10 @@ impl DockerBuilder {
 
     fn get_docker_build_cmd(&self, plan: &BuildPlan, name: &str, dest: &str) -> Command {
         let mut docker_build_cmd = Command::new("docker");
+
+        if self.options.force_buildkit {
+            docker_build_cmd.env("DOCKER_BUILDKIT", "1");
+        }
         docker_build_cmd.arg("build").arg(dest).arg("-t").arg(name);
 
         if self.options.quiet {

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -1,5 +1,4 @@
 use std::{
-    char::CharTryFromError,
     fs::{self, File},
     io::Write,
     path::{Path, PathBuf},


### PR DESCRIPTION
Flag to force buildkit

Aim is to roll out optional buildkit support on Railway using this, then cut over fully once tested across a period