### PR TITLE
Nix garbage collection after installing packages

### DIFF
--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -308,7 +308,7 @@ impl DockerfileGenerator for Phase {
                 .to_slash()
                 .context("Failed to convert nix file path to slash path.")?;
             format!(
-                "COPY {nix_file_path} {nix_file_path}\nRUN nix-env -if {nix_file_path}",
+                "COPY {nix_file_path} {nix_file_path}\nRUN nix-env -if {nix_file_path} && nix-collect-garbage -d",
                 nix_file_path = nix_file_path
             )
         } else {


### PR DESCRIPTION
This PR runs [Nix garbage collection](https://nixos.org/manual/nix/stable/package-management/garbage-collection.html) after installing packages to remove any unnecessary derivations from the store.

On the `node-yarn` examples it decreased the final image size by ~200MB.

![image](https://user-images.githubusercontent.com/3044853/188804449-cefa1b03-361d-4c0d-9276-2e60871f875a.png)
