### PR TITLE
Write nixpacks related files to .nixpacks directory

### DIFF
--- a/.lsp/.cache/db.transit.json
+++ b/.lsp/.cache/db.transit.json
@@ -1,1 +1,0 @@
-["^ ","~:classpath",["~#set",[]],"~:project-hash","","~:project-root","/Users/ahmedmozaly/desktop/Railway/nixpacks","~:kondo-config-hash","84cef9c8bbb8d583dacd181603a83eab3febcaa90f21e990b1a589d7c309dd25","~:analysis",null,"~:analysis-checksums",["^ "],"~:project-analysis-type","~:project-and-deps","~:version",5,"~:stubs-generation-namespaces",["^1",[]]]

--- a/.lsp/.cache/db.transit.json
+++ b/.lsp/.cache/db.transit.json
@@ -1,0 +1,1 @@
+["^ ","~:classpath",["~#set",[]],"~:project-hash","","~:project-root","/Users/ahmedmozaly/desktop/Railway/nixpacks","~:kondo-config-hash","84cef9c8bbb8d583dacd181603a83eab3febcaa90f21e990b1a589d7c309dd25","~:analysis",null,"~:analysis-checksums",["^ "],"~:project-analysis-type","~:project-and-deps","~:version",5,"~:stubs-generation-namespaces",["^1",[]]]

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -46,7 +46,7 @@ impl OutputDir {
             .display()
             .to_string();
 
-        if !fs::metadata(&dot_nixpacks_dir).is_ok() {
+        if fs::metadata(&dot_nixpacks_dir).is_err() {
             fs::create_dir_all(&dot_nixpacks_dir)?;
         }
 
@@ -212,7 +212,7 @@ impl DockerBuilder {
         environment_nix_path: &str,
     ) -> Result<()> {
         let dockerfile = self.create_dockerfile(plan, env, environment_nix_path);
-        File::create(dockerfile_path.clone()).context("Creating Dockerfile file")?;
+        File::create(dockerfile_path).context("Creating Dockerfile file")?;
         fs::write(dockerfile_path, dockerfile).context("Writing Dockerfile")?;
 
         Ok(())

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -194,6 +194,7 @@ impl DockerBuilder {
         env: &Environment,
     ) -> Result<()> {
         let dockerfile = self.create_dockerfile(plan, env);
+        
         File::create(dockerfile_path).context("Creating Dockerfile file")?;
         fs::write(dockerfile_path, dockerfile).context("Writing Dockerfile")?;
 

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -29,11 +29,11 @@ impl OutputDir {
             .display()
             .to_string();
 
-        let dockerfile_path = PathBuf::from(&dot_nixpacks_dir).join(PathBuf::from("Dockerfile"));
-
         if fs::metadata(&dot_nixpacks_dir).is_err() {
             fs::create_dir_all(&dot_nixpacks_dir)?;
         }
+
+        let dockerfile_path = PathBuf::from(&dot_nixpacks_dir).join(PathBuf::from("Dockerfile"));
 
         Ok(OutputDir {
             root_path,
@@ -194,7 +194,7 @@ impl DockerBuilder {
         env: &Environment,
     ) -> Result<()> {
         let dockerfile = self.create_dockerfile(plan, env);
-        
+
         File::create(dockerfile_path).context("Creating Dockerfile file")?;
         fs::write(dockerfile_path, dockerfile).context("Writing Dockerfile")?;
 

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 
 const DOT_NIXPACKS_DIR: &'static &str = &".nixpacks";
 const ENVIRONMENT_NIX: &'static &str = &"environment.nix";
+const DOCKERFILE_NAME: &'static &str = &"Dockerfile";
 
 struct OutputDir {
     root_path: PathBuf,
@@ -35,7 +36,7 @@ impl OutputDir {
             fs::create_dir_all(&dot_nixpacks_dir)?;
         }
 
-        let dockerfile_path = PathBuf::from(&dot_nixpacks_dir).join(PathBuf::from("Dockerfile"));
+        let dockerfile_path = PathBuf::from(&dot_nixpacks_dir).join(PathBuf::from(DOCKERFILE_NAME));
         let environment_nix_path =
             PathBuf::from(&dot_nixpacks_dir).join(PathBuf::from(ENVIRONMENT_NIX));
 

--- a/src/nixpacks/builder/docker.rs
+++ b/src/nixpacks/builder/docker.rs
@@ -16,6 +16,7 @@ use tempdir::TempDir;
 use uuid::Uuid;
 
 const DOT_NIXPACKS_DIR: &'static &str = &".nixpacks";
+const ENVIRONMENT_NIX: &'static &str = &"environment.nix";
 
 struct OutputDir {
     root_path: PathBuf,
@@ -36,7 +37,7 @@ impl OutputDir {
 
         let dockerfile_path = PathBuf::from(&dot_nixpacks_dir).join(PathBuf::from("Dockerfile"));
         let environment_nix_path =
-            PathBuf::from(&dot_nixpacks_dir).join(PathBuf::from("environment.nix"));
+            PathBuf::from(&dot_nixpacks_dir).join(PathBuf::from(ENVIRONMENT_NIX));
 
         Ok(OutputDir {
             root_path,
@@ -233,7 +234,7 @@ impl DockerBuilder {
 
     fn create_dockerfile(&self, plan: &BuildPlan, env: &Environment) -> String {
         let environment_nix_path = PathBuf::from(DOT_NIXPACKS_DIR)
-            .join(PathBuf::from("environment.nix"))
+            .join(PathBuf::from(ENVIRONMENT_NIX))
             .display()
             .to_string();
 


### PR DESCRIPTION
## What does this PR address?
This PR change the output path for Nixpacks-related files (like Dockerfile & environment.nix) to be created under `.nixpacks` sub-directory instead of the root path of the output dir.

This should avoid the need to override certain user files (like Dockerfile) if was already exists and keep away some unexpected behavior, Like finding out DOCKERFILE in user provided code instead of Dockerfile which cause docker build step to break later.


## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Make sure to follow [GitHub's guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on creating PR.
- [x] Did you read through [contribution guidelines](https://github.com/railwayapp/nixpacks/blob/main/CONTRIBUTING.md)?
- [ ] Did your changes require updates to the documentation? Have you updated those accordingly?
- [x] Did you write tests to cover your changes? Did it pass locally when running `cargo test`?
- [x] Have you run `cargo fmt`, `cargo check` and `cargo clippy` locally to ensure that CI passes?
