### PR TITLE
Delete tmp directory after successful build

### DIFF
--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -6,7 +6,7 @@ use crate::nixpacks::{
 use anyhow::{bail, Context, Ok, Result};
 
 use std::{
-    fs::{self, File},
+    fs::{self, remove_dir_all, File},
     process::Command,
 };
 use tempdir::TempDir;
@@ -29,7 +29,7 @@ impl ImageBuilder for DockerImageBuilder {
             }
         };
         let name = self.options.name.clone().unwrap_or_else(|| id.to_string());
-        let output = OutputDir::new(dir)?;
+        let output = OutputDir::new(dir.clone())?;
         output.ensure_output_exists()?;
 
         let dockerfile = plan
@@ -63,6 +63,8 @@ impl ImageBuilder for DockerImageBuilder {
             self.logger.log_section("Successfully Built!");
             println!("\nRun:");
             println!("  docker run -it {}", name);
+
+            remove_dir_all(dir)?;
         } else {
             println!("\nSaved output to:");
             println!("  {}", output.root.to_str().unwrap());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->


Nixpacks creates a temp directory (if `--out` was not provided) then it takes a copy of the code & build at this temp directory 
This PR ensures that we remove this temp directory after we're done.

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
