### PR TITLE
Cache rust dependencies in tag workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           toolchain: stable
       
+      - uses: Swatinem/rust-cache@v2
+      
       - run: cargo install cargo-release
 
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR caches the result of `cargo install cargo-release`, so it doesn't waste time running it multiple-times.

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
