### PR TITLE
puppeteer example to node 16

### DIFF
--- a/examples/node-canvas/package.json
+++ b/examples/node-canvas/package.json
@@ -7,5 +7,8 @@
   },
   "dependencies": {
     "canvas": "^2.9.1"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }

--- a/examples/node-puppeteer/package.json
+++ b/examples/node-puppeteer/package.json
@@ -11,5 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "puppeteer": "^16.1.1"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -290,15 +290,7 @@ impl NodeProvider {
     /// Returns the nodejs nix package and the appropriate package manager nix image.
     pub fn get_nix_packages(app: &App, env: &Environment) -> Result<Vec<Pkg>> {
         let package_json: PackageJson = app.read_json("package.json")?;
-        let mut node_pkg = NodeProvider::get_nix_node_pkg(&package_json, env)?;
-
-        // If node-canvas is used, we want to default to node 16
-        // https://github.com/Automattic/node-canvas/issues/2025
-        if NodeProvider::uses_node_dependency(app, "canvas")
-            && node_pkg.name == DEFAULT_NODE_PKG_NAME
-        {
-            node_pkg = Pkg::new("nodejs-16_x");
-        }
+        let node_pkg = NodeProvider::get_nix_node_pkg(&package_json, env)?;
 
         let pm_pkg: Pkg;
         let mut pkgs = Vec::<Pkg>::new();

--- a/tests/snapshots/generate_plan_tests__node_canvas.snap
+++ b/tests/snapshots/generate_plan_tests__node_canvas.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__node_canvas.snap
+++ b/tests/snapshots/generate_plan_tests__node_canvas.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs-16_x"
+          "name": "nodejs"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__node_nx.snap
+++ b/tests/snapshots/generate_plan_tests__node_nx.snap
@@ -31,7 +31,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs-16_x"
+          "name": "nodejs"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__node_puppeteer.snap
+++ b/tests/snapshots/generate_plan_tests__node_puppeteer.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",


### PR DESCRIPTION
Node-canvas doesn't have pre-built binaries for node 18, which is now the default on Railway
https://github.com/Automattic/node-canvas/issues/2025

This PR pins the version of node to 16 for the puppeteer examples

