### PR TITLE
no-cache option also does not use the docker cache

### DIFF
--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -110,6 +110,10 @@ impl DockerBuilder {
             docker_build_cmd.arg("--quiet");
         }
 
+        if self.options.no_cache {
+            docker_build_cmd.arg("--no-cache");
+        }
+
         // Add build environment variables
         for (name, value) in plan.variables.clone().unwrap_or_default().iter() {
             docker_build_cmd


### PR DESCRIPTION
When not building with a cache (`--no-cache` or `NIXPACKS_NO_CACHE=1`), do not use the buildkit cache mount **as well as the regular docker cache**.
