### PR TITLE
Add current-dir flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -85,8 +85,7 @@ fn main() -> Result<()> {
                     Arg::new("current-dir")
                         .long("current-dir")
                         .help("Output Nixpacks related files to the current directory ")
-                        .takes_value(false)
-                        .global(true),
+                        .takes_value(false),
                 )
                 .arg(
                     Arg::new("no-cache")

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,13 @@ fn main() -> Result<()> {
                         .takes_value(true),
                 )
                 .arg(
+                    Arg::new("current-dir")
+                        .long("current-dir")
+                        .help("Output Nixpacks related files to the current directory ")
+                        .takes_value(false)
+                        .global(true),
+                )
+                .arg(
                     Arg::new("no-cache")
                         .long("no-cache")
                         .help("Disable building with the cache"),
@@ -199,6 +206,7 @@ fn main() -> Result<()> {
             let path = matches.value_of("PATH").expect("required");
             let name = matches.value_of("name").map(ToString::to_string);
             let out_dir = matches.value_of("out").map(ToString::to_string);
+            let current_dir = matches.is_present("current-dir");
             let mut cache_key = matches.value_of("cache-key").map(ToString::to_string);
             let no_cache = matches.is_present("no-cache");
 
@@ -233,6 +241,7 @@ fn main() -> Result<()> {
                 no_cache,
                 platform,
                 print_dockerfile,
+                current_dir,
             };
 
             create_docker_image(path, envs, plan_options, build_options)?;

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -140,7 +140,11 @@ impl DockerImageBuilder {
     }
 
     fn write_app(&self, app_src: &str, output: &OutputDir) -> Result<()> {
-        files::recursive_copy_dir(app_src, &output.root)
+        if output.is_temp {
+            files::recursive_copy_dir(app_src, &output.root)
+        } else {
+            Ok(())
+        }
     }
 
     fn write_dockerfile(&self, dockerfile: String, output: &OutputDir) -> Result<()> {

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -17,23 +17,27 @@ pub struct DockerImageBuilder {
     options: DockerBuilderOptions,
 }
 
+fn get_output_dir(options: &DockerBuilderOptions) -> Result<OutputDir> {
+    if let Some(value) = &options.out_dir {
+        OutputDir::new(value.into(), false)
+    } else if options.current_dir {
+        Ok(OutputDir::default())
+    } else {
+        let tmp = TempDir::new("nixpacks").context("Creating a temp directory")?;
+        OutputDir::new(tmp.into_path(), true)
+    }
+}
+
 impl ImageBuilder for DockerImageBuilder {
     fn create_image(&self, app_src: &str, plan: &BuildPlan, env: &Environment) -> Result<()> {
         let id = Uuid::new_v4();
 
-        let dir = match &self.options.out_dir {
-            Some(dir) => dir.into(),
-            None => {
-                let tmp = TempDir::new("nixpacks").context("Creating a temp directory")?;
-                tmp.into_path()
-            }
-        };
+        let output_dir = get_output_dir(&self.options)?;
         let name = self.options.name.clone().unwrap_or_else(|| id.to_string());
-        let output = OutputDir::new(dir.clone())?;
-        output.ensure_output_exists()?;
+        output_dir.ensure_output_exists()?;
 
         let dockerfile = plan
-            .generate_dockerfile(&self.options, env, &output)
+            .generate_dockerfile(&self.options, env, &output_dir)
             .context("Generating Dockerfile for plan")?;
 
         // If printing the Dockerfile, don't write anything to disk
@@ -44,15 +48,17 @@ impl ImageBuilder for DockerImageBuilder {
 
         println!("{}", plan.get_build_string()?);
 
-        self.write_app(app_src, &output).context("Writing app")?;
-        self.write_dockerfile(dockerfile, &output)
+        self.write_app(app_src, &output_dir)
+            .context("Writing app")?;
+        self.write_dockerfile(dockerfile, &output_dir)
             .context("Writing Dockerfile")?;
-        plan.write_supporting_files(&self.options, env, &output)
+        plan.write_supporting_files(&self.options, env, &output_dir)
             .context("Writing supporting files")?;
 
         // Only build if the --out flag was not specified
         if self.options.out_dir.is_none() {
-            let mut docker_build_cmd = self.get_docker_build_cmd(plan, name.as_str(), &output)?;
+            let mut docker_build_cmd =
+                self.get_docker_build_cmd(plan, name.as_str(), &output_dir)?;
 
             // Execute docker build
             let build_result = docker_build_cmd.spawn()?.wait().context("Building image")?;
@@ -64,10 +70,12 @@ impl ImageBuilder for DockerImageBuilder {
             println!("\nRun:");
             println!("  docker run -it {}", name);
 
-            remove_dir_all(dir)?;
+            if output_dir.is_temp {
+                remove_dir_all(output_dir.root)?;
+            }
         } else {
             println!("\nSaved output to:");
-            println!("  {}", output.root.to_str().unwrap());
+            println!("  {}", output_dir.root.to_str().unwrap());
         }
 
         Ok(())

--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -24,18 +24,23 @@ pub const APP_DIR: &str = "/app/";
 pub struct OutputDir {
     pub root: PathBuf,
     pub asset_root: PathBuf,
+    pub is_temp: bool,
 }
 
 impl OutputDir {
-    pub fn new(root: PathBuf) -> Result<Self> {
+    pub fn new(root: PathBuf, is_temp: bool) -> Result<Self> {
         let root = root;
         let asset_root = PathBuf::from(NIXPACKS_OUTPUT_DIR);
 
-        Ok(Self { root, asset_root })
+        Ok(Self {
+            root,
+            asset_root,
+            is_temp,
+        })
     }
 
-    pub fn from(root: &str) -> Result<Self> {
-        Self::new(PathBuf::from(root))
+    pub fn from(root: &str, is_temp: bool) -> Result<Self> {
+        Self::new(PathBuf::from(root), is_temp)
     }
 
     /// Ensure that the output directory and all necessary subdirectories exist.
@@ -65,7 +70,7 @@ impl OutputDir {
 
 impl Default for OutputDir {
     fn default() -> Self {
-        Self::from(".").unwrap()
+        Self::from(".", false).unwrap()
     }
 }
 

--- a/src/nixpacks/builder/docker/mod.rs
+++ b/src/nixpacks/builder/docker/mod.rs
@@ -1,6 +1,7 @@
 use super::ImageBuilder;
 
 #[derive(Clone, Default, Debug)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct DockerBuilderOptions {
     pub name: Option<String>,
     pub out_dir: Option<String>,

--- a/src/nixpacks/builder/docker/mod.rs
+++ b/src/nixpacks/builder/docker/mod.rs
@@ -11,6 +11,7 @@ pub struct DockerBuilderOptions {
     pub cache_key: Option<String>,
     pub no_cache: bool,
     pub platform: Vec<String>,
+    pub current_dir: bool,
 }
 
 mod cache;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR adds new `--current-dir` flag. When passed, Nixpacks won't create a temp dir & copy code to
Will start working right away on the current directory and create `.nixpacks` sub-directory at.

Also, with `--current-dir` flag. Nixpacks won't delete the directory after successful build, It will be up to the caller to decide.

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
