### PR TITLE
Spike: Delete DOCKERFILE if found before writing to Dockerfile

### DIFF
--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -143,6 +143,14 @@ impl DockerBuilder {
         let dockerfile = self.create_dockerfile(plan, env);
 
         let dockerfile_path = PathBuf::from(dest).join(PathBuf::from("Dockerfile"));
+
+        // if a file named DOCKERFILE already exists, it will cause buildkit to fail later
+        // As calling File::create won't force a rename to Dockerfile, so better to delete before writing our Dockerfile
+        let file_exists = fs::metadata(dockerfile_path.clone()).is_ok();
+        if file_exists {
+            fs::remove_file(dockerfile_path.clone())?;
+        }
+
         File::create(dockerfile_path.clone()).context("Creating Dockerfile file")?;
         fs::write(dockerfile_path, dockerfile).context("Writing Dockerfile")?;
 


### PR DESCRIPTION
By Spike: I mean we can decide not to merge this PR, it is meant for discussing proposed changes (instead of only describing it)

Currently, if Nixpacks build is called on a directory that already has a file named `DOCKERFILE` (or any other case than Dockerfile or dockerfile) It will fail with this error

```
failed to solve with frontend dockerfile.v0: failed to read dockerfile: open /var/lib/docker/tmp/buildkit-mount938323349/Dockerfile: no such file or directory
 
Error: Docker build failed
```

So, better to make sure we're writing to the right path by removing any file with conflicting case 
Instead of users spending time figuring out why builds are failing with no clear error message about the issue

What do you think?
