### PR TITLE
Correctly support Python patch versions

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -206,7 +206,7 @@ impl PythonProvider {
 
         let python_regex = Regex::new(r"^(\d)\.(\d+)(?:\.\d+)?$")?;
 
-        let matches = python_regex.captures(custom_version)
+        let matches = python_regex.captures(custom_version);
 
         match matches {
             None => return Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
@@ -216,9 +216,9 @@ impl PythonProvider {
                     match m.get(2) {
                         Some(s) => s.as_str(),
                         None => "0",
-                    }, 
+                    },
                 );
-        
+
                 match python_version {
                     ("3", "11") => Ok(Pkg::new("python311")),
                     ("3", "10") => Ok(Pkg::new("python310Full")),
@@ -230,7 +230,7 @@ impl PythonProvider {
                     ("2", "0") => Ok(Pkg::new("python27Full")),
                     _ => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
                 }
-            },
+            }
         }
     }
 

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -214,7 +214,7 @@ impl PythonProvider {
         fn as_default(v: Option<Match>) -> &str {
             match v {
                 Some(m) => m.as_str(),
-                None => "0",
+                None => "_",
             }
         }
 
@@ -231,9 +231,9 @@ impl PythonProvider {
             ("3", "9") => Ok(Pkg::new("python39")),
             ("3", "8") => Ok(Pkg::new("python38")),
             ("3", "7") => Ok(Pkg::new("python37")),
-            ("3", "0") => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
+            ("3", "_") => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
             ("2", "7") => Ok(Pkg::new("python27Full")),
-            ("2", "0") => Ok(Pkg::new("python27Full")),
+            ("2", "_") => Ok(Pkg::new("python27Full")),
             _ => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
         }
     }

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -196,35 +196,44 @@ impl PythonProvider {
     }
 
     fn get_nix_python_package(app: &App, env: &Environment) -> Result<Pkg> {
-        println!("GETING PYTHON");
+        // Fetch version from configs
         let mut custom_version = env
             .get_config_variable("PYTHON_VERSION")
             .map(|s| s.to_string());
 
+        // If not from configs, get it from the .python-version file
         if custom_version.is_none() && app.includes_file(".python-version") {
             custom_version = Some(app.read_file(".python-version")?);
         }
 
-        let python_regex = Regex::new(r"^(\d)\.(\d+)(?:\.\d+)?$")?;
-
+        // If it's still none, return default
+        if custom_version.is_none() {
+            return Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME));
+        }
         let custom_version = custom_version.unwrap();
 
+        // Regex for reading Python versions (e.g. 3.8.0 or 3.8 or 3)
+        let python_regex = Regex::new(r"^(\d)\.(\d+)(?:\.\d+)?$")?;
+
+        // Capture matches
         let matches = python_regex.captures(custom_version.as_str().trim());
 
+        // If no matches, just use default
+        if matches.is_none() {
+            return Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME));
+        }
+        let matches = matches.unwrap();
+
+        // Fetch python versions into tuples with defaults
         fn as_default(v: Option<Match>) -> &str {
             match v {
                 Some(m) => m.as_str(),
                 None => "_",
             }
         }
-
-        if matches.is_none() {
-            return Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME));
-        }
-        let matches = matches.unwrap();
-
         let python_version = (as_default(matches.get(1)), as_default(matches.get(2)));
 
+        // Match major and minor versions
         match python_version {
             ("3", "11") => Ok(Pkg::new("python311")),
             ("3", "10") => Ok(Pkg::new("python310Full")),

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context, Ok, Result};
 
 use std::result::Result::Ok as OkResult;
 
-use regex::Regex;
+use regex::{Match, Regex};
 use serde::Deserialize;
 
 use crate::{
@@ -208,16 +208,17 @@ impl PythonProvider {
 
         let matches = python_regex.captures(custom_version);
 
+        fn as_default<'t>(v: Option<Match<'t>>) -> &str {
+            match v {
+                Some(m) => m.as_str(),
+                None => "0",
+            }
+        }
+
         match matches {
             None => return Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
             Some(m) => {
-                let python_version = (
-                    m.get(1).unwrap().as_str(),
-                    match m.get(2) {
-                        Some(s) => s.as_str(),
-                        None => "0",
-                    },
-                );
+                let python_version = (as_default(m.get(1)), as_default(m.get(1)));
 
                 match python_version {
                     ("3", "11") => Ok(Pkg::new("python311")),

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -196,6 +196,7 @@ impl PythonProvider {
     }
 
     fn get_nix_python_package(app: &App, env: &Environment) -> Result<Pkg> {
+        println!("GETING PYTHON");
         let mut custom_version = env
             .get_config_variable("PYTHON_VERSION")
             .map(|s| s.to_string());
@@ -208,7 +209,7 @@ impl PythonProvider {
 
         let custom_version = custom_version.unwrap();
 
-        let matches = python_regex.captures(&custom_version);
+        let matches = python_regex.captures(custom_version.as_str().trim());
 
         fn as_default(v: Option<Match>) -> &str {
             match v {
@@ -218,12 +219,17 @@ impl PythonProvider {
         }
 
         if matches.is_none() {
+            println!("NO MATCHES");
             return Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME));
         }
 
+        println!("GOT MATCHES");
+
         let matches = matches.unwrap();
 
-        let python_version = (as_default(matches.get(1)), as_default(matches.get(1)));
+        let python_version = (as_default(matches.get(1)), as_default(matches.get(2)));
+
+        println!("Using python version: {:?}", python_version);
 
         match python_version {
             ("3", "11") => Ok(Pkg::new("python311")),

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -215,23 +215,24 @@ impl PythonProvider {
             }
         }
 
-        match matches {
-            None => return Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
-            Some(m) => {
-                let python_version = (as_default(m.get(1)), as_default(m.get(1)));
+        if matches.is_none() {
+            return Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME));
+        }
 
-                match python_version {
-                    ("3", "11") => Ok(Pkg::new("python311")),
-                    ("3", "10") => Ok(Pkg::new("python310Full")),
-                    ("3", "9") => Ok(Pkg::new("python39")),
-                    ("3", "8") => Ok(Pkg::new("python38")),
-                    ("3", "7") => Ok(Pkg::new("python37")),
-                    ("3", "0") => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
-                    ("2", "7") => Ok(Pkg::new("python27Full")),
-                    ("2", "0") => Ok(Pkg::new("python27Full")),
-                    _ => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
-                }
-            }
+        let matches = matches.unwrap();
+
+        let python_version = (as_default(matches.get(1)), as_default(matches.get(1)));
+
+        match python_version {
+            ("3", "11") => Ok(Pkg::new("python311")),
+            ("3", "10") => Ok(Pkg::new("python310Full")),
+            ("3", "9") => Ok(Pkg::new("python39")),
+            ("3", "8") => Ok(Pkg::new("python38")),
+            ("3", "7") => Ok(Pkg::new("python37")),
+            ("3", "0") => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
+            ("2", "7") => Ok(Pkg::new("python27Full")),
+            ("2", "0") => Ok(Pkg::new("python27Full")),
+            _ => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
         }
     }
 

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -206,9 +206,11 @@ impl PythonProvider {
 
         let python_regex = Regex::new(r"^(\d)\.(\d+)(?:\.\d+)?$")?;
 
-        let matches = python_regex.captures(custom_version);
+        let custom_version = custom_version.unwrap();
 
-        fn as_default<'t>(v: Option<Match<'t>>) -> &str {
+        let matches = python_regex.captures(&custom_version);
+
+        fn as_default(v: Option<Match>) -> &str {
             match v {
                 Some(m) => m.as_str(),
                 None => "0",

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -204,18 +204,33 @@ impl PythonProvider {
             custom_version = Some(app.read_file(".python-version")?);
         }
 
-        match custom_version.map(|s| s.trim().to_string()) {
-            Some(custom_version) => match custom_version.as_str() {
-                "3.11" => Ok(Pkg::new("python311")),
-                "3.10" => Ok(Pkg::new("python310Full")),
-                "3.9" => Ok(Pkg::new("python39")),
-                "3.8" => Ok(Pkg::new("python38")),
-                "3.7" => Ok(Pkg::new("python37")),
-                "2.7" => Ok(Pkg::new("python27Full")),
-                "2" => Ok(Pkg::new("python27Full")),
-                _ => Ok(Pkg::new("python38")),
+        let python_regex = Regex::new(r"^(\d)\.(\d+)(?:\.\d+)?$")?;
+
+        let matches = python_regex.captures(custom_version)
+
+        match matches {
+            None => return Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
+            Some(m) => {
+                let python_version = (
+                    m.get(1).unwrap().as_str(),
+                    match m.get(2) {
+                        Some(s) => s.as_str(),
+                        None => "0",
+                    }, 
+                );
+        
+                match python_version {
+                    ("3", "11") => Ok(Pkg::new("python311")),
+                    ("3", "10") => Ok(Pkg::new("python310Full")),
+                    ("3", "9") => Ok(Pkg::new("python39")),
+                    ("3", "8") => Ok(Pkg::new("python38")),
+                    ("3", "7") => Ok(Pkg::new("python37")),
+                    ("3", "0") => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
+                    ("2", "7") => Ok(Pkg::new("python27Full")),
+                    ("2", "0") => Ok(Pkg::new("python27Full")),
+                    _ => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
+                }
             },
-            None => Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME)),
         }
     }
 

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -219,17 +219,11 @@ impl PythonProvider {
         }
 
         if matches.is_none() {
-            println!("NO MATCHES");
             return Ok(Pkg::new(DEFAULT_PYTHON_PKG_NAME));
         }
-
-        println!("GOT MATCHES");
-
         let matches = matches.unwrap();
 
         let python_version = (as_default(matches.get(1)), as_default(matches.get(2)));
-
-        println!("Using python version: {:?}", python_version);
 
         match python_version {
             ("3", "11") => Ok(Pkg::new("python311")),


### PR DESCRIPTION
Previously, patch versions would land in the default python version, NOT in the correct version

e.g 3.10.4 would go to 3.8 (default) instead of 3.10

This PR fixes that
