### PR TITLE
redact build plan version and nix archive in snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
 name = "box_drawing"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +81,18 @@ checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cargo_toml"
@@ -80,9 +113,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.14"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54635806b078b7925d6e36810b1755f2a4b5b4d57560432c1ecf60bcbe10602b"
+checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
 dependencies = [
  "bitflags",
  "clap_lex",
@@ -159,10 +192,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fnv"
@@ -175,6 +223,15 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "getrandom"
@@ -244,6 +301,8 @@ checksum = "36fb7ec420af04ce7d1a422945cd19c52bf01772ead45934cee77f056dca1081"
 dependencies = [
  "console",
  "once_cell",
+ "pest",
+ "pest_derive",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -273,6 +332,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
@@ -314,16 +379,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.40"
+name = "pest"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc2916cde080c1876ff40292a396541241fe0072ef928cd76582e9ea5d60d2"
 dependencies = [
  "unicode-ident",
 ]
@@ -481,6 +595,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +663,18 @@ checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ globset = { default-features = false, version = "0.4.9" }
 walkdir = "2.3.2"
 indoc = "1.0.6"
 regex = "1.6.0"
-serde = { version = "1.0.140", features = ["derive"] }
+serde = { version = "1.0.140", default-features = false}
 serde_json = "1.0.82"
 serde_yaml = "0.8.26"
 serde_with = { features = ["macros"], default-features = false, version = "1.14.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ globset = { default-features = false, version = "0.4.9" }
 walkdir = "2.3.2"
 indoc = "1.0.6"
 regex = "1.6.0"
-serde = { version = "1.0.140", default-features = false }
+serde = { version = "1.0.140", features = ["derive"] }
 serde_json = "1.0.82"
 serde_yaml = "0.8.26"
 serde_with = { features = ["macros"], default-features = false, version = "1.14.0" }
@@ -43,4 +43,4 @@ textwrap = { default-features = false, version = "0.15.0" }
 cargo_toml = "0.11.5"
 
 [dev-dependencies]
-insta = "1.16.0"
+insta = {version = "1.16.0", features=["redactions"]}

--- a/tests/generate_plan_tests.rs
+++ b/tests/generate_plan_tests.rs
@@ -7,6 +7,15 @@ use nixpacks::{
 };
 use std::env::consts::ARCH;
 
+macro_rules! assert_plan_snapshot {
+    ($plan:expr) => {
+        insta::assert_json_snapshot!($plan, {
+            ".version" => "[version]",
+            ".setup.archive" => "[archive]",
+        });
+    }
+}
+
 fn simple_gen_plan(path: &str) -> BuildPlan {
     generate_build_plan(path, Vec::new(), &GeneratePlanOptions::default()).unwrap()
 }
@@ -14,103 +23,103 @@ fn simple_gen_plan(path: &str) -> BuildPlan {
 #[test]
 fn test_node() {
     let plan = simple_gen_plan("./examples/node");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_node_no_lockfile() {
     let plan = simple_gen_plan("./examples/node-no-lockfile-canvas");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_node_npm_old_lockfile() {
     let plan = simple_gen_plan("./examples/node-npm-old-lockfile");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_npm() {
     let plan = simple_gen_plan("./examples/node-npm");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_node_no_scripts() {
     let plan = simple_gen_plan("./examples/node-no-scripts");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_node_custom_version() {
     let plan = simple_gen_plan("./examples/node-custom-version");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_node_monorepo() {
     let plan = simple_gen_plan("./examples/node-monorepo");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_yarn() {
     let plan = simple_gen_plan("./examples/node-yarn");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_yarn_berry() {
     let plan = simple_gen_plan("./examples/node-yarn-berry");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_yarn_custom_version() {
     let plan = simple_gen_plan("./examples/node-yarn-custom-node-version");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_pnpm() {
     let plan = simple_gen_plan("./examples/node-pnpm");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_bun() {
     let plan = simple_gen_plan("./examples/node-bun");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_bun_no_start() {
     let plan = simple_gen_plan("./examples/node-bun-no-start");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_bun_web_server() {
     let plan = simple_gen_plan("./examples/node-bun-no-start");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_pnpm_v7() {
     let plan = simple_gen_plan("./examples/node-pnpm-v7");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_pnpm_custom_version() {
     let plan = simple_gen_plan("./examples/node-pnpm-custom-node-version");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_go() {
     let plan = simple_gen_plan("./examples/go");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
@@ -121,55 +130,55 @@ fn test_go_cgo_enabled() {
         &GeneratePlanOptions::default(),
     )
     .unwrap();
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_go_mod() {
     let plan = simple_gen_plan("./examples/go-mod");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_go_custom_version() {
     let plan = simple_gen_plan("./examples/go-custom-version");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_deno() {
     let plan = simple_gen_plan("./examples/deno");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_deno_fresh() {
     let plan = simple_gen_plan("./examples/deno-fresh");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_csharp_api() {
     let plan = simple_gen_plan("./examples/csharp-api");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_fsharp_api() {
     let plan = simple_gen_plan("./examples/fsharp-api");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_csharp_cli() {
     let plan = simple_gen_plan("./examples/csharp-cli");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_procfile() {
     let plan = simple_gen_plan("./examples/procfile");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
@@ -184,7 +193,7 @@ fn test_custom_pkgs() {
         },
     )
     .unwrap();
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
@@ -198,7 +207,7 @@ fn test_pin_archive() {
         },
     )
     .unwrap();
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
@@ -254,37 +263,37 @@ fn test_rust_rocket_no_musl() {
         &GeneratePlanOptions::default(),
     )
     .unwrap();
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 pub fn test_python() {
     let plan = simple_gen_plan("./examples/python");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 pub fn test_python_poetry() {
     let plan = simple_gen_plan("./examples/python-poetry");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_node_main_file() {
     let plan = simple_gen_plan("./examples/node-main-file");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 pub fn test_python_setuptools() {
     let plan = simple_gen_plan("./examples/python-setuptools");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_node_main_file_doesnt_exist() {
     let plan = simple_gen_plan("./examples/node-main-file-not-exist");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
@@ -307,7 +316,7 @@ fn test_haskell_stack() {
 #[test]
 fn test_crystal() {
     let plan = simple_gen_plan("./examples/crystal");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
@@ -318,7 +327,7 @@ fn test_overriding_environment_variables() {
         &GeneratePlanOptions::default(),
     )
     .unwrap();
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
@@ -338,61 +347,61 @@ fn test_config_from_environment_variables() {
     )
     .unwrap();
 
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_staticfile() {
     let plan = simple_gen_plan("./examples/staticfile");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_php_vanilla() {
     let plan = simple_gen_plan("./examples/php-vanilla");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_php_laravel() {
     let plan = simple_gen_plan("./examples/php-laravel");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_dart() {
     let plan = simple_gen_plan("./examples/dart");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_swift() {
     let plan = simple_gen_plan("./examples/swift");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_swift_vapor() {
     let plan = simple_gen_plan("./examples/swift-vapor");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_java_maven() {
     let plan = simple_gen_plan("./examples/java-maven");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_java_maven_wrapper() {
     let plan = simple_gen_plan("./examples/java-maven-wrapper");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_zig() {
     let plan = simple_gen_plan("./examples/zig");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "i386"))]
@@ -421,23 +430,23 @@ fn test_zig_gyro() {
 #[test]
 fn test_ruby_rails() {
     let plan = simple_gen_plan("./examples/ruby-rails-postgres");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_ruby_sinatra() {
     let plan = simple_gen_plan("./examples/ruby-sinatra");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_clojure() {
     let plan = simple_gen_plan("./examples/clojure");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }
 
 #[test]
 fn test_clojure_ring_app() {
     let plan = simple_gen_plan("./examples/clojure-ring-app");
-    insta::assert_json_snapshot!(plan);
+    assert_plan_snapshot!(plan);
 }

--- a/tests/snapshots/generate_plan_tests__bun.snap
+++ b/tests/snapshots/generate_plan_tests__bun.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__bun_no_start.snap
+++ b/tests/snapshots/generate_plan_tests__bun_no_start.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__bun_web_server.snap
+++ b/tests/snapshots/generate_plan_tests__bun_web_server.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__clojure.snap
+++ b/tests/snapshots/generate_plan_tests__clojure.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__clojure_ring_app.snap
+++ b/tests/snapshots/generate_plan_tests__clojure_ring_app.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__config_from_environment_variables.snap
+++ b/tests/snapshots/generate_plan_tests__config_from_environment_variables.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__crystal.snap
+++ b/tests/snapshots/generate_plan_tests__crystal.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__csharp_api.snap
+++ b/tests/snapshots/generate_plan_tests__csharp_api.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__csharp_cli.snap
+++ b/tests/snapshots/generate_plan_tests__csharp_cli.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__custom_pkgs.snap
+++ b/tests/snapshots/generate_plan_tests__custom_pkgs.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__dart.snap
+++ b/tests/snapshots/generate_plan_tests__dart.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__deno.snap
+++ b/tests/snapshots/generate_plan_tests__deno.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__deno_fresh.snap
+++ b/tests/snapshots/generate_plan_tests__deno_fresh.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__fsharp_api.snap
+++ b/tests/snapshots/generate_plan_tests__fsharp_api.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__go.snap
+++ b/tests/snapshots/generate_plan_tests__go.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__go_cgo_enabled.snap
+++ b/tests/snapshots/generate_plan_tests__go_cgo_enabled.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__go_custom_version.snap
+++ b/tests/snapshots/generate_plan_tests__go_custom_version.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__go_mod.snap
+++ b/tests/snapshots/generate_plan_tests__go_mod.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__java_maven.snap
+++ b/tests/snapshots/generate_plan_tests__java_maven.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__java_maven_wrapper.snap
+++ b/tests/snapshots/generate_plan_tests__java_maven_wrapper.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__node.snap
+++ b/tests/snapshots/generate_plan_tests__node.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__node_custom_version.snap
+++ b/tests/snapshots/generate_plan_tests__node_custom_version.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__node_main_file.snap
+++ b/tests/snapshots/generate_plan_tests__node_main_file.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__node_main_file_doesnt_exist.snap
+++ b/tests/snapshots/generate_plan_tests__node_main_file_doesnt_exist.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__node_monorepo.snap
+++ b/tests/snapshots/generate_plan_tests__node_monorepo.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__node_no_lockfile.snap
+++ b/tests/snapshots/generate_plan_tests__node_no_lockfile.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__node_no_scripts.snap
+++ b/tests/snapshots/generate_plan_tests__node_no_scripts.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__node_npm_old_lockfile.snap
+++ b/tests/snapshots/generate_plan_tests__node_npm_old_lockfile.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__npm.snap
+++ b/tests/snapshots/generate_plan_tests__npm.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__overriding_environment_variables.snap
+++ b/tests/snapshots/generate_plan_tests__overriding_environment_variables.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__php_laravel.snap
+++ b/tests/snapshots/generate_plan_tests__php_laravel.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__php_vanilla.snap
+++ b/tests/snapshots/generate_plan_tests__php_vanilla.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__pin_archive.snap
+++ b/tests/snapshots/generate_plan_tests__pin_archive.snap
@@ -3,10 +3,10 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [],
-    "archive": "9eb60f25aff0d2218c848dd4574a0ab5e296cabe",
+    "archive": "[archive]",
     "libraries": [],
     "apt_pkgs": [],
     "baseImage": "ghcr.io/railwayapp/nixpacks:debian-1657820962"

--- a/tests/snapshots/generate_plan_tests__pnpm.snap
+++ b/tests/snapshots/generate_plan_tests__pnpm.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__pnpm_custom_version.snap
+++ b/tests/snapshots/generate_plan_tests__pnpm_custom_version.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__pnpm_v7.snap
+++ b/tests/snapshots/generate_plan_tests__pnpm_v7.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__procfile.snap
+++ b/tests/snapshots/generate_plan_tests__procfile.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__python.snap
+++ b/tests/snapshots/generate_plan_tests__python.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__python_poetry.snap
+++ b/tests/snapshots/generate_plan_tests__python_poetry.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__python_setuptools.snap
+++ b/tests/snapshots/generate_plan_tests__python_setuptools.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__ruby_rails.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_rails.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [],
     "libraries": [],

--- a/tests/snapshots/generate_plan_tests__ruby_sinatra.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_sinatra.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [],
     "libraries": [],

--- a/tests/snapshots/generate_plan_tests__rust_rocket_no_musl.snap
+++ b/tests/snapshots/generate_plan_tests__rust_rocket_no_musl.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__staticfile.snap
+++ b/tests/snapshots/generate_plan_tests__staticfile.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__swift.snap
+++ b/tests/snapshots/generate_plan_tests__swift.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {
@@ -22,7 +22,7 @@ expression: plan
         "name": "zlib.dev"
       }
     ],
-    "archive": "c82b46413401efa740a0b994f52e9903a4f6dcd5",
+    "archive": "[archive]",
     "libraries": [],
     "apt_pkgs": [],
     "baseImage": "ghcr.io/railwayapp/nixpacks:debian-1657820962"

--- a/tests/snapshots/generate_plan_tests__swift_vapor.snap
+++ b/tests/snapshots/generate_plan_tests__swift_vapor.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {
@@ -22,7 +22,7 @@ expression: plan
         "name": "zlib.dev"
       }
     ],
-    "archive": "c82b46413401efa740a0b994f52e9903a4f6dcd5",
+    "archive": "[archive]",
     "libraries": [],
     "apt_pkgs": [],
     "baseImage": "ghcr.io/railwayapp/nixpacks:debian-1657820962"

--- a/tests/snapshots/generate_plan_tests__yarn.snap
+++ b/tests/snapshots/generate_plan_tests__yarn.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__yarn_berry.snap
+++ b/tests/snapshots/generate_plan_tests__yarn_berry.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__yarn_custom_version.snap
+++ b/tests/snapshots/generate_plan_tests__yarn_custom_version.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {

--- a/tests/snapshots/generate_plan_tests__zig.snap
+++ b/tests/snapshots/generate_plan_tests__zig.snap
@@ -3,7 +3,7 @@ source: tests/generate_plan_tests.rs
 expression: plan
 ---
 {
-  "version": "0.2.9",
+  "version": "[version]",
   "setup": {
     "pkgs": [
       {


### PR DESCRIPTION
Use insta [redactions](https://insta.rs/docs/redactions/) to redact the nixpacks version and nix pacakge archive in the snapshots
