### PR TITLE
Add ruby bin dir to path

### DIFF
--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -41,7 +41,6 @@ impl Provider for RubyProvider {
         setup_phase.add_cmd(format!("gem install {}", self.get_bundler_version(app)));
         setup_phase
             .add_cmd("echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile".to_string());
-        setup_phase.add_cmd("source /usr/local/rvm/scripts/rvm".to_string());
 
         Ok(Some(setup_phase))
     }

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -1,7 +1,7 @@
 use super::{node::NodeProvider, Provider};
 use crate::nixpacks::{
     app::App,
-    environment::Environment,
+    environment::{Environment, EnvironmentVariables},
     phase::{InstallPhase, SetupPhase, StartPhase},
 };
 use anyhow::{bail, Ok, Result};
@@ -37,9 +37,11 @@ impl Provider for RubyProvider {
         );
 
         setup_phase.add_cmd(format!("rvm install {}", self.get_ruby_version(app)?));
+        setup_phase.add_cmd(format!("rvm --default use {}", self.get_ruby_version(app)?));
         setup_phase.add_cmd(format!("gem install {}", self.get_bundler_version(app)));
         setup_phase
             .add_cmd("echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile".to_string());
+        setup_phase.add_cmd("source /usr/local/rvm/scripts/rvm".to_string());
 
         Ok(Some(setup_phase))
     }
@@ -54,6 +56,8 @@ impl Provider for RubyProvider {
         // Ensure that the ruby executable is in the PATH
         let ruby_version = self.get_ruby_version(app)?;
         install_phase.add_path(format!("/usr/local/rvm/rubies/{}/bin", ruby_version));
+        install_phase.add_path(format!("/usr/local/rvm/gems/{}/bin", ruby_version));
+        install_phase.add_path(format!("/usr/local/rvm/gems/{}@global/bin", ruby_version));
 
         if app.includes_file("package.json") {
             install_phase.add_file_dependency("package.json".to_string());
@@ -79,6 +83,28 @@ impl Provider for RubyProvider {
         } else {
             Ok(None)
         }
+    }
+
+    fn environment_variables(
+        &self,
+        app: &App,
+        _env: &Environment,
+    ) -> Result<Option<crate::nixpacks::environment::EnvironmentVariables>> {
+        let ruby_version = self.get_ruby_version(app)?;
+        Ok(Some(EnvironmentVariables::from([
+            ("BUNDLE_GEMFILE".to_string(), "/app/Gemfile".to_string()),
+            (
+                "GEM_PATH".to_string(),
+                format!(
+                    "/usr/local/rvm/gems/{ruby_version}:/usr/local/rvm/gems/{ruby_version}@global",
+                    ruby_version = ruby_version
+                ),
+            ),
+            (
+                "GEM_HOME".to_string(),
+                format!("/usr/local/rvm/gems/{ruby_version}"),
+            ),
+        ])))
     }
 }
 

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -51,6 +51,10 @@ impl Provider for RubyProvider {
 
         install_phase.add_cmd("bundle install".to_string());
 
+        // Ensure that the ruby executable is in the PATH
+        let ruby_version = self.get_ruby_version(app)?;
+        install_phase.add_path(format!("/usr/local/rvm/rubies/{}/bin", ruby_version));
+
         if app.includes_file("package.json") {
             install_phase.add_file_dependency("package.json".to_string());
             install_phase


### PR DESCRIPTION
## What does this PR address?
Ensure that the ruby binaries are available on the path. This is necessary when using custom Railway start commands.
