### PR TITLE
Add pkg-config to base image

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-20220622-slim
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y upgrade \
-  && apt-get install --no-install-recommends -y sudo locales curl xz-utils ca-certificates openssl make git \
+  && apt-get install --no-install-recommends -y sudo locales curl xz-utils ca-certificates openssl make git pkg-config \
   && apt-get clean && rm -rf /var/lib/apt/lists/* \
   && mkdir -m 0755 /nix && mkdir -m 0755 /etc/nix && groupadd -r nixbld && chown root /nix \
   && printf 'sandbox = false \nfilter-syscalls = false' > /etc/nix/nix.conf \


### PR DESCRIPTION
## What does this PR address?
<!-- Thanks for sending a pull request! -->
Including this library should hopefully make it easier for packages to find the necessary libraries and header files they need.

It only increase the base image size by 6MB.

