### PR TITLE
add ./node_modules/.bin to the path for ruby

### DIFF
--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -99,6 +99,8 @@ impl RubyProvider {
                     install.add_file_dependency(file.to_string());
                 }
             }
+
+            install.add_path("/app/node_modules/.bin".to_string());
         }
 
         Ok(Some(install))


### PR DESCRIPTION
Fixes #447 

This PR adds `./node_modules/.bin` to the global `PATH` variable so that NPM installed binaries are available to use.