### PR TITLE
support any package.json workspaces value

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -13,6 +13,7 @@ use anyhow::Result;
 use path_slash::PathExt;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 
 mod nx;
@@ -30,6 +31,13 @@ const BUN_CACHE_DIR: &str = "/root/.bun";
 const CYPRESS_CACHE_DIR: &str = "/root/.cache/Cypress";
 const NODE_MODULES_CACHE_DIR: &str = "node_modules/.cache";
 
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum Workspaces {
+    Array(Vec<String>),
+    Unknown(Value),
+}
+
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub struct PackageJson {
     pub name: Option<String>,
@@ -42,7 +50,7 @@ pub struct PackageJson {
     #[serde(rename = "type")]
     pub project_type: Option<String>,
 
-    pub workspaces: Option<Vec<String>>,
+    pub workspaces: Option<Workspaces>,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]

--- a/src/providers/node/turborepo.rs
+++ b/src/providers/node/turborepo.rs
@@ -4,7 +4,10 @@ use std::{collections::HashMap, error::Error};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::nixpacks::{app::App, environment::Environment};
+use crate::{
+    nixpacks::{app::App, environment::Environment},
+    providers::node::Workspaces,
+};
 
 use super::{NodeProvider, PackageJson};
 
@@ -79,12 +82,10 @@ impl Turborepo {
                 app,
                 if pkg_manager == "pnpm" {
                     pnpm_workspaces(app)?
+                } else if let Some(Workspaces::Array(workspaces)) = &package_json.workspaces {
+                    workspaces.clone()
                 } else {
-                    package_json
-                        .workspaces
-                        .as_ref()
-                        .unwrap_or(&Vec::default())
-                        .clone()
+                    Vec::default()
                 },
                 &name,
             )? {


### PR DESCRIPTION
The `workspaces` key in `package.json` is typically an array of workspaces. However, it can be any object. Nixpacks should not crash if an array is not found. This PR handles that case gracefully.
