### PR TITLE
Decrease base image size

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -5,12 +5,15 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y upgrade \
   && apt-get install --no-install-recommends -y sudo locales curl xz-utils ca-certificates openssl make git pkg-config \
   && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /usr/share/doc/* \
   && mkdir -m 0755 /nix && mkdir -m 0755 /etc/nix && groupadd -r nixbld && chown root /nix \
-  && printf 'sandbox = false \nfilter-syscalls = false' > /etc/nix/nix.conf \
+  && printf 'sandbox = false \nfilter-syscalls = false\n' > /etc/nix/nix.conf \
+  && printf 'experimental-features = nix-command\n' >> /etc/nix/nix.conf \
   && for n in $(seq 1 10); do useradd -c "Nix build user $n" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(command -v nologin)" "nixbld$n"; done
 
 SHELL ["/bin/bash", "-ol", "pipefail", "-c"]
 RUN set -o pipefail && curl -L https://nixos.org/nix/install | bash \
+    && /nix/var/nix/profiles/default/bin/nix-channel --remove nixpkgs \
     && /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-old \
     && printf 'if [ -d $HOME/.nix-profile/etc/profile.d ]; then\n for i in $HOME/.nix-profile/etc/profile.d/*.sh; do\n if [ -r $i ]; then\n . $i\n fi\n done\n fi\n' >> /root/.profile
 
@@ -26,5 +29,3 @@ ENV \
   CPATH=~/.nix-profile/include:$CPATH \
   LIBRARY_PATH=~/.nix-profile/lib:$LIBRARY_PATH \
   QTDIR=~/.nix-profile:$QTDIR
-
-RUN nix-channel --update

--- a/src/nixpacks/plan/merge.rs
+++ b/src/nixpacks/plan/merge.rs
@@ -13,7 +13,7 @@ impl Mergeable for BuildPlan {
         let plan2 = c2.clone();
 
         new_plan.providers = fill_auto_in_vec(new_plan.providers.clone(), plan2.providers.clone());
-        new_plan.build_image = new_plan.build_image.or(plan2.build_image);
+        new_plan.build_image = plan2.build_image.or(new_plan.build_image);
 
         new_plan.static_assets = match (new_plan.static_assets, plan2.static_assets) {
             (None, assets) | (assets, None) => assets,

--- a/src/nixpacks/plan/mod.rs
+++ b/src/nixpacks/plan/mod.rs
@@ -3,7 +3,7 @@ use self::{
     phase::{Phase, Phases, StartPhase},
     topological_sort::topological_sort,
 };
-use super::images::{DEBIAN_SLIM_IMAGE, DEFAULT_BASE_IMAGE};
+use super::images::DEFAULT_BASE_IMAGE;
 use crate::nixpacks::{
     app::{App, StaticAssets},
     environment::{Environment, EnvironmentVariables},
@@ -48,7 +48,6 @@ impl BuildPlan {
         Self {
             phases: Some(phases.iter().map(|p| (p.get_name(), p.clone())).collect()),
             start_phase,
-            build_image: Some(DEFAULT_BASE_IMAGE.to_string()),
             ..Default::default()
         }
     }
@@ -243,7 +242,7 @@ impl BuildPlan {
     pub fn pin(&mut self) {
         self.providers = Some(Vec::new());
         if self.build_image.is_none() {
-            self.build_image = Some(DEBIAN_SLIM_IMAGE.to_string());
+            self.build_image = Some(DEFAULT_BASE_IMAGE.to_string());
         }
 
         self.resolve_phase_names();


### PR DESCRIPTION
This PR decreases the base image size by 146MB by removing the default Nix channel since it is no longer needed. It is not needed since we pin all Nix packages by default so are installing the Nix packages from a remote archive. The default `<nixpkgs>` package is not needed and is just wasted space.

I've also fixed the merging of the build image on the plan.

![image](https://user-images.githubusercontent.com/3044853/189496280-024bdd99-cdf7-4aec-8ec4-185b016d21ad.png)

