### PR TITLE
Search All Python files Django + Support Double Quote identification

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -196,7 +196,7 @@ impl PythonProvider {
 
     fn get_django_app_name(app: &App, _env: &Environment) -> Result<String> {
         // Look for the settings.py file
-        let paths = app.find_files("/**/settings.py").unwrap();
+        let paths = app.find_files("/*.py").unwrap();
 
         // Generate regex to find the application name
         let re = Regex::new(r"WSGI_APPLICATION = '(.*).application'").unwrap();

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -201,8 +201,6 @@ impl PythonProvider {
         // Generate regex to find the application name
         let re = Regex::new(r#"WSGI_APPLICATION = ["|'](.*).application["|']"#).unwrap();
 
-        println!("{:?}", paths.len());
-
         // Search all settings.py matches
         for path in paths {
             let path_buf = fs::canonicalize(path)?;

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -191,15 +191,17 @@ impl PythonProvider {
         // Check for the engine database type in settings.py
         let re = Regex::new(r"django.db.backends.postgresql").unwrap();
 
-        app.find_match(&re, "/**/settings.py")
+        app.find_match(&re, "/**/*.py")
     }
 
     fn get_django_app_name(app: &App, _env: &Environment) -> Result<String> {
         // Look for the settings.py file
-        let paths = app.find_files("/*.py").unwrap();
+        let paths = app.find_files("/**/*.py").unwrap();
 
         // Generate regex to find the application name
         let re = Regex::new(r#"WSGI_APPLICATION = ["|'](.*).application["|']"#).unwrap();
+
+        println!("{:?}", paths.len());
 
         // Search all settings.py matches
         for path in paths {

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -199,7 +199,7 @@ impl PythonProvider {
         let paths = app.find_files("/*.py").unwrap();
 
         // Generate regex to find the application name
-        let re = Regex::new(r"WSGI_APPLICATION = '(.*).application'").unwrap();
+        let re = Regex::new(r#"WSGI_APPLICATION = ["|'](.*).application["|']"#).unwrap();
 
         // Search all settings.py matches
         for path in paths {


### PR DESCRIPTION
## What does this PR address?
Fixes an issue where the WSGI_APPLICATION identified could be somewhere other than 
settings.py, as well as supports the usecase of double quotes, as well as the original single quotes usecase

<!-- Remove if not applicable -->
Fixes #367 (issue)

## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Make sure to follow [GitHub's 
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on creating PR.
- [x] Did you read through [contribution 
guidelines](https://github.com/railwayapp/nixpacks/blob/main/CONTRIBUTING.md)?
- [x] Did your changes require updates to the documentation? Have you updated those accordingly?
- [ ] Did you write tests to cover your changes? Did it pass locally when running `cargo test`?
- [ ] Have you run `cargo fmt`, `cargo check` and `cargo clippy` locally to ensure that CI passes?
