### PR TITLE
Set `PYTHONUNBUFFERED=1` for the Python provider

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -61,6 +61,11 @@ impl Provider for PythonProvider {
             plan.set_start_phase(start);
         }
 
+        plan.add_variables(EnvironmentVariables::from([(
+            "PYTHONUNBUFFERED".to_owned(),
+            "1".to_owned(),
+        )]));
+
         if app.includes_file("poetry.lock") {
             plan.add_variables(EnvironmentVariables::from([(
                 "NIXPACKS_POETRY_VERSION".to_string(),

--- a/tests/snapshots/generate_plan_tests__python.snap
+++ b/tests/snapshots/generate_plan_tests__python.snap
@@ -6,7 +6,8 @@ expression: plan
   "nixpacksVersion": "[version]",
   "buildImage": "[build_image]",
   "variables": {
-    "NIXPACKS_METADATA": "python"
+    "NIXPACKS_METADATA": "python",
+    "PYTHONUNBUFFERED": "1"
   },
   "phases": [
     {

--- a/tests/snapshots/generate_plan_tests__python_2.snap
+++ b/tests/snapshots/generate_plan_tests__python_2.snap
@@ -6,7 +6,8 @@ expression: plan
   "nixpacksVersion": "[version]",
   "buildImage": "[build_image]",
   "variables": {
-    "NIXPACKS_METADATA": "python"
+    "NIXPACKS_METADATA": "python",
+    "PYTHONUNBUFFERED": "1"
   },
   "phases": [
     {

--- a/tests/snapshots/generate_plan_tests__python_2_runtime.snap
+++ b/tests/snapshots/generate_plan_tests__python_2_runtime.snap
@@ -6,7 +6,8 @@ expression: plan
   "nixpacksVersion": "[version]",
   "buildImage": "[build_image]",
   "variables": {
-    "NIXPACKS_METADATA": "python"
+    "NIXPACKS_METADATA": "python",
+    "PYTHONUNBUFFERED": "1"
   },
   "phases": [
     {

--- a/tests/snapshots/generate_plan_tests__python_django.snap
+++ b/tests/snapshots/generate_plan_tests__python_django.snap
@@ -6,7 +6,8 @@ expression: plan
   "nixpacksVersion": "[version]",
   "buildImage": "[build_image]",
   "variables": {
-    "NIXPACKS_METADATA": "python,django,postgres"
+    "NIXPACKS_METADATA": "python,django,postgres",
+    "PYTHONUNBUFFERED": "1"
   },
   "phases": [
     {

--- a/tests/snapshots/generate_plan_tests__python_django_mysql.snap
+++ b/tests/snapshots/generate_plan_tests__python_django_mysql.snap
@@ -6,7 +6,8 @@ expression: plan
   "nixpacksVersion": "[version]",
   "buildImage": "[build_image]",
   "variables": {
-    "NIXPACKS_METADATA": "python,django"
+    "NIXPACKS_METADATA": "python,django",
+    "PYTHONUNBUFFERED": "1"
   },
   "phases": [
     {

--- a/tests/snapshots/generate_plan_tests__python_numpy.snap
+++ b/tests/snapshots/generate_plan_tests__python_numpy.snap
@@ -6,7 +6,8 @@ expression: plan
   "nixpacksVersion": "[version]",
   "buildImage": "[build_image]",
   "variables": {
-    "NIXPACKS_METADATA": "python"
+    "NIXPACKS_METADATA": "python",
+    "PYTHONUNBUFFERED": "1"
   },
   "phases": [
     {

--- a/tests/snapshots/generate_plan_tests__python_poetry.snap
+++ b/tests/snapshots/generate_plan_tests__python_poetry.snap
@@ -7,7 +7,8 @@ expression: plan
   "buildImage": "[build_image]",
   "variables": {
     "NIXPACKS_METADATA": "python,poetry",
-    "NIXPACKS_POETRY_VERSION": "1.1.13"
+    "NIXPACKS_POETRY_VERSION": "1.1.13",
+    "PYTHONUNBUFFERED": "1"
   },
   "phases": [
     {

--- a/tests/snapshots/generate_plan_tests__python_procfile.snap
+++ b/tests/snapshots/generate_plan_tests__python_procfile.snap
@@ -6,7 +6,8 @@ expression: plan
   "nixpacksVersion": "[version]",
   "buildImage": "[build_image]",
   "variables": {
-    "NIXPACKS_METADATA": "python"
+    "NIXPACKS_METADATA": "python",
+    "PYTHONUNBUFFERED": "1"
   },
   "phases": [
     {

--- a/tests/snapshots/generate_plan_tests__python_setuptools.snap
+++ b/tests/snapshots/generate_plan_tests__python_setuptools.snap
@@ -6,7 +6,8 @@ expression: plan
   "nixpacksVersion": "[version]",
   "buildImage": "[build_image]",
   "variables": {
-    "NIXPACKS_METADATA": "python"
+    "NIXPACKS_METADATA": "python",
+    "PYTHONUNBUFFERED": "1"
   },
   "phases": [
     {


### PR DESCRIPTION
This PR sets `PYTHONUNBUFFERED=1` for the Python provider so that logs are immediately sent to stdout instead of buffering.

Fixes https://github.com/railwayapp/nixpacks/issues/503

https://stackoverflow.com/a/59812588