### PR TITLE
Use new version of caching action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           override: true
           components: rustfmt, clippy
           
-      - uses: Swaitnem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -93,7 +93,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swaitnem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
       
       - name: Run cargo test
         uses: actions-rs/cargo@v1
@@ -128,7 +128,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swaitnem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1
@@ -57,7 +57,7 @@ jobs:
           override: true
           components: rustfmt, clippy
           
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swaitnem/rust-cache@v2
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -93,7 +93,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swaitnem/rust-cache@v2
       
       - name: Run cargo test
         uses: actions-rs/cargo@v1
@@ -128,7 +128,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swaitnem/rust-cache@v2
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
## What does this PR address?
<!-- Thanks for sending a pull request! -->

Bumps the version we use for caching rust dependencies.

<!-- Remove if not applicable -->
Fixes # (issue)

## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Make sure to follow [GitHub's guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on creating PR.
- [ ] Did you read through [contribution guidelines](https://github.com/railwayapp/nixpacks/blob/main/CONTRIBUTING.md)?
- [ ] Did your changes require updates to the documentation? Have you updated those accordingly?
- [ ] Did you write tests to cover your changes? Did it pass locally when running `cargo test`?
- [ ] Have you run `cargo fmt`, `cargo check` and `cargo clippy` locally to ensure that CI passes?
