### PR TITLE
Sanitize both cache key and directory

### DIFF
--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -376,7 +376,7 @@ fn get_cache_mount(cache_key: &Option<String>, cache_directories: &Option<Vec<St
         (Some(cache_key), Some(cache_directories)) => cache_directories
             .iter()
             .map(|dir| {
-                let sanitized_dir = dir.to_string().replace('~',"/root");
+                let sanitized_dir = dir.replace('~',"/root");
                 let sanitized_key = sanitize_cache_key(format!("{cache_key}-{sanitized_dir}"));
                 format!("--mount=type=cache,id={sanitized_key},target={sanitized_dir}")
             })

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -376,9 +376,9 @@ fn get_cache_mount(cache_key: &Option<String>, cache_directories: &Option<Vec<St
         (Some(cache_key), Some(cache_directories)) => cache_directories
             .iter()
             .map(|dir| {
-                let key = format!("{cache_key}-{dir}");
-                let safe_key = sanitize_cache_key(key);
-                format!("--mount=type=cache,id={safe_key},target={dir}")
+                let sanitized_dir = dir.to_string().replace('~',"root");
+                let sanitized_key = sanitize_cache_key(format!("{cache_key}-{sanitized_dir}"));
+                format!("--mount=type=cache,id={sanitized_key},target={sanitized_dir}")
             })
             .collect::<Vec<String>>()
             .join(" "),

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -376,7 +376,7 @@ fn get_cache_mount(cache_key: &Option<String>, cache_directories: &Option<Vec<St
         (Some(cache_key), Some(cache_directories)) => cache_directories
             .iter()
             .map(|dir| {
-                let sanitized_dir = dir.replace('~',"/root");
+                let sanitized_dir = dir.replace('~', "/root");
                 let sanitized_key = sanitize_cache_key(format!("{cache_key}-{sanitized_dir}"));
                 format!("--mount=type=cache,id={sanitized_key},target={sanitized_dir}")
             })

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -376,7 +376,7 @@ fn get_cache_mount(cache_key: &Option<String>, cache_directories: &Option<Vec<St
         (Some(cache_key), Some(cache_directories)) => cache_directories
             .iter()
             .map(|dir| {
-                let sanitized_dir = dir.to_string().replace('~',"root");
+                let sanitized_dir = dir.to_string().replace('~',"/root");
                 let sanitized_key = sanitize_cache_key(format!("{cache_key}-{sanitized_dir}"));
                 format!("--mount=type=cache,id={sanitized_key},target={sanitized_dir}")
             })

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -372,12 +372,14 @@ impl DockerBuilder {
 }
 
 fn get_cache_mount(cache_key: &Option<String>, cache_directories: &Option<Vec<String>>) -> String {
-    let sanitized_cache_key = cache_key.clone().map(sanitize_cache_key);
-
-    match (sanitized_cache_key, cache_directories) {
+    match (cache_key, cache_directories) {
         (Some(cache_key), Some(cache_directories)) => cache_directories
             .iter()
-            .map(|dir| format!("--mount=type=cache,id={cache_key}-{dir},target={dir}"))
+            .map(|dir| {
+                let key = format!("{cache_key}-{dir}");
+                let safe_key = sanitize_cache_key(key);
+                format!("--mount=type=cache,id={safe_key},target={dir}")
+            })
             .collect::<Vec<String>>()
             .join(" "),
         _ => "".to_string(),

--- a/src/nixpacks/cache.rs
+++ b/src/nixpacks/cache.rs
@@ -24,6 +24,6 @@ mod tests {
             sanitize_cache_key("s p a c e s".to_string()),
             "s-p-a-c-e-s".to_string()
         );
-        assert_eq!(sanitize_cache_key("~/.m2".to_string()), "-m2".to_string());
+        assert_eq!(sanitize_cache_key("/.m2".to_string()), "-m2".to_string());
     }
 }

--- a/src/nixpacks/cache.rs
+++ b/src/nixpacks/cache.rs
@@ -1,5 +1,16 @@
 pub fn sanitize_cache_key(cache_key: String) -> String {
-    cache_key.replace(' ', "-")
+    cache_key
+        .chars()
+        .filter(|x| match x {
+            // remove these chars
+            '/' | '.' => false,
+            _ => true,
+        })
+        .map(|x| match x {
+            ' ' | '~' => '-',
+            _ => x,
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -13,5 +24,6 @@ mod tests {
             sanitize_cache_key("s p a c e s".to_string()),
             "s-p-a-c-e-s".to_string()
         );
+        assert_eq!(sanitize_cache_key("~/.m2".to_string()), "-m2".to_string());
     }
 }

--- a/src/nixpacks/cache.rs
+++ b/src/nixpacks/cache.rs
@@ -3,11 +3,11 @@ pub fn sanitize_cache_key(cache_key: String) -> String {
         .chars()
         .filter(|x| match x {
             // remove these chars
-            '/' | '.' => false,
+            '.' => false,
             _ => true,
         })
         .map(|x| match x {
-            ' ' | '~' => '-',
+            ' ' | '/' => '-',
             _ => x,
         })
         .collect()

--- a/src/nixpacks/cache.rs
+++ b/src/nixpacks/cache.rs
@@ -1,11 +1,7 @@
 pub fn sanitize_cache_key(cache_key: String) -> String {
     cache_key
         .chars()
-        .filter(|x| match x {
-            // remove these chars
-            '.' => false,
-            _ => true,
-        })
+        .filter(|x| !matches!(x, '.')) // remove dot from the string
         .map(|x| match x {
             ' ' | '/' => '-',
             _ => x,


### PR DESCRIPTION
While working on adding caching to Clojure provider, I've set the caching directory to `~/.m2` (Maven directory used by [Lein](https://leiningen.org/) for caching)

Got this caching path `DdFtDTR8ns0-~/.m2` which represents invalid path that lead to disabling caching entirely 
Sanitizing both cache key + cache dir would end up with something like `DdFtDTR8ns0-m2` which is safe & ensure caching won't be disturbed by dir values 


