### PR TITLE
Use different action for publishing release

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -15,6 +15,6 @@ jobs:
           toolchain: stable
       - uses: nash-ws/cargo-release-action@main
         with:
-          major-label: major
-          minor-label: minor
-          patch-label: patch
+          major-label: release/major
+          minor-label: release/minor
+          patch-label: release/patch

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: nash-ws/cargo-release-action@main
+      - uses: nash-io/cargo-release-action@main
         with:
           major-label: release/major
           minor-label: release/minor

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,16 +1,20 @@
 name: Release Label Check
 
 on:
-  pull_request_target:
-    types: [opened, labeled, unlabeled, synchronize]
-
+  pull_request:
+    branches:
+      - main
 jobs:
-  label-check:
+  check-release:
     runs-on: ubuntu-latest
+    name: Check Release
     steps:
-      - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          valid-labels: "release/patch, release/minor, release/major"
-          pull-request-number: '${{ github.event.pull_request.number }}'
-          disable-reviews: true
+          toolchain: stable
+      - uses: nash-ws/cargo-release-action@main
+        with:
+          major-label: major
+          minor-label: minor
+          patch-label: patch

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,4 +19,4 @@ jobs:
           major-label: major
           minor-label: minor
           patch-label: patch
-          cargo-token: ${{ secrets.CARGO_TOKEN }}
+          cargo-token: ${{ secrets.NIXPACKS_CARGO_RELEASE_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,30 +4,19 @@ on:
   push:
     branches:
       - main
-
 jobs:
-  tag:
+  release:
     runs-on: ubuntu-latest
+    environment: Release
+    name: Release
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions-ecosystem/action-get-merged-pull-request@v1
-        id: get-merged-pull-request
-        with:
-          github_token: ${{ secrets.COMMITTER_TOKEN }}
-
-      - uses: actions-ecosystem/action-release-label@v1
-        id: release-label
-        if: ${{ steps.get-merged-pull-request.outputs.title != null }}
-        with:
-          github_token: ${{ secrets.GH_PAT }}
-          labels: ${{ steps.get-merged-pull-request.outputs.labels }}
-      
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      
-      - uses: actions-rs/cargo@v1
+      - uses: nash-ws/cargo-release-action@main
         with:
-          command: release ${{ steps.release-label.outputs.level }}
-          args: --execute
+          major-label: major
+          minor-label: minor
+          patch-label: patch
+          cargo-token: ${{ secrets.CARGO_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: nash-ws/cargo-release-action@main
+      - uses: nash-io/cargo-release-action@main
         with:
           major-label: release/major
           minor-label: release/minor

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
           toolchain: stable
       - uses: nash-ws/cargo-release-action@main
         with:
-          major-label: major
-          minor-label: minor
-          patch-label: patch
+          major-label: release/major
+          minor-label: release/minor
+          patch-label: release/patch
           cargo-token: ${{ secrets.NIXPACKS_CARGO_RELEASE_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR replaces the actions-rs/cargo stuff with https://github.com/nash-io/cargo-release-action

This is due to an issue where you can't seem to call release directly 
https://github.com/actions-rs/cargo/issues/215

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
