### PR TITLE
Fix missing command in django application

### DIFF
--- a/docs/pages/docs/providers/python.md
+++ b/docs/pages/docs/providers/python.md
@@ -47,7 +47,7 @@ poetry install --no-dev --no-interactive --no-ansi
 if Django Application
 
 ```
-python manage.py migrate && gunicorn {app_name}
+python manage.py migrate && gunicorn {app_name}.wsgi
 ```
 
 if `pyproject.toml`


### PR DESCRIPTION
- Fixed a command by adding the `wsgi` module in the gunicorn command