### PR TITLE
Prettier plan output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "box_drawing"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea27d8d5fd867b17523bf6788b1175fa9867f34669d057e9adaf76e27bcea44b"
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +118,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +166,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "fnv"
@@ -276,8 +303,10 @@ version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",
+ "box_drawing",
  "clap",
  "colored",
+ "console",
  "fs_extra",
  "globset",
  "indoc",
@@ -287,6 +316,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "tempdir",
+ "textwrap",
  "thiserror",
  "toml",
  "uuid",
@@ -492,6 +522,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,10 +564,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -567,6 +618,21 @@ name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ toml = "0.5.9"
 uuid = { version = "1.1.2", features = ["v4"] }
 wait-timeout = "0.2.0"
 base64 = "0.13.0"
+console = "0.15.0"
+box_drawing = "0.1.2"
+textwrap = "0.15.0"

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -8,7 +8,7 @@ use std::{
 use super::Builder;
 use crate::nixpacks::{
     app, cache::sanitize_cache_key, environment::Environment, files, logger::Logger, nix,
-    plan::BuildPlan, NIX_PACKS_VERSION,
+    plan::BuildPlan,
 };
 use anyhow::{bail, Context, Ok, Result};
 use indoc::formatdoc;
@@ -55,8 +55,6 @@ impl Builder for DockerBuilder {
             return Ok(());
         }
 
-        self.logger
-            .log_section(format!("Building (nixpacks v{})", NIX_PACKS_VERSION).as_str());
         println!("{}", plan.get_build_string());
 
         // Write everything to destination

--- a/src/nixpacks/plan/mod.rs
+++ b/src/nixpacks/plan/mod.rs
@@ -37,33 +37,39 @@ impl BuildPlan {
 
         let top_box = format!(
             "{}{} {} {}{}",
-            box_drawing::double::DOWN_RIGHT.dimmed(),
+            box_drawing::double::DOWN_RIGHT.cyan().dimmed(),
             str::repeat(
                 box_drawing::double::HORIZONTAL,
                 (BOX_WIDTH - title_width) / 2
             )
+            .cyan()
             .dimmed(),
             title_str.magenta().bold(),
             str::repeat(
                 box_drawing::double::HORIZONTAL,
                 (BOX_WIDTH - title_width) / 2
             )
+            .cyan()
             .dimmed(),
-            box_drawing::double::DOWN_LEFT.dimmed(),
+            box_drawing::double::DOWN_LEFT.cyan().dimmed(),
         );
 
         let bottom_box = format!(
             "{}{}{}",
-            box_drawing::double::UP_RIGHT.dimmed(),
-            str::repeat(box_drawing::double::HORIZONTAL, BOX_WIDTH - 1).dimmed(),
-            box_drawing::double::UP_LEFT.dimmed()
+            box_drawing::double::UP_RIGHT.cyan().dimmed(),
+            str::repeat(box_drawing::double::HORIZONTAL, BOX_WIDTH - 1)
+                .cyan()
+                .dimmed(),
+            box_drawing::double::UP_LEFT.cyan().dimmed()
         );
 
         let hor_sep = format!(
             "{}{}{}",
-            box_drawing::double::VERTICAL.dimmed(),
-            str::repeat(box_drawing::light::HORIZONTAL, BOX_WIDTH - 1).dimmed(),
-            box_drawing::double::VERTICAL.dimmed()
+            box_drawing::double::VERTICAL.cyan().dimmed(),
+            str::repeat(box_drawing::light::HORIZONTAL, BOX_WIDTH - 1)
+                .cyan()
+                .dimmed(),
+            box_drawing::double::VERTICAL.cyan().dimmed()
         );
 
         let setup_phase = self.setup.clone().unwrap_or_default();
@@ -107,6 +113,7 @@ fn print_row(title: &str, content: String) -> String {
     let first_column_width = 10;
 
     let middle_padding = format!(" {} ", box_drawing::light::VERTICAL)
+        .cyan()
         .dimmed()
         .to_string();
     let middle_padding_width = console::measure_text_width(middle_padding.as_str());
@@ -119,7 +126,7 @@ fn print_row(title: &str, content: String) -> String {
     let list_lines = textwrap::wrap(content.as_str(), textwrap_opts);
     let mut output = format!(
         "{} {}{}{} {}",
-        box_drawing::double::VERTICAL.dimmed(),
+        box_drawing::double::VERTICAL.cyan().dimmed(),
         console::pad_str(
             title,
             first_column_width - 1,
@@ -134,13 +141,13 @@ fn print_row(title: &str, content: String) -> String {
             None
         )
         .white(),
-        box_drawing::double::VERTICAL.dimmed()
+        box_drawing::double::VERTICAL.cyan().dimmed()
     );
 
     for line in list_lines.iter().skip(1) {
         output = format!(
             "{output}\n{}{}{}{}{}",
-            box_drawing::double::VERTICAL.dimmed(),
+            box_drawing::double::VERTICAL.cyan().dimmed(),
             console::pad_str("", first_column_width, console::Alignment::Left, None),
             middle_padding,
             console::pad_str(
@@ -150,7 +157,7 @@ fn print_row(title: &str, content: String) -> String {
                 None
             )
             .white(),
-            box_drawing::double::VERTICAL.dimmed()
+            box_drawing::double::VERTICAL.cyan().dimmed()
         );
     }
 

--- a/src/nixpacks/plan/mod.rs
+++ b/src/nixpacks/plan/mod.rs
@@ -4,10 +4,15 @@ use crate::nixpacks::{
     phase::{BuildPhase, InstallPhase, SetupPhase, StartPhase},
 };
 use anyhow::Result;
+use colored::Colorize;
 use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
 
+use super::NIX_PACKS_VERSION;
+
 pub mod generator;
+
+pub const BOX_WIDTH: usize = 80;
 
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize)]
@@ -27,54 +32,125 @@ pub trait PlanGenerator {
 
 impl BuildPlan {
     pub fn get_build_string(&self) -> String {
-        let setup_phase = self.setup.clone();
-        let nix_pkgs = setup_phase
-            .clone()
-            .unwrap_or_default()
-            .pkgs
-            .iter()
-            .map(|pkg| pkg.to_pretty_string())
-            .collect::<Vec<_>>();
-        let apt_pkgs = setup_phase.unwrap_or_default().apt_pkgs.unwrap_or_default();
-        let pkgs = [nix_pkgs, apt_pkgs].concat();
-        let packages_string = get_phase_string("Packages", Some(pkgs.join("\n    -> ")));
-        let install_phase = self.install.clone();
-        let install_string = get_phase_string(
-            "Install",
-            install_phase.map(|install| install.cmds.unwrap_or_default().join("\n    -> ")),
+        let title_str = format!("Nixpacks v{}", NIX_PACKS_VERSION);
+        let title_width = console::measure_text_width(title_str.as_str()) + 2;
+
+        let top_box = format!(
+            "{}{} {} {}{}",
+            box_drawing::double::DOWN_RIGHT.dimmed(),
+            str::repeat(
+                box_drawing::double::HORIZONTAL,
+                (BOX_WIDTH - title_width) / 2
+            )
+            .dimmed(),
+            title_str.magenta().bold(),
+            str::repeat(
+                box_drawing::double::HORIZONTAL,
+                (BOX_WIDTH - title_width) / 2
+            )
+            .dimmed(),
+            box_drawing::double::DOWN_LEFT.dimmed(),
         );
 
-        let build_phase = self.build.clone();
-        let build_string = get_phase_string(
-            "Build",
-            build_phase.map(|build| build.cmds.unwrap_or_default().join("\n    -> ")),
+        let bottom_box = format!(
+            "{}{}{}",
+            box_drawing::double::UP_RIGHT.dimmed(),
+            str::repeat(box_drawing::double::HORIZONTAL, BOX_WIDTH - 1).dimmed(),
+            box_drawing::double::UP_LEFT.dimmed()
         );
 
-        let start_phase = self.start.clone();
-        let start_string = get_phase_string("Start", start_phase.and_then(|start| start.cmd));
+        let hor_sep = format!(
+            "{}{}{}",
+            box_drawing::double::VERTICAL.dimmed(),
+            str::repeat(box_drawing::light::HORIZONTAL, BOX_WIDTH - 1),
+            box_drawing::double::VERTICAL.dimmed()
+        );
+
+        let setup_phase = self.setup.clone().unwrap_or_default();
+        let install_phase = self.install.clone().unwrap_or_default();
+        let build_phase = self.build.clone().unwrap_or_default();
+        let start_phase = self.start.clone().unwrap_or_default();
+
+        let pkg_list = [
+            setup_phase
+                .pkgs
+                .iter()
+                .map(|pkg| pkg.to_pretty_string())
+                .collect::<Vec<_>>(),
+            setup_phase.apt_pkgs.unwrap_or_default(),
+        ]
+        .concat()
+        .join(", ");
+
+        let packages_row = print_row("Packages", pkg_list);
+        let install_row = print_row("Install", install_phase.cmds.unwrap_or_default().join("\n"));
+        let build_row = print_row("Build", build_phase.cmds.unwrap_or_default().join("\n"));
+        let start_row = print_row("Start", start_phase.cmd.unwrap_or_default());
 
         return formatdoc! {"
-          {packages_string}
-          {install_string}
-          {build_string}
-          {start_string}",
-            packages_string=packages_string,
-            install_string=install_string,
-            build_string=build_string,
-        start_string=start_string};
+          {top_box}
+          {packages_row}
+          {hor_sep}
+          {install_row}
+          {hor_sep}
+          {build_row}
+          {hor_sep}
+          {start_row}
+          {bottom_box}",
+        };
     }
 }
 
-fn get_phase_string(phase: &str, content: Option<String>) -> String {
-    match &content {
-        Some(content) => {
-            if content.is_empty() {
-                return format!("=> {}\n    -> Skipping", phase);
-            }
-            format!("=> {}\n    -> {}", phase, content.trim())
-        }
-        None => {
-            format!("=> {}\n    -> Skipping", phase)
-        }
+fn print_row(title: &str, content: String) -> String {
+    let first_column_width = 10;
+
+    let middle_padding = format!(" {} ", box_drawing::light::VERTICAL)
+        .dimmed()
+        .to_string();
+    let middle_padding_width = console::measure_text_width(middle_padding.as_str());
+    let second_column_width = BOX_WIDTH - first_column_width - middle_padding_width - 2;
+
+    let mut textwrap_opts = textwrap::Options::new(second_column_width);
+    textwrap_opts.break_words = true;
+    textwrap_opts.subsequent_indent = "  ";
+
+    let list_lines = textwrap::wrap(content.as_str(), textwrap_opts);
+    let mut output = format!(
+        "{} {}{}{} {}",
+        box_drawing::double::VERTICAL.dimmed(),
+        console::pad_str(
+            title,
+            first_column_width - 1,
+            console::Alignment::Left,
+            None
+        ),
+        middle_padding,
+        console::pad_str(
+            &list_lines[0],
+            second_column_width,
+            console::Alignment::Left,
+            None
+        )
+        .white(),
+        box_drawing::double::VERTICAL.dimmed()
+    );
+
+    for line in list_lines.iter().skip(1) {
+        output.push_str(&format!(
+            "\n{}{}{}{}{}",
+            box_drawing::double::VERTICAL.dimmed(),
+            console::pad_str("", first_column_width, console::Alignment::Left, None),
+            middle_padding,
+            console::pad_str(
+                line,
+                second_column_width + 1,
+                console::Alignment::Left,
+                None
+            )
+            .white(),
+            box_drawing::double::VERTICAL.dimmed()
+        ));
     }
+
+    output
 }

--- a/src/nixpacks/plan/mod.rs
+++ b/src/nixpacks/plan/mod.rs
@@ -62,7 +62,7 @@ impl BuildPlan {
         let hor_sep = format!(
             "{}{}{}",
             box_drawing::double::VERTICAL.dimmed(),
-            str::repeat(box_drawing::light::HORIZONTAL, BOX_WIDTH - 1),
+            str::repeat(box_drawing::light::HORIZONTAL, BOX_WIDTH - 1).dimmed(),
             box_drawing::double::VERTICAL.dimmed()
         );
 
@@ -138,8 +138,8 @@ fn print_row(title: &str, content: String) -> String {
     );
 
     for line in list_lines.iter().skip(1) {
-        output.push_str(&format!(
-            "\n{}{}{}{}{}",
+        output = format!(
+            "{output}\n{}{}{}{}{}",
             box_drawing::double::VERTICAL.dimmed(),
             console::pad_str("", first_column_width, console::Alignment::Left, None),
             middle_padding,
@@ -151,7 +151,7 @@ fn print_row(title: &str, content: String) -> String {
             )
             .white(),
             box_drawing::double::VERTICAL.dimmed()
-        ));
+        );
     }
 
     output

--- a/src/nixpacks/plan/mod.rs
+++ b/src/nixpacks/plan/mod.rs
@@ -88,6 +88,7 @@ impl BuildPlan {
         let start_row = print_row("Start", start_phase.cmd.unwrap_or_default());
 
         return formatdoc! {"
+
           {top_box}
           {packages_row}
           {hor_sep}
@@ -96,7 +97,8 @@ impl BuildPlan {
           {build_row}
           {hor_sep}
           {start_row}
-          {bottom_box}",
+          {bottom_box}
+          ",
         };
     }
 }


### PR DESCRIPTION
Output the build plan inside of a box in a table format. This makes it a bit easier to visually parse and see what is going on.

![image](https://user-images.githubusercontent.com/3044853/178564816-d32942c5-b76b-4a69-8a63-d48e3be1cfe6.png)
