### PR TITLE
Better errors when failing to read JSON and TOML files

### DIFF
--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -133,7 +133,10 @@ impl App {
         T: DeserializeOwned,
     {
         let contents = self.read_file(name)?;
-        let value: T = serde_json::from_str(contents.as_str())?;
+        let value: T = serde_json::from_str(contents.as_str()).with_context(|| {
+            let relative_path = self.strip_source_path(Path::new(name)).unwrap();
+            format!("Error reading {} as JSON", relative_path.to_str().unwrap())
+        })?;
         Ok(value)
     }
 
@@ -142,7 +145,10 @@ impl App {
         T: DeserializeOwned,
     {
         let contents = self.read_file(name)?;
-        let toml_file = toml::from_str(contents.as_str())?;
+        let toml_file = toml::from_str(contents.as_str()).with_context(|| {
+            let relative_path = self.strip_source_path(Path::new(name)).unwrap();
+            format!("Error reading {} as TOML", relative_path.to_str().unwrap())
+        })?;
         Ok(toml_file)
     }
 


### PR DESCRIPTION
add context to error reading JSON and TOML files

![image](https://user-images.githubusercontent.com/3044853/177869156-faa4ff28-0cff-4197-b8b4-0280cdb8b0b7.png)
