### PR TITLE
exclude examples and docs directories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Generate an OCI compliant image based off app source"
 readme = "README.md"
 homepage = "https://github.com/railwayapp/nixpacks"
 repository = "https://github.com/railwayapp/nixpacks"
+exclude = ["examples/", "docs/"]
 
 [[bin]]
 name = "nixpacks"


### PR DESCRIPTION
We've hit the filesize limit when attempting to publish a new version to crates.io. This PR excludes the `examples/` and `docs/` directories since they do not need to be included.
