### PR TITLE
Use which to find binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +414,7 @@ dependencies = [
  "uuid",
  "wait-timeout",
  "walkdir",
+ "which",
 ]
 
 [[package]]
@@ -835,6 +842,17 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ cargo_toml = "0.11.6"
 rand = "0.8.5"
 path-slash = "0.2.1"
 ignore = "0.4.18"
+which = "4.3.0"
 
 [dev-dependencies]
 dotenv-parser = "0.1.3"

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -96,7 +96,7 @@ impl DockerImageBuilder {
         name: &str,
         output: &OutputDir,
     ) -> Result<Command> {
-        let mut docker_build_cmd = Command::new("docker");
+        let mut docker_build_cmd = Command::new(which::which("docker")?);
 
         if docker_build_cmd.output().is_err() {
             bail!("Please install Docker to build the app https://docs.docker.com/engine/install/")

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -96,7 +96,7 @@ impl DockerImageBuilder {
         name: &str,
         output: &OutputDir,
     ) -> Result<Command> {
-        let mut docker_build_cmd = Command::new(which::which("docker")?);
+        let mut docker_build_cmd = Command::new(which::which("docker").unwrap());
 
         if docker_build_cmd.output().is_err() {
             bail!("Please install Docker to build the app https://docs.docker.com/engine/install/")

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -96,7 +96,11 @@ impl DockerImageBuilder {
         name: &str,
         output: &OutputDir,
     ) -> Result<Command> {
-        let mut docker_build_cmd = Command::new(which::which("docker").unwrap());
+        let mut docker_build_cmd = Command::new(
+            which::which("docker")
+                .context("The docker binary could not be found")
+                .unwrap(),
+        );
 
         if docker_build_cmd.output().is_err() {
             bail!("Please install Docker to build the app https://docs.docker.com/engine/install/")

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -16,7 +16,8 @@ use rand::thread_rng;
 use rand::{distributions::Alphanumeric, Rng};
 
 fn get_container_ids_from_image(image: &str) -> String {
-    let output = Command::new("docker")
+    // just unwrapping here is fine - the which error is clearer
+    let output = Command::new(which::which("docker").unwrap())
         .arg("ps")
         .arg("-a")
         .arg("-q")
@@ -29,7 +30,7 @@ fn get_container_ids_from_image(image: &str) -> String {
 }
 
 fn stop_containers(container_id: &str) {
-    Command::new("docker")
+    Command::new(which::which("docker").unwrap())
         .arg("stop")
         .arg(container_id)
         .spawn()
@@ -40,7 +41,7 @@ fn stop_containers(container_id: &str) {
 }
 
 fn remove_containers(container_id: &str) {
-    Command::new("docker")
+    Command::new(which::which("docker").unwrap())
         .arg("rm")
         .arg(container_id)
         .spawn()
@@ -70,7 +71,7 @@ struct Config {
 /// Runs an image with Docker and returns the output
 /// The image is automatically stopped and removed after `TIMEOUT_SECONDS`
 fn run_image(name: &str, cfg: Option<Config>) -> String {
-    let mut cmd = Command::new("docker");
+    let mut cmd = Command::new(which::which("docker").unwrap());
     cmd.arg("run");
 
     if let Some(config) = cfg {
@@ -149,7 +150,7 @@ struct Network {
 }
 
 fn attach_container_to_network(network_name: String, container_name: String) {
-    Command::new("docker")
+    Command::new(which::which("docker").unwrap())
         .arg("network")
         .arg("connect")
         .arg(network_name)
@@ -164,7 +165,7 @@ fn attach_container_to_network(network_name: String, container_name: String) {
 fn create_network() -> Network {
     let network_name = format!("test-net-{}", Uuid::new_v4());
 
-    Command::new("docker")
+    Command::new(which::which("docker").unwrap())
         .arg("network")
         .arg("create")
         .arg(network_name.clone())
@@ -178,7 +179,7 @@ fn create_network() -> Network {
 }
 
 fn remove_network(network_name: String) {
-    Command::new("docker")
+    Command::new(which::which("docker").unwrap())
         .arg("network")
         .arg("rm")
         .arg(network_name)
@@ -195,7 +196,7 @@ struct Container {
 }
 
 fn run_postgres() -> Container {
-    let mut docker_cmd = Command::new("docker");
+    let mut docker_cmd = Command::new(which::which("docker").unwrap());
 
     let hash = Uuid::new_v4().to_string();
     let container_name = format!("postgres-{}", hash);
@@ -249,7 +250,7 @@ fn run_postgres() -> Container {
 }
 
 fn run_mysql() -> Container {
-    let mut docker_cmd = Command::new("docker");
+    let mut docker_cmd = Command::new(which::which("docker").unwrap());
 
     let hash = Uuid::new_v4().to_string();
     let container_name = format!("mysql-{}", hash);
@@ -288,7 +289,7 @@ fn run_mysql() -> Container {
     // MySQL starts listening for connections after it has initialised its default database
     // so wait until mysqladmin ping via TCP succeeds (or we timeout)
     let test_loop = format!("while ! mysqladmin ping --password={} -h localhost --port=3306 --protocol=TCP 2> /dev/null ; do echo 'waiting for mysql'; sleep 1; done", &password);
-    let mut docker_exec_cmd = Command::new("docker");
+    let mut docker_exec_cmd = Command::new(which::which("docker").unwrap());
     docker_exec_cmd
         .arg("exec")
         .arg(container_name.clone())

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -17,38 +17,50 @@ use rand::{distributions::Alphanumeric, Rng};
 
 fn get_container_ids_from_image(image: &str) -> String {
     // just unwrapping here is fine - the which error is clearer
-    let output = Command::new(which::which("docker").unwrap())
-        .arg("ps")
-        .arg("-a")
-        .arg("-q")
-        .arg("--filter")
-        .arg(format!("ancestor={}", image))
-        .output()
-        .expect("failed to execute docker ps");
+    let output = Command::new(
+        which::which("docker")
+            .context("The docker binary could not be found")
+            .unwrap(),
+    )
+    .arg("ps")
+    .arg("-a")
+    .arg("-q")
+    .arg("--filter")
+    .arg(format!("ancestor={}", image))
+    .output()
+    .expect("failed to execute docker ps");
 
     String::from_utf8_lossy(&output.stdout).to_string()
 }
 
 fn stop_containers(container_id: &str) {
-    Command::new(which::which("docker").unwrap())
-        .arg("stop")
-        .arg(container_id)
-        .spawn()
-        .unwrap()
-        .wait()
-        .context("Stopping container")
-        .unwrap();
+    Command::new(
+        which::which("docker")
+            .context("The docker binary could not be found")
+            .unwrap(),
+    )
+    .arg("stop")
+    .arg(container_id)
+    .spawn()
+    .unwrap()
+    .wait()
+    .context("Stopping container")
+    .unwrap();
 }
 
 fn remove_containers(container_id: &str) {
-    Command::new(which::which("docker").unwrap())
-        .arg("rm")
-        .arg(container_id)
-        .spawn()
-        .unwrap()
-        .wait()
-        .context("Removing container")
-        .unwrap();
+    Command::new(
+        which::which("docker")
+            .context("The docker binary could not be found")
+            .unwrap(),
+    )
+    .arg("rm")
+    .arg(container_id)
+    .spawn()
+    .unwrap()
+    .wait()
+    .context("Removing container")
+    .unwrap();
 }
 
 fn stop_and_remove_container_by_image(image: &str) {
@@ -71,7 +83,11 @@ struct Config {
 /// Runs an image with Docker and returns the output
 /// The image is automatically stopped and removed after `TIMEOUT_SECONDS`
 fn run_image(name: &str, cfg: Option<Config>) -> String {
-    let mut cmd = Command::new(which::which("docker").unwrap());
+    let mut cmd = Command::new(
+        which::which("docker")
+            .context("The docker binary could not be found")
+            .unwrap(),
+    );
     cmd.arg("run");
 
     if let Some(config) = cfg {
@@ -150,44 +166,56 @@ struct Network {
 }
 
 fn attach_container_to_network(network_name: String, container_name: String) {
-    Command::new(which::which("docker").unwrap())
-        .arg("network")
-        .arg("connect")
-        .arg(network_name)
-        .arg(container_name)
-        .spawn()
-        .unwrap()
-        .wait()
-        .context("Setting up network")
-        .unwrap();
+    Command::new(
+        which::which("docker")
+            .context("The docker binary could not be found")
+            .unwrap(),
+    )
+    .arg("network")
+    .arg("connect")
+    .arg(network_name)
+    .arg(container_name)
+    .spawn()
+    .unwrap()
+    .wait()
+    .context("Setting up network")
+    .unwrap();
 }
 
 fn create_network() -> Network {
     let network_name = format!("test-net-{}", Uuid::new_v4());
 
-    Command::new(which::which("docker").unwrap())
-        .arg("network")
-        .arg("create")
-        .arg(network_name.clone())
-        .spawn()
-        .unwrap()
-        .wait()
-        .context("Setting up network")
-        .unwrap();
+    Command::new(
+        which::which("docker")
+            .context("The docker binary could not be found")
+            .unwrap(),
+    )
+    .arg("network")
+    .arg("create")
+    .arg(network_name.clone())
+    .spawn()
+    .unwrap()
+    .wait()
+    .context("Setting up network")
+    .unwrap();
 
     Network { name: network_name }
 }
 
 fn remove_network(network_name: String) {
-    Command::new(which::which("docker").unwrap())
-        .arg("network")
-        .arg("rm")
-        .arg(network_name)
-        .spawn()
-        .unwrap()
-        .wait()
-        .context("Tearing down network")
-        .unwrap();
+    Command::new(
+        which::which("docker")
+            .context("The docker binary could not be found")
+            .unwrap(),
+    )
+    .arg("network")
+    .arg("rm")
+    .arg(network_name)
+    .spawn()
+    .unwrap()
+    .wait()
+    .context("Tearing down network")
+    .unwrap();
 }
 
 struct Container {
@@ -196,7 +224,11 @@ struct Container {
 }
 
 fn run_postgres() -> Container {
-    let mut docker_cmd = Command::new(which::which("docker").unwrap());
+    let mut docker_cmd = Command::new(
+        which::which("docker")
+            .context("The docker binary could not be found")
+            .unwrap(),
+    );
 
     let hash = Uuid::new_v4().to_string();
     let container_name = format!("postgres-{}", hash);
@@ -250,7 +282,11 @@ fn run_postgres() -> Container {
 }
 
 fn run_mysql() -> Container {
-    let mut docker_cmd = Command::new(which::which("docker").unwrap());
+    let mut docker_cmd = Command::new(
+        which::which("docker")
+            .context("The docker binary could not be found")
+            .unwrap(),
+    );
 
     let hash = Uuid::new_v4().to_string();
     let container_name = format!("mysql-{}", hash);
@@ -289,7 +325,11 @@ fn run_mysql() -> Container {
     // MySQL starts listening for connections after it has initialised its default database
     // so wait until mysqladmin ping via TCP succeeds (or we timeout)
     let test_loop = format!("while ! mysqladmin ping --password={} -h localhost --port=3306 --protocol=TCP 2> /dev/null ; do echo 'waiting for mysql'; sleep 1; done", &password);
-    let mut docker_exec_cmd = Command::new(which::which("docker").unwrap());
+    let mut docker_exec_cmd = Command::new(
+        which::which("docker")
+            .context("The docker binary could not be found")
+            .unwrap(),
+    );
     docker_exec_cmd
         .arg("exec")
         .arg(container_name.clone())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR uses the `which` crate to find binaries.

It is fine to unwrap directly after calling the function as it is more descriptive than the standard error we would print (which is current behaviour).

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
