### PR TITLE
feat: add supports for --platform

### DIFF
--- a/docs/pages/docs/cli.md
+++ b/docs/pages/docs/cli.md
@@ -27,8 +27,8 @@ nixpacks build --help
 |                             |                                                                |
 | :-------------------------- | :------------------------------------------------------------- |
 | `--install-cmd <cmd>`, `-i` | Specify the install command                                    |
-| `--build-cmd <cmd>`, `-b`   | Specify the build command                                       |
-| `--start-cmd <cmd>`, `-s`   | Specify the start command                                    |
+| `--build-cmd <cmd>`, `-b`   | Specify the build command                                      |
+| `--start-cmd <cmd>`, `-s`   | Specify the start command                                      |
 | `--name <name>`             | Name for the built image                                       |
 | `--env <envs...>`           | Provide environment variables to your build.                   |
 | `--pkgs <pkgs...>`, `-p`    | Provide additional Nix packages to install in the environment  |
@@ -39,6 +39,7 @@ nixpacks build --help
 | `--cache-key <key>`         | Unique identifier to use for the build cache                   |
 | `--no-cache`                | Disable caching for the build                                  |
 | `--out <dir>`, `-o`         | Save output directory instead of building it with Docker       |
+| `--platform <platforms...>` | Choosing the target platform for the target environment        |
 
 #### Environment Variables
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,13 @@ fn main() -> Result<()> {
                         .multiple_values(true),
                 )
                 .arg(
+                    Arg::new("platform")
+                        .long("platform")
+                        .help("Set target platform for your output image")
+                        .takes_value(true)
+                        .multiple_values(true),
+                )
+                .arg(
                     Arg::new("cache-key")
                         .long("cache-key")
                         .help(
@@ -219,6 +226,10 @@ fn main() -> Result<()> {
                 .values_of("label")
                 .map(|values| values.map(|s| s.to_string()).collect::<Vec<_>>())
                 .unwrap_or_default();
+            let platform = matches
+                .values_of("platform")
+                .map(|values| values.map(|s| s.to_string()).collect::<Vec<_>>())
+                .unwrap_or_default();
 
             let build_options = &DockerBuilderOptions {
                 name,
@@ -228,6 +239,7 @@ fn main() -> Result<()> {
                 quiet: false,
                 cache_key,
                 no_cache,
+                platform,
                 print_dockerfile,
             };
 

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -25,6 +25,7 @@ pub struct DockerBuilderOptions {
     pub quiet: bool,
     pub cache_key: Option<String>,
     pub no_cache: bool,
+    pub platform: Vec<String>,
 }
 
 pub struct DockerBuilder {
@@ -124,6 +125,9 @@ impl DockerBuilder {
         }
         for l in self.options.labels.clone() {
             docker_build_cmd.arg("--label").arg(l);
+        }
+        for l in self.options.platform.clone() {
+            docker_build_cmd.arg("--platform").arg(l);
         }
 
         Ok(docker_build_cmd)


### PR DESCRIPTION
Since nixpacks is using buildkit as backend, it is possible to pass in
`--platform` to set target platform for the generated docker container.

This would enable the target app to be built on different target platform.

I don't know what is the team's progress on supporting multiple architecture for target nixpacks.