### PR TITLE
Node 16 as default

### DIFF
--- a/docs/pages/docs/providers/node.md
+++ b/docs/pages/docs/providers/node.md
@@ -20,8 +20,8 @@ The Node provider sets the following environment variables:
 The following major versions are available
 
 - `14`
-- `16`
-- `18` (Default)
+- `16` (Default)
+- `18`
 
 The version can be overriden by
 

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -27,7 +27,7 @@ mod nx;
 
 pub const NODE_OVERLAY: &str = "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz";
 
-const DEFAULT_NODE_PKG_NAME: &str = "nodejs";
+const DEFAULT_NODE_PKG_NAME: &str = "nodejs-16_x";
 const AVAILABLE_NODE_VERSIONS: &[u32] = &[14, 16, 18];
 
 const YARN_CACHE_DIR: &str = "/usr/local/share/.cache/yarn/v6";

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -678,7 +678,7 @@ mod test {
                 &Environment::default()
             )?
             .name,
-            "nodejs"
+            DEFAULT_NODE_PKG_NAME
         );
 
         Ok(())

--- a/tests/snapshots/generate_plan_tests__node.snap
+++ b/tests/snapshots/generate_plan_tests__node.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__node_main_file.snap
+++ b/tests/snapshots/generate_plan_tests__node_main_file.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__node_main_file_not_exist.snap
+++ b/tests/snapshots/generate_plan_tests__node_main_file_not_exist.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__node_monorepo.snap
+++ b/tests/snapshots/generate_plan_tests__node_monorepo.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "yarn-1_x",

--- a/tests/snapshots/generate_plan_tests__node_no_scripts.snap
+++ b/tests/snapshots/generate_plan_tests__node_no_scripts.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__node_npm.snap
+++ b/tests/snapshots/generate_plan_tests__node_npm.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__node_npm_old_lockfile.snap
+++ b/tests/snapshots/generate_plan_tests__node_npm_old_lockfile.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-6_x",

--- a/tests/snapshots/generate_plan_tests__node_nx.snap
+++ b/tests/snapshots/generate_plan_tests__node_nx.snap
@@ -31,7 +31,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__node_pnpm.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "pnpm-6_x",

--- a/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "pnpm-7_x",

--- a/tests/snapshots/generate_plan_tests__node_variables.snap
+++ b/tests/snapshots/generate_plan_tests__node_variables.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__node_yarn.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "yarn-1_x",

--- a/tests/snapshots/generate_plan_tests__overriding_environment_variables.snap
+++ b/tests/snapshots/generate_plan_tests__overriding_environment_variables.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__php_laravel.snap
+++ b/tests/snapshots/generate_plan_tests__php_laravel.snap
@@ -42,7 +42,7 @@ expression: plan
           "name": "php81Packages.composer"
         },
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__procfile.snap
+++ b/tests/snapshots/generate_plan_tests__procfile.snap
@@ -30,7 +30,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",

--- a/tests/snapshots/generate_plan_tests__ruby_with_node.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_with_node.snap
@@ -15,7 +15,7 @@ expression: plan
       "name": "node:setup",
       "nixPackages": [
         {
-          "name": "nodejs"
+          "name": "nodejs-16_x"
         },
         {
           "name": "npm-8_x",


### PR DESCRIPTION
The unstable channel of nixpkgs has Node 18 as the default for the "nodejs" package

![image](https://user-images.githubusercontent.com/3044853/187567305-9d87727a-ef31-4b9e-bd92-5f0187e71364.png)

I initially thought this was okay, but after reading the [Node release schedule](https://nodejs.org/en/about/releases/) in more detail, Node versions "move to Active LTS status and are ready for general use". This means that node 16 should still be the default on Railway. This PR explicitly sets node 16 as the default, which I think is a good idea anyway.