### PR TITLE
Improve on current regexes

### DIFF
--- a/src/providers/clojure.rs
+++ b/src/providers/clojure.rs
@@ -80,7 +80,7 @@ impl ClojureProvider {
 
     fn parse_custom_version(custom_version: String) -> Result<String> {
         // Regex for reading JDK versions (e.g. 8 or 11 or latest)
-        let jdk_regex = Regex::new(r"(^[0-9][0-9]?$)|(^latest$)")?;
+        let jdk_regex = Regex::new(r"^([0-9][0-9]?|latest)$")?;
 
         // Capture matches
         let matches = jdk_regex.captures(custom_version.as_str().trim());
@@ -91,11 +91,7 @@ impl ClojureProvider {
         }
 
         let matches = matches.unwrap();
-        let matched_value = if matches.get(0).is_some() {
-            matches.get(0)
-        } else {
-            matches.get(1)
-        };
+        let matched_value = matches.get(0);
 
         let value = match matched_value {
             Some(m) => m.as_str(),

--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -29,10 +29,13 @@ impl Provider for DenoProvider {
     }
 
     fn detect(&self, app: &App, _env: &Environment) -> Result<bool> {
-        let re = Regex::new(r##"^import .+ from (?:"|'|`)https://deno.land/[^"`']+\.(?:ts|js|tsx|jsx)(?:"|'|`);?$"##).unwrap();
+        let re = Regex::new(
+            r##"import .+ from (?:"|'|`)https://deno.land/[^"`']+\.(?:ts|js|tsx|jsx)(?:"|'|`);?"##,
+        )
+        .unwrap();
         Ok(app.includes_file("deno.json")
             || app.includes_file("deno.jsonc")
-            || app.find_match(&re, "**/*.ts")?)
+            || app.find_match(&re, "**/*.{tsx,ts,js,jsx}")?)
     }
 
     fn setup(&self, _app: &App, _env: &Environment) -> Result<Option<SetupPhase>> {

--- a/src/providers/deno.rs
+++ b/src/providers/deno.rs
@@ -29,7 +29,7 @@ impl Provider for DenoProvider {
     }
 
     fn detect(&self, app: &App, _env: &Environment) -> Result<bool> {
-        let re = Regex::new(r##"(?m)^import .+ from "https://deno.land/[^"]+\.ts";?$"##).unwrap();
+        let re = Regex::new(r##"^import .+ from (?:"|'|`)https://deno.land/[^"`']+\.(?:ts|js|tsx|jsx)(?:"|'|`);?$"##).unwrap();
         Ok(app.includes_file("deno.json")
             || app.includes_file("deno.jsonc")
             || app.find_match(&re, "**/*.ts")?)

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -195,7 +195,7 @@ impl NodeProvider {
 
         // Parse `18` or `18.x` into nodejs-18_x
         // This also supports 18.x.x, or any number in place of the x.
-        let re = Regex::new(r"^(\d*)\.?([x|X]|[0-9]+)\.?([x|X]|[0-9]+)?$").unwrap();
+        let re = Regex::new(r"^(\d*)(?:\.?(\d|[xX])?)(?:\.?(\d|[xX])?)$").unwrap();
         if let Some(node_pkg) = parse_regex_into_pkg(&re, node_version.clone()) {
             return Ok(Pkg::new(node_pkg.as_str()));
         }
@@ -379,13 +379,8 @@ fn version_number_to_pkg(version: &u32) -> String {
 
 fn parse_regex_into_pkg(re: &Regex, node_version: String) -> Option<String> {
     let matches: Vec<_> = re.captures_iter(node_version.as_str()).collect();
-    if let Some(m) = matches.get(0) {
-        let capture = if node_version.contains('.') {
-            &m[1]
-        } else {
-            &m[0]
-        };
-        match capture.parse::<u32>() {
+    if let Some(captures) = matches.get(0) {
+        match captures[0].parse::<u32>() {
             Ok(version) => return Some(version_number_to_pkg(&version)),
             Err(_e) => {}
         }

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -195,7 +195,7 @@ impl NodeProvider {
 
         // Parse `18` or `18.x` into nodejs-18_x
         // This also supports 18.x.x, or any number in place of the x.
-        let re = Regex::new(r"^(\d*)(?:\.?\d|[xX]?)(?:\.?\d|[xX]?)$").unwrap();
+        let re = Regex::new(r"^(\d*)(?:\.?\d*|[xX]?)(?:\.?\d*|[xX]?)$").unwrap();
         if let Some(node_pkg) = parse_regex_into_pkg(&re, node_version.clone()) {
             return Ok(Pkg::new(node_pkg.as_str()));
         }

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -195,7 +195,7 @@ impl NodeProvider {
 
         // Parse `18` or `18.x` into nodejs-18_x
         // This also supports 18.x.x, or any number in place of the x.
-        let re = Regex::new(r"^(\d*)(?:\.?\d*|[xX]?)(?:\.?\d*|[xX]?)$").unwrap();
+        let re = Regex::new(r"^(\d*)(?:\.?(?:\d*|[xX]?)?)(?:\.?(?:\d*|[xX]?)?)").unwrap();
         if let Some(node_pkg) = parse_regex_into_pkg(&re, node_version.clone()) {
             return Ok(Pkg::new(node_pkg.as_str()));
         }

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -195,7 +195,7 @@ impl NodeProvider {
 
         // Parse `18` or `18.x` into nodejs-18_x
         // This also supports 18.x.x, or any number in place of the x.
-        let re = Regex::new(r"^(\d*)(?:\.?(\d|[xX])?)(?:\.?(\d|[xX])?)$").unwrap();
+        let re = Regex::new(r"^(\d*)(?:\.?\d|[xX]?)(?:\.?\d|[xX]?)$").unwrap();
         if let Some(node_pkg) = parse_regex_into_pkg(&re, node_version.clone()) {
             return Ok(Pkg::new(node_pkg.as_str()));
         }

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -379,9 +379,8 @@ fn version_number_to_pkg(version: &u32) -> String {
 
 fn parse_regex_into_pkg(re: &Regex, node_version: String) -> Option<String> {
     let matches: Vec<_> = re.captures_iter(node_version.as_str()).collect();
-    dbg!(&matches);
     if let Some(captures) = matches.get(0) {
-        match captures[0].parse::<u32>() {
+        match captures[1].parse::<u32>() {
             Ok(version) => return Some(version_number_to_pkg(&version)),
             Err(_e) => {}
         }

--- a/src/providers/node.rs
+++ b/src/providers/node.rs
@@ -379,6 +379,7 @@ fn version_number_to_pkg(version: &u32) -> String {
 
 fn parse_regex_into_pkg(re: &Regex, node_version: String) -> Option<String> {
     let matches: Vec<_> = re.captures_iter(node_version.as_str()).collect();
+    dbg!(&matches);
     if let Some(captures) = matches.get(0) {
         match captures[0].parse::<u32>() {
             Ok(version) => return Some(version_number_to_pkg(&version)),


### PR DESCRIPTION
## What does this PR address?
<!-- Thanks for sending a pull request! -->
This just changes some regexes to be slightly cleaner & less hacky.

The notable change is that the node versoin Regex now only matches the semver major version. I noticed that we are only checking the major version, and there is no point in getting other captures if we don't need them.
<!-- Remove if not applicable -->
Fixes # (issue)

## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Make sure to follow [GitHub's guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on creating PR.
- [x] Did you read through [contribution guidelines](https://github.com/railwayapp/nixpacks/blob/main/CONTRIBUTING.md)?
- [ ] Did your changes require updates to the documentation? Have you updated those accordingly?
- [ ] Did you write tests to cover your changes? Did it pass locally when running `cargo test`?
- [ ] Have you run `cargo fmt`, `cargo check` and `cargo clippy` locally to ensure that CI passes?
