### PR TITLE
Support `npm run build` for Laravel

### DIFF
--- a/src/providers/php.rs
+++ b/src/providers/php.rs
@@ -66,6 +66,10 @@ impl Provider for PhpProvider {
             return Ok(Some(BuildPhase::new(
                 NodeProvider::get_package_manager(app) + " run prod",
             )));
+        } else if let Ok(true) = NodeProvider::has_script(app, "build") {
+            return Ok(Some(BuildPhase::new(
+                NodeProvider::get_package_manager(app) + " run build",
+            )));
         }
         Ok(None)
     }


### PR DESCRIPTION
Laravel Vite uses a `build` script instead of `prod`.