### PR TITLE
Fix auto update nixpkg archive

### DIFF
--- a/.github/workflows/update-nixpkgs-archive.yml
+++ b/.github/workflows/update-nixpkgs-archive.yml
@@ -34,7 +34,7 @@ jobs:
 
           sed -i "/\/\/ Last Modified:/c\/\/ Last Modified: ${DATE}" src/nixpacks/plan/generator.rs
           sed -i "/\/\/ https:\/\/github.com\/NixOS\/nixpkgs\/commit/c\/\/ $URL" src/nixpacks/plan/generator.rs
-          sed -i "/const NIXPKGS_ARCHIVE: &str/c\const NIXPKGS_ARCHIVE: &str = \"$SHA\";" src/nixpacks/plan/generator.rs
+          sed -i "/const NIXPKGS_ARCHIVE: &str/c\pub const NIXPKGS_ARCHIVE: &str = \"$SHA\";" src/nixpacks/plan/generator.rs
 
           echo "::set-output name=sha::$SHA"
           echo "::set-output name=url::$URL"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR ensures that the constant generated by the auto-update nixpkg archive script is always `pub`, preventing errors.

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
