### PR TITLE
Allow specifying location of config file with env var

### DIFF
--- a/docs/pages/docs/cli.md
+++ b/docs/pages/docs/cli.md
@@ -24,24 +24,25 @@ nixpacks build --help
 
 ### Options
 
-|                             |                                                                |
-| :-------------------------- | :------------------------------------------------------------- |
-| `--install-cmd <cmd>`, `-i` | Specify the install command                                    |
-| `--build-cmd <cmd>`, `-b`   | Specify the build command                                      |
-| `--start-cmd <cmd>`, `-s`   | Specify the start command                                      |
-| `--name <name>`             | Name for the built image                                       |
-| `--env <envs...>`           | Provide environment variables to your build.                   |
-| `--pkgs <pkgs...>`, `-p`    | Provide additional Nix packages to install in the environment  |
-| `--apt <pkgs...>`           | Provide additional apt packages to install in the environment  |
-| `--libs <libs...>`          | Provide additional Nix libraries to install in the environment |
-| `--tag <tag...>`, `-t`      | Additional tags to add to the output image                     |
-| `--label <labels...>`, `-l` | Additional labels to add to the output image                   |
-| `--cache-key <key>`         | Unique identifier to use for the build cache                   |
-| `--no-cache`                | Disable caching for the build                                  |
-| `--cache-from`              | Image to consider as cache sources                             |
-| `--inline-cache`            | Enable writing cache metadata into the output image            |
-| `--out <dir>`, `-o`         | Save output directory instead of building it with Docker       |
-| `--platform <platforms...>` | Choosing the target platform for the target environment        |
+|                             |                                                                             |
+| :-------------------------- | :-------------------------------------------------------------------------- |
+| `--install-cmd <cmd>`, `-i` | Specify the install command                                                 |
+| `--build-cmd <cmd>`, `-b`   | Specify the build command                                                   |
+| `--start-cmd <cmd>`, `-s`   | Specify the start command                                                   |
+| `--name <name>`             | Name for the built image                                                    |
+| `--env <envs...>`           | Provide environment variables to your build.                                |
+| `--pkgs <pkgs...>`, `-p`    | Provide additional Nix packages to install in the environment               |
+| `--apt <pkgs...>`           | Provide additional apt packages to install in the environment               |
+| `--libs <libs...>`          | Provide additional Nix libraries to install in the environment              |
+| `--tag <tag...>`, `-t`      | Additional tags to add to the output image                                  |
+| `--label <labels...>`, `-l` | Additional labels to add to the output image                                |
+| `--cache-key <key>`         | Unique identifier to use for the build cache                                |
+| `--no-cache`                | Disable caching for the build                                               |
+| `--cache-from`              | Image to consider as cache sources                                          |
+| `--inline-cache`            | Enable writing cache metadata into the output image                         |
+| `--out <dir>`, `-o`         | Save output directory instead of building it with Docker                    |
+| `--platform <platforms...>` | Choosing the target platform for the target environment                     |
+| `--config <file>`           | Location of the Nixpacks configuration file relative to the root of the app |
 
 #### Environment Variables
 

--- a/docs/pages/docs/configuration/environment.md
+++ b/docs/pages/docs/configuration/environment.md
@@ -17,3 +17,4 @@ Nixpacks can be configured via environment variables. All of these variables are
 | `NIXPACKS_INSTALL_CACHE_DIRS` | Add additional directories to cache during the install phase                                 |
 | `NIXPACKS_BUILD_CACHE_DIRS`   | Add additional directories to cache during the build phase                                   |
 | `NIXPACKS_NO_CACHE`           | Disable caching for the build                                                                |
+| `NIXPACKS_CONFIG_FILE`        | Location of the Nixpacks configuration file relative to the root of the app                  |

--- a/docs/pages/docs/configuration/file.md
+++ b/docs/pages/docs/configuration/file.md
@@ -4,7 +4,7 @@ title: Configuration File
 
 # {% $markdoc.frontmatter.title %}
 
-Nixpacks has **experimental** support for specifying build configuration in a `nixpacks.toml` or `nixpacks.json` file. The config will automatically be used if one of these files is found in the app root. Otherwise, the file can be specified with the `--config <file>` flag.
+Nixpacks has **experimental** support for specifying build configuration in a `nixpacks.toml` or `nixpacks.json` file. The config will automatically be used if one of these files is found in the app root. Otherwise, the file can be specified with the `--config <file>` flag or with the `NIXPACKS_CONFIG_FILE` environment variable.
 
 The contents of this file can contain a full build plan, which means that every aspect of the build can be customized. An example config looks something like:
 

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -145,7 +145,7 @@ impl NixpacksBuildPlanGenerator<'_> {
     fn read_file_plan(&self, app: &App, env: &Environment) -> Result<BuildPlan> {
         let file_path = if let Some(file_path) = &self.config.config_file {
             Some(file_path.clone())
-        } else if let Some(env_config_file) = env.get_config_variable("CONFIG") {
+        } else if let Some(env_config_file) = env.get_config_variable("CONFIG_FILE") {
             if !app.includes_file(&env_config_file) {
                 bail!("Config file {} does not exist", env_config_file);
             }

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -49,7 +49,7 @@ impl NixpacksBuildPlanGenerator<'_> {
 
     /// Get a build plan from the provider and by applying the config from the environment
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<BuildPlan> {
-        let file_plan = self.read_file_plan(app)?;
+        let file_plan = self.read_file_plan(app, env)?;
         let env_plan = BuildPlan::from_environment(env);
         let cli_plan = self.config.plan.clone().unwrap_or_default();
         let plan_before_providers = BuildPlan::merge_plans(&vec![file_plan, env_plan, cli_plan]);
@@ -142,9 +142,15 @@ impl NixpacksBuildPlanGenerator<'_> {
         Ok(plan)
     }
 
-    fn read_file_plan(&self, app: &App) -> Result<BuildPlan> {
+    fn read_file_plan(&self, app: &App, env: &Environment) -> Result<BuildPlan> {
         let file_path = if let Some(file_path) = &self.config.config_file {
             Some(file_path.clone())
+        } else if let Some(env_config_file) = env.get_config_variable("CONFIG") {
+            if !app.includes_file(&env_config_file) {
+                bail!("Config file {} does not exist", env_config_file);
+            }
+
+            Some(env_config_file)
         } else if app.includes_file("nixpacks.toml") {
             Some("nixpacks.toml".to_owned())
         } else if app.includes_file("nixpacks.json") {


### PR DESCRIPTION
This PR adds a `NIXPACKS_CONFIG_FILE` environment variable that can be used to specify the location of the `nixpacks.toml` file.
