### PR TITLE
Softer NX requirements

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -1,25 +1,20 @@
-use self::nx::{Nx, ProjectJson};
+use self::nx::Nx;
 use super::Provider;
-use crate::{
-    nixpacks::{
-        app::App,
-        environment::{Environment, EnvironmentVariables},
-        nix::pkg::Pkg,
-        plan::{
-            phase::{Phase, StartPhase},
-            BuildPlan,
-        },
+use crate::nixpacks::{
+    app::App,
+    environment::{Environment, EnvironmentVariables},
+    nix::pkg::Pkg,
+    plan::{
+        phase::{Phase, StartPhase},
+        BuildPlan,
     },
-    providers::node::nx::NxJson,
 };
-use anyhow::{bail, Result};
+use anyhow::Result;
 use path_slash::PathExt;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-};
+use std::collections::{HashMap, HashSet};
+
 mod nx;
 
 pub const NODE_OVERLAY: &str = "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz";
@@ -142,7 +137,7 @@ impl NodeProvider {
 
     pub fn get_build_cmd(app: &App, env: &Environment) -> Result<Option<String>> {
         if Nx::is_nx_monorepo(app, env) {
-            if let Some(nx_build_cmd) = Nx::get_nx_build_cmd(app, env)? {
+            if let Some(nx_build_cmd) = Nx::get_nx_build_cmd(app, env) {
                 return Ok(Some(nx_build_cmd));
             }
         }

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -1,4 +1,4 @@
-use self::nx::ProjectJson;
+use self::nx::{Nx, ProjectJson};
 use super::Provider;
 use crate::{
     nixpacks::{
@@ -12,8 +12,7 @@ use crate::{
     },
     providers::node::nx::NxJson,
 };
-use anyhow::bail;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use path_slash::PathExt;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -34,7 +33,6 @@ const NPM_CACHE_DIR: &str = "/root/.npm";
 const BUN_CACHE_DIR: &str = "/root/.bun";
 const CYPRESS_CACHE_DIR: &str = "/root/.cache/Cypress";
 const NODE_MODULES_CACHE_DIR: &str = "node_modules/.cache";
-const NX_APP_NAME_ENV_VAR: &str = "NX_APP_NAME";
 
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub struct PackageJson {
@@ -96,15 +94,7 @@ impl Provider for NodeProvider {
         }
 
         // Build
-        let mut build = if NodeProvider::is_nx_monorepo(app) {
-            let app_name = NodeProvider::get_nx_app_name(app, env)?.unwrap();
-            Phase::build(Some(format!("npx nx run {}:build:production", app_name)))
-        } else if NodeProvider::has_script(app, "build")? {
-            let pkg_manager = NodeProvider::get_package_manager(app);
-            Phase::build(Some(format!("{} run build", pkg_manager)))
-        } else {
-            Phase::build(None)
-        };
+        let mut build = Phase::build(NodeProvider::get_build_cmd(app, env)?);
 
         // Next build cache directories
         let next_cache_dirs = NodeProvider::find_next_packages(app)?;
@@ -150,34 +140,26 @@ impl NodeProvider {
         Ok(false)
     }
 
+    pub fn get_build_cmd(app: &App, env: &Environment) -> Result<Option<String>> {
+        if Nx::is_nx_monorepo(app, env) {
+            if let Some(nx_build_cmd) = Nx::get_nx_build_cmd(app, env)? {
+                return Ok(Some(nx_build_cmd));
+            }
+        }
+
+        if NodeProvider::has_script(app, "build")? {
+            let pkg_manager = NodeProvider::get_package_manager(app);
+            Ok(Some(format!("{} run build", pkg_manager)))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub fn get_start_cmd(app: &App, env: &Environment) -> Result<Option<String>> {
-        if NodeProvider::is_nx_monorepo(app) {
-            let app_name = NodeProvider::get_nx_app_name(app, env)?.unwrap();
-            let output_path = NodeProvider::get_nx_output_path(app, env)?;
-            let project_json = NodeProvider::get_nx_project_json_for_app(app, env)?;
-
-            if let Some(start_target) = project_json.targets.start {
-                if start_target.configurations.is_some()
-                    && start_target.configurations.unwrap().production.is_some()
-                {
-                    return Ok(Some(format!("npx nx run {}:start:production ", app_name)));
-                }
-                return Ok(Some(format!("npx nx run {}:start", app_name)));
+        if Nx::is_nx_monorepo(app, env) {
+            if let Some(nx_start_cmd) = Nx::get_nx_start_cmd(app, env)? {
+                return Ok(Some(nx_start_cmd));
             }
-
-            if project_json.targets.build.executor == "@nrwl/next:build" {
-                return Ok(Some(format!("cd {} && npm run start", output_path)));
-            }
-
-            if let Some(options) = project_json.targets.build.options {
-                if let Some(main_path) = options.main {
-                    let current_path = PathBuf::from(main_path.as_str().unwrap());
-                    let file_name = current_path.file_stem().unwrap().to_str().unwrap();
-
-                    return Ok(Some(format!("node {}/{}.js", output_path, file_name)));
-                }
-            }
-            return Ok(Some(format!("node {}/index.js", output_path)));
         }
 
         let package_manager = NodeProvider::get_package_manager(app);
@@ -412,47 +394,6 @@ impl NodeProvider {
         all_deps.extend(dev_deps.into_iter());
 
         all_deps
-    }
-
-    pub fn is_nx_monorepo(app: &App) -> bool {
-        app.includes_file("nx.json")
-    }
-
-    pub fn get_nx_app_name(app: &App, env: &Environment) -> Result<Option<String>> {
-        if let Some(app_name) = env.get_config_variable(NX_APP_NAME_ENV_VAR) {
-            return Ok(Some(app_name));
-        }
-
-        if let Ok(nx_json) = app.read_json::<NxJson>("nx.json") {
-            if let Some(default_project) = nx_json.default_project {
-                return Ok(Some(default_project.as_str().unwrap().to_owned()));
-            }
-        }
-
-        bail!("Could not derive nx app to build and run. Please add a default project to your nx config or set NIXPACKS_{}", NX_APP_NAME_ENV_VAR);
-    }
-
-    pub fn get_nx_project_json_for_app(app: &App, env: &Environment) -> Result<ProjectJson> {
-        let app_name = NodeProvider::get_nx_app_name(app, env)?.unwrap();
-        let project_path = format!("./apps/{}/project.json", app_name);
-        app.read_json::<ProjectJson>(&project_path)
-    }
-
-    pub fn get_nx_output_path(app: &App, env: &Environment) -> Result<String> {
-        let project_json = NodeProvider::get_nx_project_json_for_app(app, env)?;
-        if let Some(options) = project_json.targets.build.options {
-            if let Some(output_path) = options.output_path {
-                if let Some(the_output_path) = output_path.as_str() {
-                    return Ok(the_output_path.to_string());
-                }
-            }
-        }
-
-        if let Ok(Some(app_name)) = NodeProvider::get_nx_app_name(app, env) {
-            return Ok(format!("dist/apps/{}", app_name));
-        };
-
-        bail!("Could not derive nx output path. Please add an output_path to your project.json");
     }
 }
 

--- a/src/providers/node/nx.rs
+++ b/src/providers/node/nx.rs
@@ -1,12 +1,17 @@
 // Code relating to NX Monorepos
 
+use std::path::PathBuf;
+
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+use crate::nixpacks::{app::App, environment::Environment};
 
 #[derive(Debug, Serialize, PartialEq, Eq, Deserialize)]
 pub struct NxJson {
     #[serde(alias = "defaultProject")]
-    pub default_project: Option<Value>,
+    pub default_project: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq, Deserialize)]
@@ -31,10 +36,100 @@ pub struct Target {
 pub struct NxTargetOptions {
     #[serde(alias = "outputPath")]
     pub output_path: Option<Value>,
-    pub main: Option<Value>,
+    pub main: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq, Deserialize)]
 pub struct Configuration {
     pub production: Option<Value>,
+}
+
+pub struct Nx {}
+
+const NX_APP_NAME_ENV_VAR: &str = "NX_APP_NAME";
+
+impl Nx {
+    pub fn is_nx_monorepo(app: &App, env: &Environment) -> bool {
+        // Only consider an Nx app if an nx app name and project path can be found
+        if let Some(nx_app_name) = Nx::get_nx_app_name(app, env) {
+            return app.includes_file("nx.json")
+                && Nx::get_nx_project_json_for_app(app, &nx_app_name).is_ok();
+        }
+
+        false
+    }
+
+    pub fn get_nx_app_name(app: &App, env: &Environment) -> Option<String> {
+        if let Some(app_name) = env.get_config_variable(NX_APP_NAME_ENV_VAR) {
+            return Some(app_name);
+        }
+
+        if let Ok(nx_json) = app.read_json::<NxJson>("nx.json") {
+            return nx_json.default_project;
+        }
+
+        None
+    }
+
+    pub fn get_nx_project_json_for_app(app: &App, nx_app_name: &String) -> Result<ProjectJson> {
+        let project_path = format!("./apps/{}/project.json", nx_app_name);
+        app.read_json::<ProjectJson>(&project_path)
+    }
+
+    pub fn get_nx_output_path(app: &App, nx_app_name: &String) -> Result<String> {
+        let project_json = Nx::get_nx_project_json_for_app(app, nx_app_name)?;
+        if let Some(options) = project_json.targets.build.options {
+            if let Some(output_path) = options.output_path {
+                if let Some(the_output_path) = output_path.as_str() {
+                    return Ok(the_output_path.to_string());
+                }
+            }
+        }
+
+        Ok(format!("dist/apps/{}", nx_app_name))
+    }
+
+    pub fn get_nx_build_cmd(app: &App, env: &Environment) -> Result<Option<String>> {
+        if let Some(nx_app_name) = Nx::get_nx_app_name(app, env) {
+            Ok(Some(format!("npx nx run {}:build:production", nx_app_name)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn get_nx_start_cmd(app: &App, env: &Environment) -> Result<Option<String>> {
+        if !Nx::is_nx_monorepo(app, env) {
+            return Ok(None);
+        }
+
+        if let Some(nx_app_name) = Nx::get_nx_app_name(app, env) {
+            let output_path = Nx::get_nx_output_path(app, &nx_app_name)?;
+            let project_json = Nx::get_nx_project_json_for_app(app, &nx_app_name)?;
+
+            if let Some(start_target) = project_json.targets.start {
+                if let Some(configurations) = start_target.configurations {
+                    if configurations.production.is_some() {
+                        return Ok(Some(format!("npx nx run {}:start:production", nx_app_name)));
+                    }
+                }
+                return Ok(Some(format!("npx nx run {}:start", nx_app_name)));
+            }
+
+            if project_json.targets.build.executor == "@nrwl/next:build" {
+                return Ok(Some(format!("cd {} && npm run start", output_path)));
+            }
+
+            if let Some(options) = project_json.targets.build.options {
+                if let Some(main_path) = options.main {
+                    let current_path = PathBuf::from(main_path);
+                    let file_name = current_path.file_stem().unwrap().to_str().unwrap();
+
+                    return Ok(Some(format!("node {}/{}.js", output_path, file_name)));
+                }
+            }
+            return Ok(Some(format!("node {}/index.js", output_path)));
+        }
+
+        Ok(None)
+    }
 }

--- a/src/providers/node/nx.rs
+++ b/src/providers/node/nx.rs
@@ -89,12 +89,8 @@ impl Nx {
         Ok(format!("dist/apps/{}", nx_app_name))
     }
 
-    pub fn get_nx_build_cmd(app: &App, env: &Environment) -> Result<Option<String>> {
-        if let Some(nx_app_name) = Nx::get_nx_app_name(app, env) {
-            Ok(Some(format!("npx nx run {}:build:production", nx_app_name)))
-        } else {
-            Ok(None)
-        }
+    pub fn get_nx_build_cmd(app: &App, env: &Environment) -> Option<String> {
+        Nx::get_nx_app_name(app, env).map(|nx_app_name| format!("npx nx run {}:build:production", nx_app_name))
     }
 
     pub fn get_nx_start_cmd(app: &App, env: &Environment) -> Result<Option<String>> {

--- a/src/providers/node/nx.rs
+++ b/src/providers/node/nx.rs
@@ -90,7 +90,8 @@ impl Nx {
     }
 
     pub fn get_nx_build_cmd(app: &App, env: &Environment) -> Option<String> {
-        Nx::get_nx_app_name(app, env).map(|nx_app_name| format!("npx nx run {}:build:production", nx_app_name))
+        Nx::get_nx_app_name(app, env)
+            .map(|nx_app_name| format!("npx nx run {}:build:production", nx_app_name))
     }
 
     pub fn get_nx_start_cmd(app: &App, env: &Environment) -> Result<Option<String>> {

--- a/src/providers/php/mod.rs
+++ b/src/providers/php/mod.rs
@@ -136,27 +136,27 @@ impl PhpProvider {
     fn get_php_version(app: &App) -> Result<String> {
         let composer_json: ComposerJson = app.read_json("composer.json")?;
         let version = composer_json.require.get("php").cloned();
-        Ok(match version {
-            Some(v) => {
-                if v.contains("8.0") {
-                    "8.0".to_string()
-                } else if v.contains("8.1") {
-                    "8.1".to_string()
-                } else if v.contains("7.4") {
-                    "7.4".to_string()
-                } else {
-                    println!(
-                        "Warning: PHP version {} is not available, using PHP {}",
-                        v, DEFAULT_PHP_VERSION
-                    );
-                    DEFAULT_PHP_VERSION.to_string()
-                }
-            }
-            None => {
-                println!("Warning: No PHP version specified, using PHP {}; see https://getcomposer.org/doc/04-schema.md#package-links for how to specify a PHP version.", DEFAULT_PHP_VERSION);
+
+        let version = if let Some(v) = version {
+            if v.contains("8.0") {
+                "8.0".to_string()
+            } else if v.contains("8.1") {
+                "8.1".to_string()
+            } else if v.contains("7.4") {
+                "7.4".to_string()
+            } else {
+                println!(
+                    "Warning: PHP version {} is not available, using PHP {}",
+                    v, DEFAULT_PHP_VERSION
+                );
                 DEFAULT_PHP_VERSION.to_string()
             }
-        })
+        } else {
+            println!("Warning: No PHP version specified, using PHP {}; see https://getcomposer.org/doc/04-schema.md#package-links for how to specify a PHP version.", DEFAULT_PHP_VERSION);
+            DEFAULT_PHP_VERSION.to_string()
+        };
+
+        Ok(version)
     }
 
     fn get_php_extensions(app: &App) -> Result<Vec<String>> {


### PR DESCRIPTION
Fixes https://github.com/railwayapp/nixpacks/issues/566

Currently, if we detect a `nx.json` file in the root of the Node app we will treat the app as a Nx workspace and error if other the app is not setup in a perfect Nx way. This is a problem for legacy Nx apps that use the depreated `workspace.json` as we assume the location of apps are in the `apps/` directory. The treatment as an Nx app can also have other issues if the user just wants to opt-out of the automatic Nx features and manually specify the build/start commands.

So in this PR, I've
- Removed a few of the unwraps and bails
- Only detect as Nx app if an Nx app name and project directory can be found (fallback to regular node if not)
- Moved the Nx logic to the `nx.rs` file and trait impl