### PR TITLE
Remote layer cache support

### DIFF
--- a/docs/pages/docs/cli.md
+++ b/docs/pages/docs/cli.md
@@ -38,6 +38,7 @@ nixpacks build --help
 | `--label <labels...>`, `-l` | Additional labels to add to the output image                   |
 | `--cache-key <key>`         | Unique identifier to use for the build cache                   |
 | `--no-cache`                | Disable caching for the build                                  |
+| `--inline-cache`            | Enable writing cache metadata into the output image            |
 | `--out <dir>`, `-o`         | Save output directory instead of building it with Docker       |
 | `--platform <platforms...>` | Choosing the target platform for the target environment        |
 

--- a/docs/pages/docs/cli.md
+++ b/docs/pages/docs/cli.md
@@ -38,6 +38,7 @@ nixpacks build --help
 | `--label <labels...>`, `-l` | Additional labels to add to the output image                   |
 | `--cache-key <key>`         | Unique identifier to use for the build cache                   |
 | `--no-cache`                | Disable caching for the build                                  |
+| `--cache-from`              | Image to consider as cache sources                             |
 | `--inline-cache`            | Enable writing cache metadata into the output image            |
 | `--out <dir>`, `-o`         | Save output directory instead of building it with Docker       |
 | `--platform <platforms...>` | Choosing the target platform for the target environment        |

--- a/docs/pages/docs/config.md
+++ b/docs/pages/docs/config.md
@@ -35,3 +35,5 @@ By default Nixpacks providers will cache directories during the install and buil
 The default cache identifier is a hash of the absolute path to the directory being built. This means that subsequent builds of the same directory will be faster out of the box. You can override the cache identifier by passing a `--cache-key` value to the `build` command.
 
 Caching can be disabled entirely by passing `--no-cache`.
+
+Passing`--inline-cache` will write cache metadata into the output image.

--- a/docs/pages/docs/config.md
+++ b/docs/pages/docs/config.md
@@ -37,3 +37,5 @@ The default cache identifier is a hash of the absolute path to the directory bei
 Caching can be disabled entirely by passing `--no-cache`.
 
 Passing`--inline-cache` will write cache metadata into the output image.
+
+Using previous image -created with inline cache enabled- as a cache source, Can be achieved by passing `--cache-from`

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,11 @@ fn main() -> Result<()> {
                     Arg::new("inline-cache")
                         .long("inline-cache")
                         .help("Enable writing cache metadata into the output image"),
+                )
+                .arg(
+                    Arg::new("cache-from")
+                        .long("cache-from")
+                        .help("Image to consider as cache sources"),
                 ),
         )
         .arg(
@@ -214,6 +219,7 @@ fn main() -> Result<()> {
             let mut cache_key = matches.value_of("cache-key").map(ToString::to_string);
             let no_cache = matches.is_present("no-cache");
             let inline_cache = matches.is_present("inline-cache");
+            let cache_from = matches.value_of("cache-from").map(ToString::to_string);
 
             // Default to absolute `path` of the source that is being built as the cache-key if not disabled
             if !no_cache && cache_key.is_none() {
@@ -248,6 +254,7 @@ fn main() -> Result<()> {
                 print_dockerfile,
                 current_dir,
                 inline_cache,
+                cache_from,
             };
 
             create_docker_image(path, envs, plan_options, build_options)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,11 @@ fn main() -> Result<()> {
                     Arg::new("no-cache")
                         .long("no-cache")
                         .help("Disable building with the cache"),
+                )
+                .arg(
+                    Arg::new("inline-cache")
+                        .long("inline-cache")
+                        .help("Enable writing cache metadata into the output image"),
                 ),
         )
         .arg(
@@ -208,6 +213,7 @@ fn main() -> Result<()> {
             let current_dir = matches.is_present("current-dir");
             let mut cache_key = matches.value_of("cache-key").map(ToString::to_string);
             let no_cache = matches.is_present("no-cache");
+            let inline_cache = matches.is_present("inline-cache");
 
             // Default to absolute `path` of the source that is being built as the cache-key if not disabled
             if !no_cache && cache_key.is_none() {
@@ -241,6 +247,7 @@ fn main() -> Result<()> {
                 platform,
                 print_dockerfile,
                 current_dir,
+                inline_cache,
             };
 
             create_docker_image(path, envs, plan_options, build_options)?;

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -116,6 +116,12 @@ impl DockerImageBuilder {
             docker_build_cmd.arg("--no-cache");
         }
 
+        if self.options.inline_cache {
+            docker_build_cmd
+                .arg("--build-arg")
+                .arg("BUILDKIT_INLINE_CACHE=1");
+        }
+
         // Add build environment variables
         for (name, value) in &plan.variables.clone().unwrap_or_default() {
             docker_build_cmd

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -116,6 +116,10 @@ impl DockerImageBuilder {
             docker_build_cmd.arg("--no-cache");
         }
 
+        if let Some(value) = &self.options.cache_from {
+            docker_build_cmd.arg("--cache-from").arg(value);
+        }
+
         if self.options.inline_cache {
             docker_build_cmd
                 .arg("--build-arg")

--- a/src/nixpacks/builder/docker/mod.rs
+++ b/src/nixpacks/builder/docker/mod.rs
@@ -11,6 +11,7 @@ pub struct DockerBuilderOptions {
     pub quiet: bool,
     pub cache_key: Option<String>,
     pub no_cache: bool,
+    pub inline_cache: bool,
     pub platform: Vec<String>,
     pub current_dir: bool,
 }

--- a/src/nixpacks/builder/docker/mod.rs
+++ b/src/nixpacks/builder/docker/mod.rs
@@ -12,6 +12,7 @@ pub struct DockerBuilderOptions {
     pub cache_key: Option<String>,
     pub no_cache: bool,
     pub inline_cache: bool,
+    pub cache_from: Option<String>,
     pub platform: Vec<String>,
     pub current_dir: bool,
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

Currently, Nixpacks assumes that Docker host will take care of layer caching between builds.

This PR enables Nixpacks to be used also in a cluster setup where there are multiple Docker nodes and layer caching should be maintained remotely to be accessible by all nodes.

By passing `--inline-caching` & `--cache-from` We can treat the cache metadata & output image as one unit. Which can lead to a more consistent experience between builds as cache will be always available as part of the container image. 

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ x] Docs are updated if needed  -->
