### PR TITLE
Dont output docker command result

### DIFF
--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -87,7 +87,7 @@ impl DockerBuilder {
         let mut docker_build_cmd = Command::new("docker");
 
         if docker_build_cmd.output().is_err() {
-            bail!("Please install Docker first https://docs.docker.com/engine/install/")
+            bail!("Please install Docker to build the app https://docs.docker.com/engine/install/")
         }
 
         if self.options.force_buildkit {

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -86,7 +86,7 @@ impl DockerBuilder {
     fn get_docker_build_cmd(&self, plan: &BuildPlan, name: &str, dest: &str) -> Result<Command> {
         let mut docker_build_cmd = Command::new("docker");
 
-        if docker_build_cmd.status().is_err() {
+        if docker_build_cmd.output().is_err() {
             bail!("Please install Docker first https://docs.docker.com/engine/install/")
         }
 


### PR DESCRIPTION
Capture the `docker` command result so it isn't printed to console
