### PR TITLE
BuildKit Caching

### DIFF
--- a/examples/staticfile/Staticfile
+++ b/examples/staticfile/Staticfile
@@ -1,1 +1,1 @@
-root: /app/site
+root: site

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,8 @@ pub fn get_providers() -> Vec<&'static dyn Provider> {
         &NodeProvider {},
         &PythonProvider {},
         &RustProvider {},
-        &StaticfileProvider {},
         &SwiftProvider {},
+        &StaticfileProvider {},
         &ZigProvider {},
     ]
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use anyhow::Result;
 use clap::{arg, Arg, Command};
 use nixpacks::{
@@ -54,16 +56,17 @@ fn main() -> Result<()> {
                         .multiple_values(true),
                 )
                 .arg(
-                    Arg::new("buildkit")
-                        .long("buildkit")
-                        .help("Forces docker to use buildkit")
-                        .takes_value(false),
-                )
-                .arg(
                     Arg::new("cache-key")
                         .long("cache-key")
-                        .help("Unique identifier to key cache by")
+                        .help(
+                            "Unique identifier to key cache by. Defaults to the current directory",
+                        )
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::new("no-cache")
+                        .long("no-cache")
+                        .help("Disable building with the cache"),
                 ),
         )
         .arg(
@@ -186,7 +189,15 @@ fn main() -> Result<()> {
             let path = matches.value_of("PATH").expect("required");
             let name = matches.value_of("name").map(|n| n.to_string());
             let out_dir = matches.value_of("out").map(|n| n.to_string());
-            let cache_key = matches.value_of("cache-key").map(|n| n.to_string());
+            let mut cache_key = matches.value_of("cache-key").map(|n| n.to_string());
+            let no_cache = matches.is_present("no-cache");
+
+            // Default to `path` as the cache-key if not disabled
+            if !no_cache && cache_key.is_none() {
+                cache_key = Some(path.to_owned());
+            }
+
+            println!("Cache key: {:?}", cache_key);
 
             let tags = matches
                 .values_of("tag")
@@ -198,14 +209,11 @@ fn main() -> Result<()> {
                 .map(|values| values.map(|s| s.to_string()).collect::<Vec<_>>())
                 .unwrap_or_default();
 
-            let force_buildkit = matches.is_present("buildkit");
-
             let build_options = &DockerBuilderOptions {
                 name,
                 tags,
                 labels,
                 out_dir,
-                force_buildkit,
                 quiet: false,
                 cache_key,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,9 +192,14 @@ fn main() -> Result<()> {
             let mut cache_key = matches.value_of("cache-key").map(|n| n.to_string());
             let no_cache = matches.is_present("no-cache");
 
-            // Default to `path` as the cache-key if not disabled
+            // Default to absolute `path` of the source that is being built as the cache-key if not disabled
             if !no_cache && cache_key.is_none() {
-                cache_key = Some(path.to_owned());
+                let current_dir = env::current_dir()?;
+                let source = current_dir.join(path).canonicalize();
+                match source {
+                    Ok(source) => cache_key = Some(source.to_string_lossy().to_string()),
+                    _ => {}
+                }
             }
 
             println!("Cache key: {:?}", cache_key);

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,12 @@ fn main() -> Result<()> {
                         .long("buildkit")
                         .help("Forces docker to use buildkit")
                         .takes_value(false),
+                )
+                .arg(
+                    Arg::new("cache-key")
+                        .long("cache-key")
+                        .help("Unique identifier to key cache by")
+                        .takes_value(true),
                 ),
         )
         .arg(
@@ -180,6 +186,7 @@ fn main() -> Result<()> {
             let path = matches.value_of("PATH").expect("required");
             let name = matches.value_of("name").map(|n| n.to_string());
             let out_dir = matches.value_of("out").map(|n| n.to_string());
+            let cache_key = matches.value_of("cache-key").map(|n| n.to_string());
 
             let tags = matches
                 .values_of("tag")
@@ -200,6 +207,7 @@ fn main() -> Result<()> {
                 out_dir,
                 force_buildkit,
                 quiet: false,
+                cache_key,
             };
 
             create_docker_image(path, envs, plan_options, build_options)?;

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -42,6 +42,30 @@ impl App {
     /// # Errors
     /// Creating the Glob fails
     pub fn find_files(&self, pattern: &str) -> Result<Vec<PathBuf>> {
+        let directories = self
+            .find_glob(pattern)?
+            .into_iter()
+            .filter(|path| path.is_file())
+            .collect();
+
+        Ok(directories)
+    }
+
+    /// Returns a list of paths matching a glob pattern
+    ///
+    /// # Errors
+    /// Creating the Glob fails
+    pub fn find_directories(&self, pattern: &str) -> Result<Vec<PathBuf>> {
+        let directories = self
+            .find_glob(pattern)?
+            .into_iter()
+            .filter(|path| path.is_dir())
+            .collect();
+
+        Ok(directories)
+    }
+
+    fn find_glob(&self, pattern: &str) -> Result<Vec<PathBuf>> {
         let full_pattern = self.source.join(pattern);
 
         let pattern_str = match full_pattern.to_str() {
@@ -57,7 +81,7 @@ impl App {
             .into_iter()
             .filter_map(|result| result.ok()) // remove bad ones
             .map(|dir| dir.into_path()) // convert to paths
-            .filter(|path| glob.is_match(path) && path.is_file()) // find matches
+            .filter(|path| glob.is_match(path)) // find matches
             .collect();
 
         Ok(relative_paths)

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -155,6 +155,7 @@ impl App {
         Ok(yaml_file)
     }
 
+    /// Convert an absolute path to a path relative to the app source directory
     pub fn strip_source_path(&self, abs_path: &Path) -> Result<PathBuf> {
         let source_str = match self.source.to_str() {
             Some(s) => s,

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -231,17 +231,8 @@ impl DockerBuilder {
         };
 
         // -- Install
-        let install_cache_mount = match (
-            self.options.cache_key.clone(),
-            install_phase.cache_directories,
-        ) {
-            (Some(cache_key), Some(cache_directories)) => cache_directories
-                .iter()
-                .map(|dir| format!("--mount=type=cache,id={cache_key}-{dir},target={dir}"))
-                .collect::<Vec<String>>()
-                .join(" "),
-            _ => "".to_string(),
-        };
+        let install_cache_mount =
+            get_cache_mount(&self.options.cache_key, &&install_phase.cache_directories);
 
         let install_cmd = install_phase
             .cmds
@@ -272,17 +263,8 @@ impl DockerBuilder {
 
         // TODO: Ensure BuildKit is enabled for Nixpacks
 
-        let build_cache_mount = match (
-            self.options.cache_key.clone(),
-            build_phase.cache_directories,
-        ) {
-            (Some(cache_key), Some(cache_directories)) => cache_directories
-                .iter()
-                .map(|dir| format!("--mount=type=cache,id={cache_key}-{dir},target={dir}"))
-                .collect::<Vec<String>>()
-                .join(" "),
-            _ => "".to_string(),
-        };
+        let build_cache_mount =
+            get_cache_mount(&self.options.cache_key, &&install_phase.cache_directories);
 
         let build_cmd = build_phase
             .cmds
@@ -368,6 +350,17 @@ impl DockerBuilder {
         build_copy_cmd=get_copy_command(&build_files, app_dir)};
 
         dockerfile
+    }
+}
+
+fn get_cache_mount(cache_key: &Option<String>, cache_directories: &Option<Vec<String>>) -> String {
+    match (cache_key, cache_directories) {
+        (Some(cache_key), Some(cache_directories)) => cache_directories
+            .iter()
+            .map(|dir| format!("--mount=type=cache,id={cache_key}-{dir},target={dir}"))
+            .collect::<Vec<String>>()
+            .join(" "),
+        _ => "".to_string(),
     }
 }
 

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -6,7 +6,9 @@ use std::{
 };
 
 use super::Builder;
-use crate::nixpacks::{app, files, logger::Logger, nix, plan::BuildPlan, NIX_PACKS_VERSION};
+use crate::nixpacks::{
+    app, cache::sanitize_cache_key, files, logger::Logger, nix, plan::BuildPlan, NIX_PACKS_VERSION,
+};
 use anyhow::{bail, Context, Ok, Result};
 use indoc::formatdoc;
 use tempdir::TempDir;
@@ -19,7 +21,6 @@ pub struct DockerBuilderOptions {
     pub tags: Vec<String>,
     pub labels: Vec<String>,
     pub quiet: bool,
-    pub force_buildkit: bool,
     pub cache_key: Option<String>,
 }
 
@@ -91,9 +92,9 @@ impl DockerBuilder {
             bail!("Please install Docker to build the app https://docs.docker.com/engine/install/")
         }
 
-        if self.options.cache_key.is_some() && self.options.force_buildkit {
-            docker_build_cmd.env("DOCKER_BUILDKIT", "1");
-        }
+        // Enable BuildKit for all builds
+        docker_build_cmd.env("DOCKER_BUILDKIT", "1");
+
         docker_build_cmd.arg("build").arg(dest).arg("-t").arg(name);
 
         if self.options.quiet {
@@ -351,7 +352,9 @@ impl DockerBuilder {
 }
 
 fn get_cache_mount(cache_key: &Option<String>, cache_directories: &Option<Vec<String>>) -> String {
-    match (cache_key, cache_directories) {
+    let sanitized_cache_key = cache_key.clone().map(|key| sanitize_cache_key(key));
+
+    match (sanitized_cache_key, cache_directories) {
         (Some(cache_key), Some(cache_directories)) => cache_directories
             .iter()
             .map(|dir| format!("--mount=type=cache,id={cache_key}-{dir},target={dir}"))
@@ -383,5 +386,32 @@ fn get_copy_from_command(from: &str, files: &[String], app_dir: &str) -> String 
                 .join(" "),
             app_dir
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_cache_mount() {
+        let cache_key = Some("cache_key".to_string());
+        let cache_directories = Some(vec!["dir1".to_string(), "dir2".to_string()]);
+
+        let expected = "--mount=type=cache,id=cache_key-dir1,target=dir1 --mount=type=cache,id=cache_key-dir2,target=dir2";
+        let actual = get_cache_mount(&cache_key, &cache_directories);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_get_cache_mount_invalid_cache_key() {
+        let cache_key = Some("my cache key".to_string());
+        let cache_directories = Some(vec!["dir1".to_string(), "dir2".to_string()]);
+
+        let expected = "--mount=type=cache,id=my-cache-key-dir1,target=dir1 --mount=type=cache,id=my-cache-key-dir2,target=dir2";
+        let actual = get_cache_mount(&cache_key, &cache_directories);
+
+        assert_eq!(expected, actual);
     }
 }

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -237,7 +237,7 @@ impl DockerBuilder {
         ) {
             (Some(cache_key), Some(cache_directories)) => cache_directories
                 .iter()
-                .map(|dir| format!("--mount=type=cache,id={cache_key},target={dir}"))
+                .map(|dir| format!("--mount=type=cache,id={cache_key}-{dir},target={dir}"))
                 .collect::<Vec<String>>()
                 .join(" "),
             _ => "".to_string(),
@@ -269,13 +269,16 @@ impl DockerBuilder {
             .unwrap_or_else(|| vec![".".to_string()]);
 
         // -- Build
+
+        // TODO: Ensure BuildKit is enabled for Nixpacks
+
         let build_cache_mount = match (
             self.options.cache_key.clone(),
             build_phase.cache_directories,
         ) {
             (Some(cache_key), Some(cache_directories)) => cache_directories
                 .iter()
-                .map(|dir| format!("--mount=type=cache,id={cache_key},target={dir}"))
+                .map(|dir| format!("--mount=type=cache,id={cache_key}-{dir},target={dir}"))
                 .collect::<Vec<String>>()
                 .join(" "),
             _ => "".to_string(),

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -232,7 +232,7 @@ impl DockerBuilder {
 
         // -- Install
         let install_cache_mount =
-            get_cache_mount(&self.options.cache_key, &&install_phase.cache_directories);
+            get_cache_mount(&self.options.cache_key, &install_phase.cache_directories);
 
         let install_cmd = install_phase
             .cmds
@@ -261,7 +261,7 @@ impl DockerBuilder {
 
         // -- Build
         let build_cache_mount =
-            get_cache_mount(&self.options.cache_key, &&install_phase.cache_directories);
+            get_cache_mount(&self.options.cache_key, &build_phase.cache_directories);
 
         let build_cmd = build_phase
             .cmds

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -91,7 +91,7 @@ impl DockerBuilder {
             bail!("Please install Docker to build the app https://docs.docker.com/engine/install/")
         }
 
-        if self.options.force_buildkit {
+        if self.options.cache_key.is_some() && self.options.force_buildkit {
             docker_build_cmd.env("DOCKER_BUILDKIT", "1");
         }
         docker_build_cmd.arg("build").arg(dest).arg("-t").arg(name);
@@ -260,9 +260,6 @@ impl DockerBuilder {
             .unwrap_or_else(|| vec![".".to_string()]);
 
         // -- Build
-
-        // TODO: Ensure BuildKit is enabled for Nixpacks
-
         let build_cache_mount =
             get_cache_mount(&self.options.cache_key, &&install_phase.cache_directories);
 

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -231,7 +231,7 @@ impl DockerBuilder {
         };
 
         // -- Install
-        let cache_mount = match (
+        let install_cache_mount = match (
             self.options.cache_key.clone(),
             install_phase.cache_directories,
         ) {
@@ -247,7 +247,7 @@ impl DockerBuilder {
             .cmds
             .unwrap_or_default()
             .iter()
-            .map(|c| format!("RUN {} {}", cache_mount, c))
+            .map(|c| format!("RUN {} {}", install_cache_mount, c))
             .collect::<Vec<String>>()
             .join("\n");
 
@@ -269,11 +269,23 @@ impl DockerBuilder {
             .unwrap_or_else(|| vec![".".to_string()]);
 
         // -- Build
+        let build_cache_mount = match (
+            self.options.cache_key.clone(),
+            build_phase.cache_directories,
+        ) {
+            (Some(cache_key), Some(cache_directories)) => cache_directories
+                .iter()
+                .map(|dir| format!("--mount=type=cache,id={cache_key},target={dir}"))
+                .collect::<Vec<String>>()
+                .join(" "),
+            _ => "".to_string(),
+        };
+
         let build_cmd = build_phase
             .cmds
             .unwrap_or_default()
             .iter()
-            .map(|c| format!("RUN {}", c))
+            .map(|c| format!("RUN {} {}", build_cache_mount, c))
             .collect::<Vec<String>>()
             .join("\n");
 

--- a/src/nixpacks/cache.rs
+++ b/src/nixpacks/cache.rs
@@ -1,5 +1,5 @@
 pub fn sanitize_cache_key(cache_key: String) -> String {
-    cache_key.replace("/", "-").replace(" ", "-")
+    cache_key.replace(" ", "-")
 }
 
 #[cfg(test)]
@@ -12,10 +12,6 @@ mod tests {
         assert_eq!(
             sanitize_cache_key("s p a c e s".to_string()),
             "s-p-a-c-e-s".to_string()
-        );
-        assert_eq!(
-            sanitize_cache_key("s/l/a/s/h/e/s".to_string()),
-            "s-l-a-s-h-e-s".to_string()
         );
     }
 }

--- a/src/nixpacks/cache.rs
+++ b/src/nixpacks/cache.rs
@@ -1,0 +1,21 @@
+pub fn sanitize_cache_key(cache_key: String) -> String {
+    cache_key.replace("/", "-").replace(" ", "-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitizing_cache_key() {
+        assert_eq!(sanitize_cache_key("key".to_string()), "key".to_string());
+        assert_eq!(
+            sanitize_cache_key("s p a c e s".to_string()),
+            "s-p-a-c-e-s".to_string()
+        );
+        assert_eq!(
+            sanitize_cache_key("s/l/a/s/h/e/s".to_string()),
+            "s-l-a-s-h-e-s".to_string()
+        );
+    }
+}

--- a/src/nixpacks/mod.rs
+++ b/src/nixpacks/mod.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod builder;
+mod cache;
 pub mod environment;
 mod files;
 pub mod images;

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -159,6 +159,9 @@ pub struct BuildPhase {
 
     #[serde(rename = "onlyIncludeFiles")]
     pub only_include_files: Option<Vec<String>>,
+
+    #[serde(rename = "cacheDirectories")]
+    pub cache_directories: Option<Vec<String>>,
 }
 
 impl BuildPhase {
@@ -166,6 +169,7 @@ impl BuildPhase {
         Self {
             cmds: Some(vec![cmd]),
             only_include_files: None,
+            cache_directories: None,
         }
     }
 
@@ -175,6 +179,15 @@ impl BuildPhase {
             self.only_include_files = Some(files);
         } else {
             self.only_include_files = Some(vec![file]);
+        }
+    }
+
+    pub fn add_cache_directory(&mut self, dir: String) {
+        if let Some(mut dirs) = self.cache_directories.clone() {
+            dirs.push(dir);
+            self.cache_directories = Some(dirs);
+        } else {
+            self.cache_directories = Some(vec![dir]);
         }
     }
 

--- a/src/nixpacks/phase.rs
+++ b/src/nixpacks/phase.rs
@@ -99,6 +99,9 @@ pub struct InstallPhase {
     #[serde(rename = "onlyIncludeFiles")]
     pub only_include_files: Option<Vec<String>>,
 
+    #[serde(rename = "cacheDirectories")]
+    pub cache_directories: Option<Vec<String>>,
+
     pub paths: Option<Vec<String>>,
 }
 
@@ -107,6 +110,7 @@ impl InstallPhase {
         Self {
             cmds: Some(vec![cmd]),
             only_include_files: None,
+            cache_directories: None,
             paths: None,
         }
     }
@@ -117,6 +121,15 @@ impl InstallPhase {
             self.only_include_files = Some(files);
         } else {
             self.only_include_files = Some(vec![file]);
+        }
+    }
+
+    pub fn add_cache_directory(&mut self, dir: String) {
+        if let Some(mut dirs) = self.cache_directories.clone() {
+            dirs.push(dir);
+            self.cache_directories = Some(dirs);
+        } else {
+            self.cache_directories = Some(vec![dir]);
         }
     }
 

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -18,7 +18,7 @@ const YARN_CACHE_DIR: &'static &str = &"/usr/local/share/.cache/yarn/v6";
 const PNPM_CACHE_DIR: &'static &str = &"/root/.cache/pnpm";
 const NPM_CACHE_DIR: &'static &str = &"/root/.npm";
 const CYPRESS_CACHE_DIR: &'static &str = &"/root/.cache/Cypress";
-const NODE_MODULES_CACHE_DIR: &'static &str = &"./node_modules/.cache";
+const NODE_MODULES_CACHE_DIR: &'static &str = &"node_modules/.cache";
 
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub struct PackageJson {

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -88,7 +88,7 @@ impl Provider for NodeProvider {
         let next_cache_dirs = NodeProvider::find_next_packages(app)?;
         for dir in next_cache_dirs {
             let next_cache_dir = ".next/cache";
-            build_phase.add_cache_directory(if dir == "" {
+            build_phase.add_cache_directory(if dir.is_empty() {
                 next_cache_dir.to_string()
             } else {
                 format!("{}/{}", dir, next_cache_dir)
@@ -270,7 +270,7 @@ impl NodeProvider {
 
             if deps.contains("next") {
                 let relative = app.strip_source_path(file.as_path())?;
-                cache_dirs.push(format!("{}", relative.parent().unwrap().to_str().unwrap()));
+                cache_dirs.push(relative.parent().unwrap().to_str().unwrap().to_string());
             }
         }
 
@@ -355,9 +355,7 @@ mod test {
             NodeProvider::get_nix_node_pkg(
                 &PackageJson {
                     name: Some(String::default()),
-                    main: None,
-                    scripts: None,
-                    engines: None
+                    ..Default::default()
                 },
                 &Environment::default()
             )?,
@@ -373,9 +371,8 @@ mod test {
             NodeProvider::get_nix_node_pkg(
                 &PackageJson {
                     name: Some(String::default()),
-                    main: None,
-                    scripts: None,
-                    engines: engines_node("*")
+                    engines: engines_node("*"),
+                    ..Default::default()
                 },
                 &Environment::default()
             )?,
@@ -391,9 +388,8 @@ mod test {
             NodeProvider::get_nix_node_pkg(
                 &PackageJson {
                     name: Some(String::default()),
-                    main: None,
-                    scripts: None,
                     engines: engines_node("14"),
+                    ..Default::default()
                 },
                 &Environment::default()
             )?,
@@ -409,9 +405,8 @@ mod test {
             NodeProvider::get_nix_node_pkg(
                 &PackageJson {
                     name: Some(String::default()),
-                    main: None,
-                    scripts: None,
                     engines: engines_node("12.x"),
+                    ..Default::default()
                 },
                 &Environment::default()
             )?,
@@ -422,9 +417,8 @@ mod test {
             NodeProvider::get_nix_node_pkg(
                 &PackageJson {
                     name: Some(String::default()),
-                    main: None,
-                    scripts: None,
                     engines: engines_node("14.X"),
+                    ..Default::default()
                 },
                 &Environment::default()
             )?,
@@ -440,9 +434,8 @@ mod test {
             NodeProvider::get_nix_node_pkg(
                 &PackageJson {
                     name: Some(String::default()),
-                    main: None,
-                    scripts: None,
                     engines: engines_node(">=14.10.3 <16"),
+                    ..Default::default()
                 },
                 &Environment::default()
             )?,
@@ -458,9 +451,7 @@ mod test {
             NodeProvider::get_nix_node_pkg(
                 &PackageJson {
                     name: Some(String::default()),
-                    main: None,
-                    scripts: None,
-                    engines: None,
+                    ..Default::default()
                 },
                 &Environment::new(HashMap::from([(
                     "NIXPACKS_NODE_VERSION".to_string(),
@@ -480,9 +471,8 @@ mod test {
             NodeProvider::get_nix_node_pkg(
                 &PackageJson {
                     name: Some(String::default()),
-                    main: None,
-                    scripts: None,
                     engines: engines_node("15"),
+                    ..Default::default()
                 },
                 &Environment::default()
             )

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 const DEFAULT_NODE_PKG_NAME: &'static &str = &"nodejs";
 const AVAILABLE_NODE_VERSIONS: &[u32] = &[10, 12, 14, 16, 18];
 
-const YARN_CACHE_DIR: &'static &str = &"/.yarn-cache";
+const YARN_CACHE_DIR: &'static &str = &"/usr/local/share/.cache/yarn/v6";
 const PNPM_CACHE_DIR: &'static &str = &"/root/.cache/pnpm";
 const NPM_CACHE_DIR: &'static &str = &"/root/.npm";
 const CYPRESS_CACHE_DIR: &'static &str = &"/root/.cache/Cypress";
@@ -126,7 +126,6 @@ impl NodeProvider {
         EnvironmentVariables::from([
             ("NODE_ENV".to_string(), "production".to_string()),
             ("NPM_CONFIG_PRODUCTION".to_string(), "false".to_string()),
-            ("YARN_CACHE_FOLDER".to_string(), YARN_CACHE_DIR.to_string()),
         ])
     }
 

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -20,9 +20,7 @@ use crate::{
 use super::Provider;
 
 const DEFAULT_PYTHON_PKG_NAME: &'static &str = &"python38";
-
 const POETRY_VERSION: &'static &str = &"1.1.13";
-
 const PIP_CACHE_DIR: &'static &str = &"/root/.cache/pip";
 
 pub struct PythonProvider {}

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -22,6 +22,9 @@ use super::Provider;
 const DEFAULT_PYTHON_PKG_NAME: &'static &str = &"python38";
 
 const POETRY_VERSION: &'static &str = &"1.1.13";
+
+const PIP_CACHE_DIR: &'static &str = &"/root/.cache/pip";
+
 pub struct PythonProvider {}
 
 impl Provider for PythonProvider {
@@ -59,8 +62,12 @@ impl Provider for PythonProvider {
                 "{} && {} && pip install -r requirements.txt",
                 create_env, activate_env
             ));
+
             install_phase.add_file_dependency("requirements.txt".to_string());
             install_phase.add_path(format!("{}/bin", env_loc));
+
+            install_phase.add_cache_directory(PIP_CACHE_DIR.to_string());
+
             return Ok(Some(install_phase));
         } else if app.includes_file("pyproject.toml") {
             if app.includes_file("poetry.lock") {
@@ -69,17 +76,25 @@ impl Provider for PythonProvider {
                     "{} && {} && {} && poetry install --no-dev --no-interaction --no-ansi",
                     create_env, activate_env, install_poetry
                 ));
+
                 install_phase.add_file_dependency("poetry.lock".to_string());
                 install_phase.add_file_dependency("pyproject.toml".to_string());
                 install_phase.add_path(format!("{}/bin", env_loc));
+
+                install_phase.add_cache_directory(PIP_CACHE_DIR.to_string());
+
                 return Ok(Some(install_phase));
             }
             let mut install_phase = InstallPhase::new(format!(
                 "{} && {} && pip install --upgrade build setuptools && pip install .",
                 create_env, activate_env
             ));
+
             install_phase.add_file_dependency("pyproject.toml".to_string());
             install_phase.add_path(format!("{}/bin", env_loc));
+
+            install_phase.add_cache_directory(PIP_CACHE_DIR.to_string());
+
             return Ok(Some(install_phase));
         }
 

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -13,6 +13,10 @@ use serde::{Deserialize, Serialize};
 static RUST_OVERLAY: &str = "https://github.com/oxalica/rust-overlay/archive/master.tar.gz";
 static DEFAULT_RUST_PACKAGE: &str = "rust-bin.stable.latest.default";
 
+const CARGO_GIT_CACHE_DIR: &'static &str = &"/root/.cargo/git";
+const CARGO_REGISTRY_CACHE_DIR: &'static &str = &"/root/.cargo/registry";
+const CARGO_TARGET_CACHE_DIR: &'static &str = &"target";
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CargoTomlPackage {
     pub name: String,
@@ -84,12 +88,12 @@ impl Provider for RustProvider {
             }
         };
 
-        build_phase.add_cache_directory("/root/.cargo/git".to_string());
-        build_phase.add_cache_directory("/root/.cargo/registry".to_string());
+        build_phase.add_cache_directory(CARGO_GIT_CACHE_DIR.to_string());
+        build_phase.add_cache_directory(CARGO_REGISTRY_CACHE_DIR.to_string());
 
         if RustProvider::get_app_name(app)?.is_some() {
             // Cache target directory
-            build_phase.add_cache_directory("target".to_string());
+            build_phase.add_cache_directory(CARGO_TARGET_CACHE_DIR.to_string());
         }
 
         Ok(Some(build_phase))

--- a/src/providers/zig.rs
+++ b/src/providers/zig.rs
@@ -33,11 +33,7 @@ impl Provider for ZigProvider {
     }
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<InstallPhase>> {
-        let mut phase = InstallPhase {
-            cmds: None,
-            only_include_files: None,
-            paths: None,
-        };
+        let mut phase = InstallPhase::default();
         if app.includes_file(".gitmodules") {
             phase.add_cmd("git submodule update --init".to_string());
         }

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -356,7 +356,7 @@ fn test_rust_custom_version() {
         },
         &DockerBuilderOptions {
             name: Some(name.clone()),
-            quiet: false,
+            quiet: true,
             ..Default::default()
         },
     )

--- a/tests/generate_plan_tests.rs
+++ b/tests/generate_plan_tests.rs
@@ -367,8 +367,16 @@ fn test_pin_archive() -> Result<()> {
 #[test]
 fn test_custom_rust_version() -> Result<()> {
     let plan = simple_gen_plan("./examples/rust-custom-version");
-    let cmd = format!("cargo build --release --target {}-unknown-linux-musl", ARCH);
-    assert_eq!(plan.build.unwrap().cmds, Some(vec![cmd]));
+    assert_eq!(
+        plan.build.unwrap().cmds,
+        Some(vec![
+            format!("cargo build --release --target {}-unknown-linux-musl", ARCH),
+            format!(
+                "cp target/{}-unknown-linux-musl/release/rust-custom-version rust-custom-version",
+                ARCH
+            )
+        ])
+    );
     assert_eq!(
         plan.setup
             .unwrap()
@@ -385,8 +393,16 @@ fn test_custom_rust_version() -> Result<()> {
 #[test]
 fn test_rust_rocket() -> Result<()> {
     let plan = simple_gen_plan("./examples/rust-rocket");
-    let cmd = format!("cargo build --release --target {}-unknown-linux-musl", ARCH);
-    assert_eq!(plan.build.unwrap().cmds, Some(vec![cmd]));
+    assert_eq!(
+        plan.build.unwrap().cmds,
+        Some(vec![
+            format!("cargo build --release --target {}-unknown-linux-musl", ARCH),
+            format!(
+                "cp target/{}-unknown-linux-musl/release/rocket rocket",
+                ARCH
+            )
+        ])
+    );
     assert!(plan.start.clone().unwrap().cmd.is_some());
     assert_eq!(
         plan.start.clone().unwrap().cmd.unwrap(),
@@ -406,7 +422,10 @@ fn test_rust_rocket_no_musl() -> Result<()> {
     )?;
     assert_eq!(
         plan.build.unwrap().cmds,
-        Some(vec!["cargo build --release".to_string()])
+        Some(vec![
+            "cargo build --release".to_string(),
+            "cp target/release/rocket rocket".to_string()
+        ])
     );
     assert!(plan
         .start
@@ -414,7 +433,7 @@ fn test_rust_rocket_no_musl() -> Result<()> {
         .unwrap()
         .cmd
         .unwrap()
-        .contains("./target/release/rocket"));
+        .contains("./rocket"));
     assert!(plan.start.unwrap().run_image.is_none());
 
     Ok(())

--- a/tests/generate_plan_tests.rs
+++ b/tests/generate_plan_tests.rs
@@ -15,7 +15,14 @@ fn simple_gen_plan(path: &str) -> BuildPlan {
 #[test]
 fn test_node() -> Result<()> {
     let plan = simple_gen_plan("./examples/node");
-    assert_eq!(plan.install.unwrap().cmds, Some(vec!["npm ci".to_string()]));
+    assert_eq!(
+        plan.install.clone().unwrap().cmds,
+        Some(vec!["npm ci".to_string()])
+    );
+    assert_eq!(
+        plan.install.unwrap().cache_directories,
+        Some(vec!["/root/.npm".to_string()])
+    );
     assert_eq!(plan.build.unwrap().cmds, None);
     assert_eq!(plan.start.unwrap().cmd, Some("npm run start".to_string()));
 
@@ -70,8 +77,28 @@ fn test_node_custom_version() -> Result<()> {
 }
 
 #[test]
+fn test_node_monorepo() -> Result<()> {
+    let plan = simple_gen_plan("./examples/node-monorepo");
+    assert_eq!(
+        plan.install.clone().unwrap().cmds,
+        Some(vec!["yarn install --frozen-lockfile".to_string()])
+    );
+    assert_eq!(
+        plan.install.unwrap().cache_directories,
+        Some(vec!["/.yarn-cache".to_string()])
+    );
+    assert_eq!(plan.build.unwrap().cmds, None);
+
+    Ok(())
+}
+
+#[test]
 fn test_yarn() -> Result<()> {
     let plan = simple_gen_plan("./examples/node-yarn");
+    assert_eq!(
+        plan.install.unwrap().cmds,
+        Some(vec!["yarn install --frozen-lockfile".to_string()])
+    );
     assert_eq!(
         plan.build.unwrap().cmds,
         Some(vec!["yarn run build".to_string()])
@@ -118,6 +145,14 @@ fn test_yarn_custom_version() -> Result<()> {
 #[test]
 fn test_pnpm() -> Result<()> {
     let plan = simple_gen_plan("./examples/node-pnpm");
+    assert_eq!(
+        plan.install.clone().unwrap().cmds,
+        Some(vec!["pnpm i --frozen-lockfile".to_string()])
+    );
+    assert_eq!(
+        plan.install.unwrap().cache_directories,
+        Some(vec!["/root/.cache/pnpm".to_string()])
+    );
     assert_eq!(
         plan.build.unwrap().cmds,
         Some(vec!["pnpm run build".to_string()])

--- a/tests/generate_plan_tests.rs
+++ b/tests/generate_plan_tests.rs
@@ -85,7 +85,7 @@ fn test_node_monorepo() -> Result<()> {
     );
     assert_eq!(
         plan.install.unwrap().cache_directories,
-        Some(vec!["/.yarn-cache".to_string()])
+        Some(vec!["/usr/local/share/.cache/yarn/v6".to_string()])
     );
     assert_eq!(plan.build.unwrap().cmds, None);
 


### PR DESCRIPTION
This PR implements incremental caching by utilizing [BuildKit mount caching](https://github.com/moby/buildkit/blob/v0.10.0/frontend/dockerfile/docs/syntax.md#run---mounttypecache). It replaces #210, which used a custom approach to caching directories between builds in favor of a more Docker native approach (although we may still need a custom solution in the future).

To enable caching you can provide a `--cache-key` arg to the `build` command. If set, this key will be used as a prefix for the "id" mount option.

BuildKit caching works by caching a certain directory(ies) for `RUN` commands. The directory is restored before the command is run and wiped after. **This means that the contents of the cache directory do not appear in the final image**.

Currently, the caching only works locally in the same way that layer caching works. However, I am planning on expanding the functionality to enable [using a remote image as the cache source](https://dille.name/slides/2020-01-22/020_advanced/025_build_cache/buildkit.final/).

Example

```
nixpacks build . --cache-key my-cache-key
```

### Provider Caching

Install and build phases have a new API: `add_cache_directory(&mut self, dir: String)` that providers can use to cache a specific directory for either the install or build phases. This PR implements caching for

- Node
  + Install: Package (NPM/Yarn/PNPM) cache directories, Cypress global cache
  + Build: NextJS `.next/cache` directories, `node_modules/.cache` directory
- Python
  + Install: Pip global cache
- Rust
  + Build: `~/.cargo/git`, `~/.cargo/registry`, `/app/target`

### Results

Don't take these results too seriously. They are mainly here to illustrate that caching is actually beneficial to the builds.

Building a monorepo frontend NextJS app with the following command

```
cargo run -- build examples/node-monorepo --build-cmd "yarn workspace client build" --start-cmd "yarn workspace client start" --name monorepo --cache-key cache-key
```

| Phase | Without Cache | With Cache | Improvement |
| :--- | :--- | :--- | :--- |
| Install | 19.9s | 2.9s | 85% |
| Build | 8.0s | 4.6s | 43% |

Building a starter Django application


```
cargo run -- build examples/python-django --name django --cache-key d1
```

| Phase | Without Cache | With Cache | Improvement |
| :--- | :--- | :--- | :--- |
| Install | 14.6s | 9.6s | 38% |

Building a Rust rocket app with no musl

```
cargo run -- build examples/rust-rocket --name rocket --cache-key rr1 --env "NIXPACKS_NO_MUSL=1"
```

| Phase | Without Cache | With Cache | Improvement |
| :--- | :--- | :--- | :--- |
| Build | 80.6s | 0.3s | 99% |

_Note: The cache layer for rust dependencies is fairly large_

## Additional Changes

- Force buildkit if `cache-key` is set
- Fixed the staticfile example
- `find_directories` app API that is similar to the `find_files` method
- Copy binary out of Rust target dir 

Closes https://github.com/railwayapp/nixpacks/issues/201