### PR TITLE
Allow installing Python relative deps

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -122,9 +122,7 @@ impl PythonProvider {
                 create_env, activate_env
             )));
 
-            install_phase.add_file_dependency("requirements.txt".to_string());
             install_phase.add_path(format!("{}/bin", env_loc));
-
             install_phase.add_cache_directory(PIP_CACHE_DIR.to_string());
 
             return Ok(Some(install_phase));
@@ -136,8 +134,6 @@ impl PythonProvider {
                     create_env, activate_env, install_poetry
                 )));
 
-                install_phase.add_file_dependency("poetry.lock".to_string());
-                install_phase.add_file_dependency("pyproject.toml".to_string());
                 install_phase.add_path(format!("{}/bin", env_loc));
 
                 install_phase.add_cache_directory(PIP_CACHE_DIR.to_string());

--- a/tests/snapshots/generate_plan_tests__python.snap
+++ b/tests/snapshots/generate_plan_tests__python.snap
@@ -22,9 +22,6 @@ expression: plan
       "commands": [
         "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
       ],
-      "onlyIncludeFiles": [
-        "requirements.txt"
-      ],
       "cacheDirectories": [
         "/root/.cache/pip"
       ],

--- a/tests/snapshots/generate_plan_tests__python_django.snap
+++ b/tests/snapshots/generate_plan_tests__python_django.snap
@@ -28,9 +28,6 @@ expression: plan
       "commands": [
         "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
       ],
-      "onlyIncludeFiles": [
-        "requirements.txt"
-      ],
       "cacheDirectories": [
         "/root/.cache/pip"
       ],

--- a/tests/snapshots/generate_plan_tests__python_numpy.snap
+++ b/tests/snapshots/generate_plan_tests__python_numpy.snap
@@ -26,9 +26,6 @@ expression: plan
       "commands": [
         "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
       ],
-      "onlyIncludeFiles": [
-        "requirements.txt"
-      ],
       "cacheDirectories": [
         "/root/.cache/pip"
       ],

--- a/tests/snapshots/generate_plan_tests__python_poetry.snap
+++ b/tests/snapshots/generate_plan_tests__python_poetry.snap
@@ -25,10 +25,6 @@ expression: plan
       "commands": [
         "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install poetry==$NIXPACKS_POETRY_VERSION && poetry install --no-dev --no-interaction --no-ansi"
       ],
-      "onlyIncludeFiles": [
-        "poetry.lock",
-        "pyproject.toml"
-      ],
       "cacheDirectories": [
         "/root/.cache/pip"
       ],

--- a/tests/snapshots/generate_plan_tests__python_procfile.snap
+++ b/tests/snapshots/generate_plan_tests__python_procfile.snap
@@ -22,9 +22,6 @@ expression: plan
       "commands": [
         "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
       ],
-      "onlyIncludeFiles": [
-        "requirements.txt"
-      ],
       "cacheDirectories": [
         "/root/.cache/pip"
       ],


### PR DESCRIPTION
This PR allows installing Python relative deps by adding all files to the container before installing. With the Python dep cached installing is very quick.

Fixes https://github.com/railwayapp/nixpacks/issues/373
