### PR TITLE
disable all standard filters by default with ignore

### DIFF
--- a/src/nixpacks/files.rs
+++ b/src/nixpacks/files.rs
@@ -6,10 +6,16 @@ pub fn recursive_copy_dir<T: AsRef<Path>, Q: AsRef<Path>>(source: T, dest: Q) ->
     let walker = WalkBuilder::new(&source)
         .follow_links(false)
         // this includes hidden directories & files
+        .standard_filters(false)
+        .git_ignore(true)
         .hidden(false)
         .build();
+
     for entry in walker {
         let entry = entry?;
+
+        println!("FILE: {:?}", entry.path());
+
         if let Some(file_type) = entry.file_type() {
             let from = entry.path();
             let to = dest.as_ref().join(from.strip_prefix(&source)?);

--- a/src/nixpacks/files.rs
+++ b/src/nixpacks/files.rs
@@ -14,8 +14,6 @@ pub fn recursive_copy_dir<T: AsRef<Path>, Q: AsRef<Path>>(source: T, dest: Q) ->
     for entry in walker {
         let entry = entry?;
 
-        println!("FILE: {:?}", entry.path());
-
         if let Some(file_type) = entry.file_type() {
             let from = entry.path();
             let to = dest.as_ref().join(from.strip_prefix(&source)?);


### PR DESCRIPTION
This PR ignores all standard filters with the `ignore` crate by default and only enables the `git_ignore` filter.


https://docs.rs/ignore/0.4.18/ignore/struct.WalkBuilder.html#method.standard_filters
