### PR TITLE
Replace `-` with `.` when specifying nix packages

### DIFF
--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -111,7 +111,7 @@ impl<'a> NixpacksBuildPlanGenerator<'a> {
 
         let env_var_pkgs = environment
             .get_config_variable("PKGS")
-            .map(|pkg_string| pkg_string.split(' ').map(Pkg::new).collect::<Vec<_>>())
+            .map(|pkg_string| pkg_string.replace('-', ".").split(' ').map(Pkg::new).collect::<Vec<_>>())
             .unwrap_or_default();
 
         // Add custom user packages

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -111,7 +111,13 @@ impl<'a> NixpacksBuildPlanGenerator<'a> {
 
         let env_var_pkgs = environment
             .get_config_variable("PKGS")
-            .map(|pkg_string| pkg_string.replace('-', ".").split(' ').map(Pkg::new).collect::<Vec<_>>())
+            .map(|pkg_string| {
+                pkg_string
+                    .replace('-', ".")
+                    .split(' ')
+                    .map(Pkg::new)
+                    .collect::<Vec<_>>()
+            })
             .unwrap_or_default();
 
         // Add custom user packages

--- a/src/providers/go.rs
+++ b/src/providers/go.rs
@@ -94,7 +94,7 @@ impl GolangProvider {
             let go_version_line = lines.find(|line| line.trim().starts_with("go"));
 
             if let Some(go_version_line) = go_version_line {
-                let go_version = go_version_line.trim().split_whitespace().nth(1).unwrap();
+                let go_version = go_version_line.split_whitespace().nth(1).unwrap();
 
                 if let Some(nix_pkg) = version_number_to_pkg(go_version)? {
                     return Ok(nix_pkg);

--- a/src/providers/staticfile.rs
+++ b/src/providers/staticfile.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt::Write as _;
 
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub struct Staticfile {
@@ -67,7 +68,7 @@ impl Provider for StaticfileProvider {
         let status_code = staticfile.status_code.unwrap_or_default();
         let mut error_page = "".to_string();
         for (key, value) in status_code {
-            error_page += &format!("\terror_page {} {};\n", key, value);
+            writeln!(error_page, "\terror_page {} {};", key, value)?;
         }
 
         let nginx_conf = formatdoc! {"


### PR DESCRIPTION
This replaces `-` with `.` when a package is passed to the `NIXPACKS_PKGS` environment variable. They have the same behaviour, but `-` would break the nix flake.