### PR TITLE
Optimize installation of packages

### DIFF
--- a/.github/workflows/update-nixpkgs-archive.yml
+++ b/.github/workflows/update-nixpkgs-archive.yml
@@ -32,9 +32,9 @@ jobs:
           URL="$(echo $COMMIT_INFO | jq -r ".html_url")"
           DATE="$(date "+%Y-%m-%d %H:%M:%S %Z%z")"
 
-          sed -i "/\/\/ Last Modified:/c\/\/ Last Modified: ${DATE}" src/nixpacks/plan/generator.rs
-          sed -i "/\/\/ https:\/\/github.com\/NixOS\/nixpkgs\/commit/c\/\/ $URL" src/nixpacks/plan/generator.rs
-          sed -i "/const NIXPKGS_ARCHIVE: &str/c\pub const NIXPKGS_ARCHIVE: &str = \"$SHA\";" src/nixpacks/plan/generator.rs
+          sed -i "/\/\/ Last Modified:/c\/\/ Last Modified: ${DATE}" src/nixpacks/nix/mod.rs
+          sed -i "/\/\/ https:\/\/github.com\/NixOS\/nixpkgs\/commit/c\/\/ $URL" src/nixpacks/nix/mod.rs
+          sed -i "/const NIXPKGS_ARCHIVE: &str/c\pub const NIXPKGS_ARCHIVE: &str = \"$SHA\";" src/nixpacks/nix/mod.rs
 
           echo "::set-output name=sha::$SHA"
           echo "::set-output name=url::$URL"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,12 @@ use crate::nixpacks::{
     environment::Environment,
     logger::Logger,
     nix::pkg::Pkg,
-    plan::{generator::NixpacksBuildPlanGenerator, BuildPlan, PlanGenerator},
+    plan::{
+        generator::{GeneratePlanOptions, NixpacksBuildPlanGenerator},
+        BuildPlan, PlanGenerator,
+    },
 };
 use anyhow::Result;
-use nixpacks::plan::generator::GeneratePlanOptions;
 use providers::{
     clojure::ClojureProvider, crystal::CrystalProvider, csharp::CSharpProvider, dart::DartProvider,
     deno::DenoProvider, elixir::ElixirProvider, fsharp::FSharpProvider, go::GolangProvider,

--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -3,7 +3,7 @@ use crate::nixpacks::{
     app,
     environment::Environment,
     images::DEFAULT_BASE_IMAGE,
-    nix,
+    nix::{self, create_nix_expressions_for_phases, nix_file_names_for_phases},
     plan::{
         phase::{Phase, StartPhase},
         BuildPlan,
@@ -13,6 +13,7 @@ use anyhow::{Context, Ok, Result};
 use indoc::formatdoc;
 use path_slash::PathBufExt;
 use std::{
+    collections::BTreeMap,
     fs::{self, File},
     io::Write,
     path::{Path, PathBuf},
@@ -101,6 +102,33 @@ impl DockerfileGenerator for BuildPlan {
     ) -> Result<String> {
         let plan = self;
 
+        let nix_file_names = nix_file_names_for_phases(&plan.phases.clone().unwrap_or_default());
+
+        let mut nix_install_cmds: Vec<String> = Vec::new();
+        for name in nix_file_names {
+            let nix_file = output.get_relative_path(name);
+
+            let nix_file_path = nix_file
+                .to_slash()
+                .context("Failed to convert nix file path to slash path.")?;
+
+            nix_install_cmds.push(format!(
+                "COPY {nix_file_path} {nix_file_path}\nRUN nix-env -if {nix_file_path} && nix-collect-garbage -d",
+                nix_file_path = nix_file_path
+            ));
+        }
+        let nix_install_cmds = nix_install_cmds.join("\n");
+
+        let apt_pkgs = self.all_apt_packages();
+        let apt_pkgs_str = if apt_pkgs.is_empty() {
+            "".to_string()
+        } else {
+            format!(
+                "RUN apt-get update && apt-get install -y --no-install-recommends {}",
+                apt_pkgs.join(" ")
+            )
+        };
+
         let variables = plan.variables.clone().unwrap_or_default();
         let args_string = if variables.is_empty() {
             "".to_string()
@@ -147,30 +175,10 @@ impl DockerfileGenerator for BuildPlan {
                             phase.get_name()
                         ))?;
 
-                match phase.get_name().as_str() {
-                    // We want to load the variables immediately after the setup phase
-                    "setup" => Ok(format!(
-                        "{}\n# load variables\n{}\n",
-                        phase_dockerfile, args_string
-                    )),
-                    _ => Ok(phase_dockerfile),
-                }
+                Ok(phase_dockerfile)
             })
-            .collect::<Result<Vec<_>>>();
-        let dockerfile_phases_str = dockerfile_phases?.join("\n");
-
-        // Handle the case where there is only a setup phase and all the app files have not been copied into
-        // the image yet
-        let setup_copy_command = match (phases.first(), phases.len()) {
-            (Some(first_phase), 1) => {
-                if first_phase.get_name() == "setup" {
-                    utils::get_copy_command(&[".".to_string()], APP_DIR)
-                } else {
-                    "".to_string()
-                }
-            }
-            _ => "".to_string(),
-        };
+            .collect::<Result<Vec<_>>>()?;
+        let dockerfile_phases_str = dockerfile_phases.join("\n");
 
         let start_phase_str = plan
             .start_phase
@@ -189,18 +197,22 @@ impl DockerfileGenerator for BuildPlan {
             ENTRYPOINT [\"/bin/bash\", \"-l\", \"-c\"]
             WORKDIR {APP_DIR}
 
+            {nix_install_cmds}
+            {apt_pkgs_str}
             {assets_copy_cmd}
+            {args_string}
 
             {dockerfile_phases_str}
 
-            {setup_copy_command}
             {start_phase_str}
         ", 
         base_image=base_image,
         APP_DIR=APP_DIR,
+        nix_install_cmds=nix_install_cmds,
+        apt_pkgs_str=apt_pkgs_str,
         assets_copy_cmd=assets_copy_cmd,
+        args_string=args_string,
         dockerfile_phases_str=dockerfile_phases_str,
-        setup_copy_command=setup_copy_command,
         start_phase_str=start_phase_str};
 
         Ok(dockerfile)
@@ -213,6 +225,17 @@ impl DockerfileGenerator for BuildPlan {
         output: &OutputDir,
     ) -> Result<()> {
         self.write_assets(self, output).context("Writing assets")?;
+
+        let nix_expressions =
+            create_nix_expressions_for_phases(&self.phases.clone().unwrap_or_default());
+
+        for (name, nix_expression) in nix_expressions {
+            let nix_path = output.get_absolute_path(name);
+            let mut nix_file = File::create(nix_path).context("Creating Nix environment file")?;
+            nix_file
+                .write_all(nix_expression.as_bytes())
+                .context("Unable to write Nix expression")?;
+        }
 
         for phase in self.get_sorted_phases()? {
             phase
@@ -245,6 +268,15 @@ impl BuildPlan {
         }
 
         Ok(())
+    }
+
+    fn all_apt_packages(&self) -> Vec<String> {
+        self.phases
+            .clone()
+            .unwrap_or_default()
+            .values()
+            .flat_map(|phase| phase.apt_pkgs.clone().unwrap_or_default())
+            .collect()
     }
 }
 
@@ -325,37 +357,9 @@ impl DockerfileGenerator for Phase {
             ("".to_string(), "".to_string())
         };
 
-        // Install nix packages and libraries
-        let install_nix_pkgs_str = if self.uses_nix() {
-            let nix_file = output.get_relative_path(format!("{}.nix", phase.get_name()));
-
-            let nix_file_path = nix_file
-                .to_slash()
-                .context("Failed to convert nix file path to slash path.")?;
-            format!(
-                "COPY {nix_file_path} {nix_file_path}\nRUN nix-env -if {nix_file_path} && nix-collect-garbage -d",
-                nix_file_path = nix_file_path
-            )
-        } else {
-            "".to_string()
-        };
-
-        // Install apt packages
-        let apt_pkgs = phase.apt_pkgs.clone().unwrap_or_default();
-        let apt_pkgs_str = if apt_pkgs.is_empty() {
-            "".to_string()
-        } else {
-            format!(
-                "RUN apt-get update && apt-get install -y {}",
-                apt_pkgs.join(" ")
-            )
-        };
-
         // Copy over app files
         let phase_files = match (phase.get_name().as_str(), &phase.only_include_files) {
             (_, Some(files)) => files.clone(),
-            // Special case for the setup phase, which has no files
-            ("setup", None) => vec![],
             _ => vec![".".to_string()],
         };
         let phase_copy_cmd = utils::get_copy_command(&phase_files, APP_DIR);
@@ -370,18 +374,11 @@ impl DockerfileGenerator for Phase {
             .collect::<Vec<_>>()
             .join("\n");
 
-        let dockerfile_stmts = vec![
-            build_path,
-            run_path,
-            install_nix_pkgs_str,
-            apt_pkgs_str,
-            phase_copy_cmd,
-            cmds_str,
-        ]
-        .into_iter()
-        .filter(|stmt| !stmt.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n");
+        let dockerfile_stmts = vec![build_path, run_path, phase_copy_cmd, cmds_str]
+            .into_iter()
+            .filter(|stmt| !stmt.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
 
         let dockerfile = formatdoc! {"
             # {name} phase
@@ -398,20 +395,8 @@ impl DockerfileGenerator for Phase {
         &self,
         _options: &DockerBuilderOptions,
         _env: &Environment,
-        output: &OutputDir,
+        _output: &OutputDir,
     ) -> Result<()> {
-        if self.uses_nix() {
-            // Write the Nix expressions to the output directory
-            let nix_file_name = format!("{}.nix", self.get_name());
-            let nix_path = output.get_absolute_path(nix_file_name);
-            let nix_expression = nix::create_nix_expression(self);
-
-            let mut nix_file = File::create(nix_path).context("Creating Nix environment file")?;
-            nix_file
-                .write_all(nix_expression.as_bytes())
-                .context("Unable to write Nix expression")?;
-        }
-
         Ok(())
     }
 }

--- a/src/nixpacks/nix/mod.rs
+++ b/src/nixpacks/nix/mod.rs
@@ -1,6 +1,5 @@
 use super::plan::phase::{Phase, Phases};
 use indoc::formatdoc;
-use itertools::*;
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
@@ -86,8 +85,8 @@ fn nix_expression_for_group(group: &NixGroup) -> String {
         .archive
         .clone()
         .unwrap_or_else(|| NIXPKGS_ARCHIVE.to_string());
-    let pkgs = group.pkgs.clone().into_iter().join(" ");
-    let libs = group.libs.clone().into_iter().join(" ");
+    let pkgs = group.pkgs.clone().join(" ");
+    let libs = group.libs.clone().join(" ");
     let overlays_string = group
         .overlays
         .iter()

--- a/src/nixpacks/nix/mod.rs
+++ b/src/nixpacks/nix/mod.rs
@@ -1,45 +1,150 @@
 use super::plan::phase::{Phase, Phases};
 use indoc::formatdoc;
 use itertools::*;
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 pub mod pkg;
+
+// This line is automatically updated.
+// Last Modified: 2022-09-12 17:11:54 UTC+0000
+// https://github.com/NixOS/nixpkgs/commit/a0b7e70db7a55088d3de0cc370a59f9fbcc906c3
+pub const NIXPKGS_ARCHIVE: &str = "a0b7e70db7a55088d3de0cc370a59f9fbcc906c3";
 
 #[derive(Debug, Clone)]
 struct NixGroup {
     archive: Option<String>,
     pkgs: Vec<String>,
     libs: Vec<String>,
+    overlays: Vec<String>,
 }
 
-fn group_nix_packages_by_archive(
-    phases: &Vec<Phase>,
-) -> BTreeMap<Option<String>, (Vec<String>, Vec<String>)> {
-    let mut archive_to_packages: BTreeMap<Option<String>, (Vec<String>, Vec<String>)> =
-        BTreeMap::new();
+fn group_nix_packages_by_archive(phases: &Vec<Phase>) -> Vec<NixGroup> {
+    // Mapping from nixpkgs archive to (packages, libraries)
+    let mut archive_to_packages: BTreeMap<Option<String>, NixGroup> = BTreeMap::new();
 
-    let groups = phases.clone().into_iter().map(|phase| NixGroup {
-        archive: phase.nixpkgs_archive,
-        pkgs: phase.nix_pkgs.unwrap_or_default(),
-        libs: phase.nix_libs.unwrap_or_default(),
-    });
+    let groups = phases
+        .clone()
+        .into_iter()
+        .filter(|phase| phase.uses_nix())
+        .map(|phase| NixGroup {
+            archive: phase.nixpkgs_archive,
+            pkgs: phase.nix_pkgs.unwrap_or_default(),
+            libs: phase.nix_libs.unwrap_or_default(),
+            overlays: phase.nix_overlays.unwrap_or_default(),
+        });
 
     for g in groups {
         match archive_to_packages.get_mut(&g.archive) {
-            Some((pkgs, libs)) => {
-                pkgs.extend(g.pkgs);
-                libs.extend(g.libs);
+            Some(group) => {
+                group.pkgs.extend(g.pkgs);
+                group.libs.extend(g.libs);
+                group.overlays.extend(g.overlays);
             }
             None => {
-                archive_to_packages.insert(g.archive, (g.pkgs, g.libs));
+                archive_to_packages.insert(g.archive.clone(), g);
             }
         }
     }
 
-    archive_to_packages
+    archive_to_packages.values().map(|g| g.clone()).collect()
 }
 
-pub fn create_nix_expression_2(phases: &Phase) {}
+pub fn create_nix_expressions_for_phases(phases: &Phases) -> BTreeMap<String, String> {
+    let archive_to_packages =
+        group_nix_packages_by_archive(&phases.values().map(|p| p.clone()).collect());
+
+    archive_to_packages
+        .iter()
+        .fold(BTreeMap::new(), |mut acc, g| {
+            acc.insert(nix_file_name(&g.archive), nix_expression_for_group(g));
+            acc
+        })
+}
+
+pub fn nix_file_names_for_phases(phases: &Phases) -> Vec<String> {
+    let archives = BTreeSet::from_iter(
+        phases
+            .values()
+            .filter(|p| p.uses_nix())
+            .map(|p| p.nixpkgs_archive.clone()),
+    );
+    archives.iter().map(|a| nix_file_name(a)).collect()
+}
+
+fn nix_file_name(archive: &Option<String>) -> String {
+    match archive {
+        Some(archive) => format!("nixpkgs-{}.nix", archive),
+        None => "nixpkgs.nix".to_string(),
+    }
+}
+
+fn nix_expression_for_group(group: &NixGroup) -> String {
+    let archive = group
+        .archive
+        .clone()
+        .unwrap_or_else(|| NIXPKGS_ARCHIVE.to_string());
+    let pkgs = group.pkgs.clone().into_iter().join(" ");
+    let libs = group.libs.clone().into_iter().join(" ");
+    let overlays_string = group
+        .overlays
+        .iter()
+        .map(|url| format!("(import (builtins.fetchTarball \"{}\"))", url))
+        .collect::<Vec<String>>()
+        .join("\n");
+
+    let pkg_import = format!(
+        "import (fetchTarball \"https://github.com/NixOS/nixpkgs/archive/{}.tar.gz\")",
+        archive
+    );
+
+    // If the openssl library is added, set the OPENSSL_DIR and OPENSSL_LIB_DIR environment variables
+    // In the future, we will probably want a generic way for providers to set variables based off Nix package locations
+    let openssl_dirs = if libs.contains("openssl") {
+        formatdoc! {"
+          export OPENSSL_DIR=\"${{openssl.dev}}\"
+          export OPENSSL_LIB_DIR=\"${{openssl.out}}/lib\"
+        "}
+    } else {
+        String::new()
+    };
+
+    let name = format!("{}-env", archive);
+    let nix_expression = formatdoc! {"
+            {{ }}:
+
+            let pkgs = {} {{ overlays = [ {} ]; }};
+            in with pkgs;
+              let
+                APPEND_LIBRARY_PATH = \"${{lib.makeLibraryPath [ {} ] }}\";
+                myLibraries = writeText \"libraries\" ''
+                  export LD_LIBRARY_PATH=\"${{APPEND_LIBRARY_PATH}}:$LD_LIBRARY_PATH\"
+                  {}
+                '';
+              in
+                buildEnv {{
+                  name = \"{name}\";
+                  paths = [
+                    (runCommand \"{name}\" {{ }} ''
+                      mkdir -p $out/etc/profile.d
+                      cp ${{myLibraries}} $out/etc/profile.d/{name}.sh
+                    '')
+                    {}
+                  ];
+                }}
+        ",
+        pkg_import,
+        overlays_string,
+        libs,
+        openssl_dirs,
+        pkgs,
+        name=name,
+    };
+
+    nix_expression
+}
 
 pub fn create_nix_expression(phase: &Phase) -> String {
     let nixpkgs = phase.nix_pkgs.clone().unwrap_or_default().join(" ");

--- a/src/nixpacks/nix/mod.rs
+++ b/src/nixpacks/nix/mod.rs
@@ -19,7 +19,6 @@ struct NixGroup {
 }
 
 fn group_nix_packages_by_archive(phases: &[Phase]) -> Vec<NixGroup> {
-    // Mapping from nixpkgs archive to (packages, libraries)
     let mut archive_to_packages: BTreeMap<Option<String>, NixGroup> = BTreeMap::new();
 
     let groups = phases

--- a/src/nixpacks/nix/mod.rs
+++ b/src/nixpacks/nix/mod.rs
@@ -1,9 +1,7 @@
-use super::plan::phase::{Phase, Phases};
 use indoc::formatdoc;
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-};
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::nixpacks::plan::phase::{Phase, Phases};
 
 pub mod pkg;
 
@@ -12,7 +10,7 @@ pub mod pkg;
 // https://github.com/NixOS/nixpkgs/commit/a0b7e70db7a55088d3de0cc370a59f9fbcc906c3
 pub const NIXPKGS_ARCHIVE: &str = "a0b7e70db7a55088d3de0cc370a59f9fbcc906c3";
 
-#[derive(Debug, Clone)]
+#[derive(Eq, PartialEq, Default, Debug, Clone)]
 struct NixGroup {
     archive: Option<String>,
     pkgs: Vec<String>,
@@ -20,19 +18,18 @@ struct NixGroup {
     overlays: Vec<String>,
 }
 
-fn group_nix_packages_by_archive(phases: &Vec<Phase>) -> Vec<NixGroup> {
+fn group_nix_packages_by_archive(phases: &[Phase]) -> Vec<NixGroup> {
     // Mapping from nixpkgs archive to (packages, libraries)
     let mut archive_to_packages: BTreeMap<Option<String>, NixGroup> = BTreeMap::new();
 
     let groups = phases
-        .clone()
-        .into_iter()
+        .iter()
         .filter(|phase| phase.uses_nix())
         .map(|phase| NixGroup {
-            archive: phase.nixpkgs_archive,
-            pkgs: phase.nix_pkgs.unwrap_or_default(),
-            libs: phase.nix_libs.unwrap_or_default(),
-            overlays: phase.nix_overlays.unwrap_or_default(),
+            archive: phase.nixpkgs_archive.clone(),
+            pkgs: phase.nix_pkgs.clone().unwrap_or_default(),
+            libs: phase.nix_libs.clone().unwrap_or_default(),
+            overlays: phase.nix_overlays.clone().unwrap_or_default(),
         });
 
     for g in groups {
@@ -48,12 +45,19 @@ fn group_nix_packages_by_archive(phases: &Vec<Phase>) -> Vec<NixGroup> {
         }
     }
 
-    archive_to_packages.values().map(|g| g.clone()).collect()
+    archive_to_packages
+        .values()
+        .map(std::clone::Clone::clone)
+        .collect()
 }
 
 pub fn create_nix_expressions_for_phases(phases: &Phases) -> BTreeMap<String, String> {
-    let archive_to_packages =
-        group_nix_packages_by_archive(&phases.values().map(|p| p.clone()).collect());
+    let archive_to_packages = group_nix_packages_by_archive(
+        &phases
+            .values()
+            .map(std::clone::Clone::clone)
+            .collect::<Vec<_>>(),
+    );
 
     archive_to_packages
         .iter()
@@ -64,13 +68,12 @@ pub fn create_nix_expressions_for_phases(phases: &Phases) -> BTreeMap<String, St
 }
 
 pub fn nix_file_names_for_phases(phases: &Phases) -> Vec<String> {
-    let archives = BTreeSet::from_iter(
-        phases
-            .values()
-            .filter(|p| p.uses_nix())
-            .map(|p| p.nixpkgs_archive.clone()),
-    );
-    archives.iter().map(|a| nix_file_name(a)).collect()
+    let archives = phases
+        .values()
+        .filter(|p| p.uses_nix())
+        .map(|p| p.nixpkgs_archive.clone())
+        .collect::<BTreeSet<_>>();
+    archives.iter().map(nix_file_name).collect()
 }
 
 fn nix_file_name(archive: &Option<String>) -> String {
@@ -145,74 +148,6 @@ fn nix_expression_for_group(group: &NixGroup) -> String {
     nix_expression
 }
 
-pub fn create_nix_expression(phase: &Phase) -> String {
-    let nixpkgs = phase.nix_pkgs.clone().unwrap_or_default().join(" ");
-
-    let libraries = phase.nix_libs.clone().unwrap_or_default().join(" ");
-
-    let nix_archive = phase.nixpkgs_archive.clone();
-    let pkg_import = match nix_archive {
-        Some(archive) => format!(
-            "import (fetchTarball \"https://github.com/NixOS/nixpkgs/archive/{}.tar.gz\")",
-            archive
-        ),
-        None => "import <nixpkgs>".to_string(),
-    };
-
-    let overlays = phase.nix_overlays.clone().unwrap_or_default();
-
-    let overlays_string = overlays
-        .iter()
-        .map(|url| format!("(import (builtins.fetchTarball \"{}\"))", url))
-        .collect::<Vec<String>>()
-        .join("\n");
-
-    // If the openssl library is added, set the OPENSSL_DIR and OPENSSL_LIB_DIR environment variables
-    // In the future, we will probably want a generic way for providers to set variables based off Nix package locations
-    let openssl_dirs = if libraries.contains("openssl") {
-        formatdoc! {"
-          export OPENSSL_DIR=\"${{openssl.dev}}\"
-          export OPENSSL_LIB_DIR=\"${{openssl.out}}/lib\"
-        "}
-    } else {
-        String::new()
-    };
-
-    let name = format!("{}-env", phase.get_name());
-    let nix_expression = formatdoc! {"
-            {{ }}:
-
-            let pkgs = {} {{ overlays = [ {} ]; }};
-            in with pkgs;
-              let
-                APPEND_LIBRARY_PATH = \"${{lib.makeLibraryPath [ {} ] }}\";
-                myLibraries = writeText \"libraries\" ''
-                  export LD_LIBRARY_PATH=\"${{APPEND_LIBRARY_PATH}}:$LD_LIBRARY_PATH\"
-                  {}
-                '';
-              in
-                buildEnv {{
-                  name = \"{name}\";
-                  paths = [
-                    (runCommand \"{name}\" {{ }} ''
-                      mkdir -p $out/etc/profile.d
-                      cp ${{myLibraries}} $out/etc/profile.d/{name}.sh
-                    '')
-                    {}
-                  ];
-                }}
-        ",
-        pkg_import,
-        overlays_string,
-        libraries,
-        openssl_dirs,
-        nixpkgs,
-        name=name,
-    };
-
-    nix_expression
-}
-
 #[cfg(test)]
 mod tests {
     use super::{pkg::Pkg, *};
@@ -230,15 +165,22 @@ mod tests {
         let groups = group_nix_packages_by_archive(&vec![setup1, setup2, setup3]);
         assert_eq!(groups.len(), 2);
         assert_eq!(
-            groups.get(&None).unwrap(),
-            &(
-                vec!["foo".to_string(), "bar".to_string(), "baz".to_string()],
-                vec!["lib1".to_string()]
-            )
+            groups[0],
+            NixGroup {
+                archive: None,
+                pkgs: vec!["foo".to_string(), "bar".to_string(), "baz".to_string()],
+                libs: vec!["lib1".to_string()],
+                overlays: vec![]
+            }
         );
         assert_eq!(
-            groups.get(&Some("archive2".to_string())).unwrap(),
-            &(vec!["hello".to_string(), "world".to_string()], vec![])
+            groups[1],
+            NixGroup {
+                archive: Some("archive2".to_string()),
+                pkgs: vec!["hello".to_string(), "world".to_string()],
+                libs: vec![],
+                overlays: vec![]
+            }
         );
     }
 }

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -13,10 +13,6 @@ use colored::Colorize;
 
 use super::merge::Mergeable;
 
-// This line is automatically updated.
-// Last Modified: 2022-09-12 17:11:54 UTC+0000
-// https://github.com/NixOS/nixpkgs/commit/a0b7e70db7a55088d3de0cc370a59f9fbcc906c3
-pub const NIXPKGS_ARCHIVE: &str = "a0b7e70db7a55088d3de0cc370a59f9fbcc906c3";
 const NIXPACKS_METADATA: &str = "NIXPACKS_METADATA";
 
 #[derive(Clone, Default, Debug)]

--- a/src/nixpacks/plan/phase.rs
+++ b/src/nixpacks/plan/phase.rs
@@ -1,7 +1,6 @@
-use super::generator::NIXPKGS_ARCHIVE;
 use crate::nixpacks::{
     images::{DEBIAN_SLIM_IMAGE, DEFAULT_BASE_IMAGE},
-    nix::pkg::Pkg,
+    nix::{pkg::Pkg, NIXPKGS_ARCHIVE},
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;


### PR DESCRIPTION
This PR moves the installation of Nix and Apt packages to the start of the Dockerfile for **all** phases. Previously the Nix and Apt packages were installed separatly for each phase. When multiple providers are used (coming soon), this can be fairly inefficient. Moving all the package installations to the start speeds up the build.
