### PR TITLE
docs: fix a typo for static files provider

### DIFF
--- a/docs/pages/docs/providers/staticfile.md
+++ b/docs/pages/docs/providers/staticfile.md
@@ -4,7 +4,7 @@ title: Staticfile
 
 # {% $markdoc.frontmatter.title %}
 
-The Staticfile provider allows you to server a single directory via [NGINX](https://www.nginx.com/).
+The Staticfile provider allows you to serve a single directory via [NGINX](https://www.nginx.com/).
 
 Staticfile is detected if
 


### PR DESCRIPTION
## What does this PR address?
<!-- Thanks for sending a pull request! -->


## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Make sure to follow [GitHub's guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on creating PR.
- [x] Did you read through [contribution guidelines](https://github.com/railwayapp/nixpacks/blob/main/CONTRIBUTING.md)?
- [x] Did your changes require updates to the documentation? Have you updated those accordingly?
- [ ] Did you write tests to cover your changes? Did it pass locally when running `cargo test`?
- [ ] Have you run `cargo fmt`, `cargo check` and `cargo clippy` locally to ensure that CI passes?

Didn't run the cargo commands as it was a docs update

Note: i feel like it is a grammatical mistake, I may be wrong (about 90% sure it is one though)
