### PR TITLE
fix: get version from .yarnrc.yml

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -249,12 +249,15 @@ impl NodeProvider {
             install_cmd = "pnpm i --frozen-lockfile".to_string();
         } else if package_manager == "yarn" {
             if app.includes_file(".yarnrc.yml") {
+                install_cmd = "yarn set version berry && yarn install --check-cache".to_string();
                 let yarnrc_yml: Yarnrc = app.read_yaml(".yarnrc.yml").unwrap_or_default();
-                let version = yarnrc_yml.yarn_path.unwrap_or_else(|| "berry".to_string());
-                install_cmd = format!(
-                    "yarn set version ./{} && yarn install --check-cache",
-                    version
-                );
+                let path = yarnrc_yml.yarn_path;
+                if path.is_some() {
+                    install_cmd = format!(
+                        "yarn set version ./{} && yarn install --check-cache",
+                        path.unwrap()
+                    );
+                }
             } else {
                 install_cmd = "yarn install --frozen-lockfile".to_string();
             }

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -251,7 +251,10 @@ impl NodeProvider {
             if app.includes_file(".yarnrc.yml") {
                 let yarnrc_yml: Yarnrc = app.read_yaml(".yarnrc.yml").unwrap_or_default();
                 let version = yarnrc_yml.yarn_path.unwrap_or_else(|| "berry".to_string());
-                install_cmd = format!("yarn set version ./{} && yarn install --check-cache", version);
+                install_cmd = format!(
+                    "yarn set version ./{} && yarn install --check-cache",
+                    version
+                );
             } else {
                 install_cmd = "yarn install --frozen-lockfile".to_string();
             }

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -251,7 +251,7 @@ impl NodeProvider {
             if app.includes_file(".yarnrc.yml") {
                 let yarnrc_yml: Yarnrc = app.read_yaml(".yarnrc.yml").unwrap_or_default();
                 let version = yarnrc_yml.yarn_path.unwrap_or_else(|| "berry".to_string());
-                install_cmd = format!("yarn set version {} && yarn install --check-cache", version);
+                install_cmd = format!("yarn set version ./{} && yarn install --check-cache", version);
             } else {
                 install_cmd = "yarn install --frozen-lockfile".to_string();
             }

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -42,6 +42,12 @@ pub struct PackageJson {
     pub project_type: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct Yarnrc {
+    #[serde(rename = "yarnPath")]
+    pub yarn_path: Option<String>,
+}
+
 #[derive(Default, Debug)]
 pub struct NodeProvider {}
 
@@ -237,23 +243,25 @@ impl NodeProvider {
             return None;
         }
 
-        let mut install_cmd = "npm i";
+        let mut install_cmd = "npm i".to_string();
         let package_manager = NodeProvider::get_package_manager(app);
         if package_manager == "pnpm" {
-            install_cmd = "pnpm i --frozen-lockfile";
+            install_cmd = "pnpm i --frozen-lockfile".to_string();
         } else if package_manager == "yarn" {
             if app.includes_file(".yarnrc.yml") {
-                install_cmd = "yarn set version berry && yarn install --check-cache";
+                let yarnrc_yml: Yarnrc = app.read_yaml(".yarnrc.yml").unwrap_or_default();
+                let version = yarnrc_yml.yarn_path.unwrap_or_else(|| "berry".to_string());
+                install_cmd = format!("yarn set version {} && yarn install --check-cache", version);
             } else {
-                install_cmd = "yarn install --frozen-lockfile";
+                install_cmd = "yarn install --frozen-lockfile".to_string();
             }
         } else if app.includes_file("package-lock.json") {
-            install_cmd = "npm ci";
+            install_cmd = "npm ci".to_string();
         } else if app.includes_file("bun.lockb") {
-            install_cmd = "bun i --no-save";
+            install_cmd = "bun i --no-save".to_string();
         }
 
-        Some(install_cmd.to_string())
+        Some(install_cmd)
     }
 
     fn get_package_manager_cache_dir(app: &App) -> String {

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -251,12 +251,9 @@ impl NodeProvider {
             if app.includes_file(".yarnrc.yml") {
                 install_cmd = "yarn set version berry && yarn install --check-cache".to_string();
                 let yarnrc_yml: Yarnrc = app.read_yaml(".yarnrc.yml").unwrap_or_default();
-                let path = yarnrc_yml.yarn_path;
-                if path.is_some() {
-                    install_cmd = format!(
-                        "yarn set version ./{} && yarn install --check-cache",
-                        path.unwrap()
-                    );
+                if let Some(path) = yarnrc_yml.yarn_path {
+                    install_cmd =
+                        format!("yarn set version ./{} && yarn install --check-cache", path);
                 }
             } else {
                 install_cmd = "yarn install --frozen-lockfile".to_string();

--- a/tests/snapshots/generate_plan_tests__build.snap
+++ b/tests/snapshots/generate_plan_tests__build.snap
@@ -1,9 +1,0 @@
----
-source: tests/generate_plan_tests.rs
-expression: plan
----
-{
-  "providers": [],
-  "buildImage": "[build_image]",
-  "phases": {}
-}

--- a/tests/snapshots/generate_plan_tests__build.snap
+++ b/tests/snapshots/generate_plan_tests__build.snap
@@ -1,0 +1,9 @@
+---
+source: tests/generate_plan_tests.rs
+expression: plan
+---
+{
+  "providers": [],
+  "buildImage": "[build_image]",
+  "phases": {}
+}

--- a/tests/snapshots/generate_plan_tests__node_yarn_berry.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn_berry.snap
@@ -30,7 +30,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "yarn set version berry && yarn install --check-cache"
+        "yarn set version .yarn/releases/yarn-3.2.4.cjs && yarn install --check-cache"
       ],
       "cacheDirectories": [
         "/usr/local/share/.cache/yarn/v6"

--- a/tests/snapshots/generate_plan_tests__node_yarn_berry.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn_berry.snap
@@ -30,7 +30,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "yarn set version .yarn/releases/yarn-3.2.4.cjs && yarn install --check-cache"
+        "yarn set version ./.yarn/releases/yarn-3.2.4.cjs && yarn install --check-cache"
       ],
       "cacheDirectories": [
         "/usr/local/share/.cache/yarn/v6"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR replaces `berry` with `.yarnrc.yml's yarnPath` (if it exists) as default version for node(yarn) provider.

fixes #621 

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
