### PR TITLE
Include no files in ruby setup phase

### DIFF
--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -60,6 +60,9 @@ impl RubyProvider {
         let mut setup = Phase::setup(None);
         setup.add_apt_pkgs(vec!["procps".to_string()]);
 
+        // Don't re-install ruby if the code has changed
+        setup.only_include_files = Some(Vec::new());
+
         if self.uses_postgres(app)? {
             setup.add_apt_pkgs(vec!["libpq-dev".to_string()]);
         }

--- a/tests/snapshots/generate_plan_tests__ruby.snap
+++ b/tests/snapshots/generate_plan_tests__ruby.snap
@@ -40,7 +40,8 @@ expression: plan
         "rvm --default use ruby-3.1.2",
         "gem install bundler:2.3.7",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
-      ]
+      ],
+      "onlyIncludeFiles": []
     }
   },
   "start": {

--- a/tests/snapshots/generate_plan_tests__ruby_execjs.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_execjs.snap
@@ -63,7 +63,8 @@ expression: plan
         "rvm --default use ruby-3.1.2",
         "gem install bundler:2.3.7",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
-      ]
+      ],
+      "onlyIncludeFiles": []
     }
   },
   "start": {

--- a/tests/snapshots/generate_plan_tests__ruby_local_deps.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_local_deps.snap
@@ -40,7 +40,8 @@ expression: plan
         "rvm --default use ruby-3.1.2",
         "gem install bundler:2.3.7",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
-      ]
+      ],
+      "onlyIncludeFiles": []
     }
   },
   "start": {

--- a/tests/snapshots/generate_plan_tests__ruby_rails_postgres.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_rails_postgres.snap
@@ -51,7 +51,8 @@ expression: plan
         "rvm --default use 3.1.2",
         "gem install bundler:2.3.7",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
-      ]
+      ],
+      "onlyIncludeFiles": []
     }
   },
   "start": {

--- a/tests/snapshots/generate_plan_tests__ruby_sinatra.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_sinatra.snap
@@ -40,7 +40,8 @@ expression: plan
         "rvm --default use ruby-3.1.2",
         "gem install bundler:2.3.7",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
-      ]
+      ],
+      "onlyIncludeFiles": []
     }
   },
   "start": {

--- a/tests/snapshots/generate_plan_tests__ruby_with_node.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_with_node.snap
@@ -66,7 +66,8 @@ expression: plan
         "rvm --default use ruby-3.1.2",
         "gem install bundler:2.3.7",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
-      ]
+      ],
+      "onlyIncludeFiles": []
     }
   },
   "start": {


### PR DESCRIPTION
This PR includes no app source files in the setup phase when Ruby is being installed. This should allow us to take advantage of the Docker layer cache and not re-install Ruby everytime the source code changes.

Fixes https://github.com/railwayapp/nixpacks/issues/624