### PR TITLE
fix(install): update PATH envvar on pwsh script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -46,8 +46,12 @@ tar.exe xf $NixpacksZip -C $BinDir
 
 Remove-Item $NixpacksZip
 
-if (($Env:Path -contains "nixpacks")) {
-    $Env:Path += ";$BinDir"
+$User = [EnvironmentVariableTarget]::User
+$Path = [Environment]::GetEnvironmentVariable('Path', $User)
+if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
+  [Environment]::SetEnvironmentVariable('Path', "$Path;$BinDir", $User)
+  $Env:Path += ";$BinDir"
 }
+
 Write-Output "Nixpacks was installed successfully to $NixpacksExe"
 Write-Output "Run 'nixpacks --help' to get started"


### PR DESCRIPTION
Update the `PATH` environment variable after installing, so `nixpacks` is available to use in the shell.