### PR TITLE
Use CMD exec form with an ENTRYPOINT

### DIFF
--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -157,7 +157,10 @@ impl DockerfileGenerator for BuildPlan {
 
         let dockerfile = formatdoc! {"
             FROM {base_image}
+
+            ENTRYPOINT [\"/bin/bash\", \"-l\", \"-c\"]
             WORKDIR {APP_DIR}
+
             {assets_copy_cmd}
 
             {dockerfile_phases_str}
@@ -223,9 +226,7 @@ impl DockerfileGenerator for StartPhase {
         _output: &OutputDir,
     ) -> Result<String> {
         let start_cmd = match &self.cmd {
-            Some(cmd) => {
-                format!("CMD {}", cmd)
-            }
+            Some(cmd) => utils::get_exec_command(cmd),
             None => "".to_string(),
         };
 

--- a/src/nixpacks/builder/docker/utils.rs
+++ b/src/nixpacks/builder/docker/utils.rs
@@ -46,6 +46,12 @@ pub fn get_copy_from_command(from: &str, files: &[String], app_dir: &str) -> Str
     }
 }
 
+pub fn get_exec_command(command: &str) -> String {
+    let params = command.replace("\"", "\\\"");
+
+    format!("CMD [\"{}\"]", params)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,6 +103,24 @@ mod tests {
         assert_eq!(
             format!("COPY --from={} {} {}", from, files.join(" "), app_dir),
             get_copy_from_command(from, &files, app_dir)
+        );
+    }
+
+    #[test]
+    fn test_get_exec_cmd() {
+        assert_eq!(
+            "CMD [\"command1\"]".to_string(),
+            get_exec_command("command1")
+        );
+
+        assert_eq!(
+            "CMD [\"command1 command2\"]".to_string(),
+            get_exec_command("command1 command2")
+        );
+
+        assert_eq!(
+            "CMD [\"command1 command2 -l \\\"asdf\\\"\"]".to_string(),
+            get_exec_command("command1 command2 -l \"asdf\"")
         );
     }
 }

--- a/src/nixpacks/builder/docker/utils.rs
+++ b/src/nixpacks/builder/docker/utils.rs
@@ -47,7 +47,7 @@ pub fn get_copy_from_command(from: &str, files: &[String], app_dir: &str) -> Str
 }
 
 pub fn get_exec_command(command: &str) -> String {
-    let params = command.replace("\"", "\\\"");
+    let params = command.replace('\"', "\\\"");
 
     format!("CMD [\"{}\"]", params)
 }


### PR DESCRIPTION
This PR updates how the containers are started by default

The entrypoint is

```
ENTRYPOINT ["/bin/bash", "-l", "-c"]
```

And the `CMD` is specified in exec form. https://docs.docker.com/engine/reference/builder/#cmd

The reasoning for this change is that some providers add environment variables or startup scripts to `~/.profile` which should be loaded when the container starts (e.g. rvm info or the `LD_LIBRARY_PATH` variable). It is important that these are setup properly when the container starts.

If the default start command that nixpacks specifies is used, then all is okay. But if a custom command is used to start the container (e.g. on Railway), then we need a custom entrypoint, otherwise there will be some inconsistencies in how the command is interpreted.
