### PR TITLE
Configuring builds guide

### DIFF
--- a/docs/pages/docs/configuration/file.md
+++ b/docs/pages/docs/configuration/file.md
@@ -1,5 +1,5 @@
 ---
-title: Configuration File
+title: Configuration File Reference
 ---
 
 # {% $markdoc.frontmatter.title %}

--- a/docs/pages/docs/guides/configuring-builds.md
+++ b/docs/pages/docs/guides/configuring-builds.md
@@ -1,0 +1,69 @@
+---
+title: Configuring Builds
+---
+
+# {% $markdoc.frontmatter.title %}
+
+This guide goes over a few common configuration scenarios so you can quickly get
+up and running. For a complete reference of what is possible, please see the
+[read the file configuration docs](/docs/configuration/file).
+
+## Install additional packages
+
+You can easily install additional Nix or Apt packages so that they are available during the the build or at runtime. Packages are typically installed in the setup phase.
+
+```toml
+[phases.setup]
+nixPkgs = ["...", "ffmpeg"] # Install the ffmpeg package from Nix
+aptPkgs = ["...", "wget"] # Install the wget package with apt-get
+```
+
+The `"..."` item in the array is important as it extends the packages that will
+be installed as opposed to overrides them. This means that packages from the
+provider (e.g. Node, Cargo, Python) will also installed.
+
+It is recommended to install packages from Nix rather than Apt if they are available. You can search for Nix packages [here](https://search.nixos.org/packages?channel=unstable).
+
+## Custom start command
+
+Override the command that is run when your container starts by setting the `start.cmd` value.
+
+```toml
+[start]
+cmd = "./start.sh"
+```
+
+## Custom build command
+
+You can override the build command with
+
+```toml
+[phases.build]
+cmds = ["echo building!"]
+```
+
+Or you can add commands that will be run before or after the commands set by the providers.
+
+```toml
+[phases.build]
+cmds = ["echo first", "...", "echo last"]
+```
+
+The same can be done to custom the commands for other phases.
+
+## New phase
+
+Provider will typically define setup, install, and build phases. But you can add as many as you want. The following example will lint before the build and run tests afterwards.
+
+```toml
+[phases.lint]
+cmds = ["yarn run lint"]
+dependsOn = ["install"]
+
+[phases.build]
+dependsOn = ["...", "lint"]
+
+[phases.test]
+cmds = ["yarn run test"]
+dependsOn = ["build"]
+```

--- a/docs/pages/docs/guides/configuring-builds.md
+++ b/docs/pages/docs/guides/configuring-builds.md
@@ -15,7 +15,7 @@ You can easily install additional Nix or Apt packages so that they are available
 ```toml
 [phases.setup]
 nixPkgs = ["...", "ffmpeg"] # Install the ffmpeg package from Nix
-aptPkgs = ["...", "wget"] # Install the wget package with apt-get
+aptPkgs = ["...", "wget"]   # Install the wget package with apt-get
 ```
 
 The `"..."` item in the array is important as it extends the packages that will

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -12,10 +12,19 @@ export const sidebarItems: ISidebarSection[] = [
   { href: "/docs/install", text: "Installation" },
   { href: "/docs/how-it-works", text: "How it Works" },
   {
+    text: "Guides",
+    links: [
+      { text: "Configuring Builds", href: "/docs/guides/configuring-builds" },
+    ],
+  },
+  {
     text: "Configuration",
     links: [
-      { text: "Configuration File", href: "/docs/configuration/file" },
-      { text: "Environment", href: "/docs/configuration/environment" },
+      { text: "File", href: "/docs/configuration/file" },
+      {
+        text: "Environment",
+        href: "/docs/configuration/environment",
+      },
       { text: "Procfile", href: "/docs/configuration/procfile" },
       { text: "Caching", href: "/docs/configuration/caching" },
     ],


### PR DESCRIPTION
This PR creates a short guide on common uses cases for configuring builds with a `nixpacks.toml` file.

<img width="1484" alt="image" src="https://user-images.githubusercontent.com/3044853/193336279-3f6cd38d-6df4-4e77-a346-9c3f4d700fe3.png">
