### PR TITLE
Improve tagging CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '(cargo-release)')"
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.10.0
@@ -40,6 +41,7 @@ jobs:
   lints:
     name: Lints
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '(cargo-release)')"
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.10.0
@@ -80,6 +82,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     outputs:
       matrix: ${{ steps.docker-prep.outputs.matrix }}
+    if: "!contains(github.event.head_commit.message, '(cargo-release)')"
     steps:      
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.10.0
@@ -116,6 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{fromJson(needs.test-plan.outputs.matrix)}}
+    if: "!contains(github.event.head_commit.message, '(cargo-release)')"
     steps:      
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.10.0
@@ -146,6 +150,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, '(cargo-release)')"
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.10.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,14 +12,6 @@ jobs:
     if: "!contains(github.event.head_commit.message, '(cargo-release)')"
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for tests to succeed
-        uses: lewagon/wait-on-check-action@v1.1.2
-        with:
-          ref: ${{ github.ref }}
-          running-workflow-name: CI
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-          
       - name: checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR removes the need to wait for another workflow to succeed, and instead just skips running CI (the ci.yml workflow) on commits containing (`cargo-release`)

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
