### PR TITLE
NIXPACKS_NO_CACHE config variable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub fn create_docker_image(
 
     let logger = Logger::new();
     let builder = DockerBuilder::new(logger, build_options.to_owned());
-    builder.create_image(app.source.to_str().unwrap(), &plan)?;
+    builder.create_image(app.source.to_str().unwrap(), &plan, &environment)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,6 +219,7 @@ fn main() -> Result<()> {
                 out_dir,
                 quiet: false,
                 cache_key,
+                no_cache,
             };
 
             create_docker_image(path, envs, plan_options, build_options)?;

--- a/src/nixpacks/builder/mod.rs
+++ b/src/nixpacks/builder/mod.rs
@@ -1,8 +1,8 @@
-use super::plan::BuildPlan;
+use super::{environment::Environment, plan::BuildPlan};
 use anyhow::Result;
 
 pub mod docker;
 
 pub trait Builder {
-    fn create_image(&self, app_source: &str, plan: &BuildPlan) -> Result<()>;
+    fn create_image(&self, app_source: &str, plan: &BuildPlan, env: &Environment) -> Result<()>;
 }


### PR DESCRIPTION
Allow not building with cache by setting the `NIXPACKS_NO_CACHE=1` environment variable.
