### PR TITLE
Install gcc and clibs for python provider by default

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -97,16 +97,16 @@ impl PythonProvider {
 
         if PythonProvider::is_django(app, env)? && PythonProvider::is_using_postgres(app, env)? {
             // Django with Postgres requires postgresql and gcc on top of the original python packages
-            pkgs.append(&mut vec![Pkg::new("postgresql"), Pkg::new("gcc")]);
+            pkgs.append(&mut vec![Pkg::new("postgresql")]);
         }
 
         let mut setup_phase = Phase::setup(Some(pkgs));
 
-        // Numpy needs some C headers to be available
+        // Many Python packages need some C headers to be available
         // stdenv.cc.cc.lib -> https://discourse.nixos.org/t/nixos-with-poetry-installed-pandas-libstdc-so-6-cannot-open-shared-object-file/8442/3
-        if PythonProvider::uses_dep(app, "numpy")? || PythonProvider::uses_dep(app, "pandas")? {
-            setup_phase.add_pkgs_libs(vec!["zlib".to_string(), "stdenv.cc.cc.lib".to_string()]);
-        }
+        println!("Numpy or Pandas detected, adding gcc and libstdc++");
+        setup_phase.add_pkgs_libs(vec!["zlib".to_string(), "stdenv.cc.cc.lib".to_string()]);
+        setup_phase.add_nix_pkgs(vec![Pkg::new("gcc")]);
 
         Ok(Some(setup_phase))
     }

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -104,7 +104,6 @@ impl PythonProvider {
 
         // Many Python packages need some C headers to be available
         // stdenv.cc.cc.lib -> https://discourse.nixos.org/t/nixos-with-poetry-installed-pandas-libstdc-so-6-cannot-open-shared-object-file/8442/3
-        println!("Numpy or Pandas detected, adding gcc and libstdc++");
         setup_phase.add_pkgs_libs(vec!["zlib".to_string(), "stdenv.cc.cc.lib".to_string()]);
         setup_phase.add_nix_pkgs(vec![Pkg::new("gcc")]);
 

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -323,6 +323,7 @@ impl PythonProvider {
         ))
     }
 
+    #[allow(dead_code)]
     fn uses_dep(app: &App, dep: &str) -> Result<bool> {
         let requirements_usage = app.includes_file("requirements.txt")
             && app

--- a/tests/snapshots/generate_plan_tests__python.snap
+++ b/tests/snapshots/generate_plan_tests__python.snap
@@ -11,7 +11,14 @@ expression: plan
       "nixPackages": [
         {
           "name": "python38"
+        },
+        {
+          "name": "gcc"
         }
+      ],
+      "nixLibraries": [
+        "zlib",
+        "stdenv.cc.cc.lib"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__python_2.snap
+++ b/tests/snapshots/generate_plan_tests__python_2.snap
@@ -11,7 +11,14 @@ expression: plan
       "nixPackages": [
         {
           "name": "python27"
+        },
+        {
+          "name": "gcc"
         }
+      ],
+      "nixLibraries": [
+        "zlib",
+        "stdenv.cc.cc.lib"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__python_2_runtime.snap
+++ b/tests/snapshots/generate_plan_tests__python_2_runtime.snap
@@ -11,7 +11,14 @@ expression: plan
       "nixPackages": [
         {
           "name": "python27"
+        },
+        {
+          "name": "gcc"
         }
+      ],
+      "nixLibraries": [
+        "zlib",
+        "stdenv.cc.cc.lib"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__python_django.snap
+++ b/tests/snapshots/generate_plan_tests__python_django.snap
@@ -18,6 +18,10 @@ expression: plan
         {
           "name": "gcc"
         }
+      ],
+      "nixLibraries": [
+        "zlib",
+        "stdenv.cc.cc.lib"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__python_numpy.snap
+++ b/tests/snapshots/generate_plan_tests__python_numpy.snap
@@ -11,6 +11,9 @@ expression: plan
       "nixPackages": [
         {
           "name": "python38"
+        },
+        {
+          "name": "gcc"
         }
       ],
       "nixLibraries": [

--- a/tests/snapshots/generate_plan_tests__python_poetry.snap
+++ b/tests/snapshots/generate_plan_tests__python_poetry.snap
@@ -14,7 +14,14 @@ expression: plan
       "nixPackages": [
         {
           "name": "python38"
+        },
+        {
+          "name": "gcc"
         }
+      ],
+      "nixLibraries": [
+        "zlib",
+        "stdenv.cc.cc.lib"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__python_procfile.snap
+++ b/tests/snapshots/generate_plan_tests__python_procfile.snap
@@ -11,7 +11,14 @@ expression: plan
       "nixPackages": [
         {
           "name": "python38"
+        },
+        {
+          "name": "gcc"
         }
+      ],
+      "nixLibraries": [
+        "zlib",
+        "stdenv.cc.cc.lib"
       ]
     },
     {

--- a/tests/snapshots/generate_plan_tests__python_setuptools.snap
+++ b/tests/snapshots/generate_plan_tests__python_setuptools.snap
@@ -11,7 +11,14 @@ expression: plan
       "nixPackages": [
         {
           "name": "python38"
+        },
+        {
+          "name": "gcc"
         }
+      ],
+      "nixLibraries": [
+        "zlib",
+        "stdenv.cc.cc.lib"
       ]
     },
     {


### PR DESCRIPTION
Many (numpy, pandas, other ml libs) require gcc and c libraries to be available. We've tried matching on these packages in `requirements.txt` but it seems like a never ending game of cat and mouse. This PR installs `gcc` and some required Nix libraries by default in all Python containers. I'm hoping this reduces the number of random (missing C package errors for Python).
