### PR TITLE
Add node_modules/.bin to path

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -71,6 +71,7 @@ impl Provider for NodeProvider {
         // Install
         let mut install = Phase::install(Some(NodeProvider::get_install_command(app)));
         install.add_cache_directory(NodeProvider::get_package_manager_cache_dir(app));
+        install.add_path("/app/node_modules/.bin".to_string());
 
         // Cypress cache directory
         let all_deps = NodeProvider::get_all_deps(app)?;
@@ -79,7 +80,6 @@ impl Provider for NodeProvider {
         }
 
         // Build
-
         let mut build = if NodeProvider::is_nx_monorepo(app) {
             let app_name = NodeProvider::get_nx_app_name(app, env)?.unwrap();
             Phase::build(Some(format!("npx nx run {}:build:production", app_name)))

--- a/tests/snapshots/generate_plan_tests__node.snap
+++ b/tests/snapshots/generate_plan_tests__node.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_bun.snap
+++ b/tests/snapshots/generate_plan_tests__node_bun.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.bun"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_bun_no_start.snap
+++ b/tests/snapshots/generate_plan_tests__node_bun_no_start.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.bun"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_bun_web_server.snap
+++ b/tests/snapshots/generate_plan_tests__node_bun_web_server.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.bun"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_custom_version.snap
+++ b/tests/snapshots/generate_plan_tests__node_custom_version.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_main_file.snap
+++ b/tests/snapshots/generate_plan_tests__node_main_file.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_main_file_not_exist.snap
+++ b/tests/snapshots/generate_plan_tests__node_main_file_not_exist.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_monorepo.snap
+++ b/tests/snapshots/generate_plan_tests__node_monorepo.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/usr/local/share/.cache/yarn/v6"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_no_lockfile_canvas.snap
+++ b/tests/snapshots/generate_plan_tests__node_no_lockfile_canvas.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_no_scripts.snap
+++ b/tests/snapshots/generate_plan_tests__node_no_scripts.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_npm.snap
+++ b/tests/snapshots/generate_plan_tests__node_npm.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_npm_old_lockfile.snap
+++ b/tests/snapshots/generate_plan_tests__node_npm_old_lockfile.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_nx.snap
+++ b/tests/snapshots/generate_plan_tests__node_nx.snap
@@ -22,6 +22,9 @@ expression: plan
       "cacheDirectories": [
         "/root/.npm",
         "/root/.cache/Cypress"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_pnpm.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.cache/pnpm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_pnpm_custom_node_version.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_custom_node_version.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.cache/pnpm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.cache/pnpm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_variables.snap
+++ b/tests/snapshots/generate_plan_tests__node_variables.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_yarn.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/usr/local/share/.cache/yarn/v6"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_yarn_berry.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn_berry.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/usr/local/share/.cache/yarn/v6"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_yarn_custom_node_version.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn_custom_node_version.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/usr/local/share/.cache/yarn/v6"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__node_yarn_prisma.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn_prisma.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/usr/local/share/.cache/yarn/v6"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__overriding_environment_variables.snap
+++ b/tests/snapshots/generate_plan_tests__overriding_environment_variables.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__procfile.snap
+++ b/tests/snapshots/generate_plan_tests__procfile.snap
@@ -21,6 +21,9 @@ expression: plan
       ],
       "cacheDirectories": [
         "/root/.npm"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
       ]
     },
     {


### PR DESCRIPTION
Fixes #399

Add the `./node_modules/.bin` directory to the path in Node apps.
