### PR TITLE
Detect command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,19 @@ pub fn generate_build_plan(
     Ok(plan)
 }
 
+pub fn get_plan_providers(
+    path: &str,
+    envs: Vec<&str>,
+    options: &GeneratePlanOptions,
+) -> Result<Vec<String>> {
+    let app = App::new(path)?;
+    let environment = Environment::from_envs(envs)?;
+
+    let generator = NixpacksBuildPlanGenerator::new(get_providers(), options.clone());
+
+    generator.get_plan_providers(&app, &environment)
+}
+
 pub fn create_docker_image(
     path: &str,
     envs: Vec<&str>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use clap::{arg, Arg, Command};
 use nixpacks::{
-    create_docker_image, generate_build_plan,
+    create_docker_image, generate_build_plan, get_plan_providers,
     nixpacks::{
         builder::docker::DockerBuilderOptions,
         nix::pkg::Pkg,
@@ -282,7 +282,10 @@ fn main() -> Result<()> {
             println!("{}", plan_s);
         }
         Some(("detect", matches)) => {
-            println!("DETECT!")
+            let path = matches.value_of("PATH").unwrap_or(".");
+
+            let providers = get_plan_providers(path, envs, &options)?;
+            println!("{}", providers.join(", "));
         }
         Some(("build", matches)) => {
             let path = matches.value_of("PATH").unwrap_or(".");

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,11 @@ fn main() -> Result<()> {
                 ),
         )
         .subcommand(
+            Command::new("detect")
+                .about("List all of the providers that will be used to build the app")
+                .arg(arg!([PATH] "App source")),
+        )
+        .subcommand(
             Command::new("build")
                 .about("Create a docker image for an app")
                 .arg(arg!([PATH] "App source"))
@@ -275,6 +280,9 @@ fn main() -> Result<()> {
             };
 
             println!("{}", plan_s);
+        }
+        Some(("detect", matches)) => {
+            println!("DETECT!")
         }
         Some(("build", matches)) => {
             let path = matches.value_of("PATH").unwrap_or(".");

--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -124,7 +124,7 @@ impl DockerfileGenerator for BuildPlan {
 
         let apt_pkgs = self.all_apt_packages();
         let apt_pkgs_str = if apt_pkgs.is_empty() {
-            "".to_string()
+            String::new()
         } else {
             format!(
                 "RUN apt-get update && apt-get install -y --no-install-recommends {}",
@@ -134,7 +134,7 @@ impl DockerfileGenerator for BuildPlan {
 
         let variables = plan.variables.clone().unwrap_or_default();
         let args_string = if variables.is_empty() {
-            "".to_string()
+            String::new()
         } else {
             format!(
                 "ARG {}\nENV {}",
@@ -155,7 +155,7 @@ impl DockerfileGenerator for BuildPlan {
 
         let static_assets = plan.static_assets.clone().unwrap_or_default();
         let assets_copy_cmd = if static_assets.is_empty() {
-            "".to_string()
+            String::new()
         } else {
             let rel_assets_path = output.get_relative_path("assets");
             let rel_assets_slash_path = rel_assets_path
@@ -291,7 +291,7 @@ impl DockerfileGenerator for StartPhase {
     ) -> Result<String> {
         let start_cmd = match &self.cmd {
             Some(cmd) => utils::get_exec_command(cmd),
-            None => "".to_string(),
+            None => String::new(),
         };
 
         let dockerfile: String = match &self.run_image {
@@ -362,7 +362,7 @@ impl DockerfileGenerator for Phase {
                 ),
             )
         } else {
-            ("".to_string(), "".to_string())
+            (String::new(), String::new())
         };
 
         // Copy over app files
@@ -379,7 +379,7 @@ impl DockerfileGenerator for Phase {
                 IncrementalCache::get_copy_to_image_command(&phase.cache_directories, image)
                     .join("\n")
             } else {
-                "".to_string()
+                String::new()
             };
 
             let cache_copy_out_command = IncrementalCache::get_copy_from_image_command(

--- a/src/nixpacks/builder/docker/incremental_cache.rs
+++ b/src/nixpacks/builder/docker/incremental_cache.rs
@@ -81,7 +81,7 @@ impl IncrementalCache {
         // #3 Use Docker import: Provide 3 seconds in a sample test
         for f in files {
             let mut docker_import_cmd = Command::new("docker");
-            docker_import_cmd.arg("import").arg(&f?.path()).arg(&tag);
+            docker_import_cmd.arg("import").arg(&f?.path()).arg(tag);
 
             let result = docker_import_cmd
                 .spawn()?
@@ -102,7 +102,7 @@ impl IncrementalCache {
         docker_inspect_cmd
             .arg("manifest")
             .arg("inspect")
-            .arg(&image_tag)
+            .arg(image_tag)
             .stdout(Stdio::null())
             .stderr(Stdio::null());
 

--- a/src/nixpacks/builder/docker/utils.rs
+++ b/src/nixpacks/builder/docker/utils.rs
@@ -20,13 +20,13 @@ pub fn get_cache_mount(
             })
             .collect::<Vec<String>>()
             .join(" "),
-        _ => "".to_string(),
+        _ => String::new(),
     }
 }
 
 pub fn get_copy_command(files: &[String], app_dir: &str) -> String {
     if files.is_empty() {
-        "".to_owned()
+        String::new()
     } else {
         format!("COPY {} {}", files.join(" "), app_dir)
     }
@@ -86,7 +86,7 @@ mod tests {
         let files = vec!["file1".to_string(), "file2".to_string()];
         let app_dir = "app";
 
-        assert_eq!("".to_owned(), get_copy_command(&[], app_dir));
+        assert_eq!(String::new(), get_copy_command(&[], app_dir));
         assert_eq!(
             format!("COPY {} {}", files.join(" "), app_dir),
             get_copy_command(&files, app_dir)

--- a/src/nixpacks/files.rs
+++ b/src/nixpacks/files.rs
@@ -28,7 +28,7 @@ pub fn recursive_copy_dir<T: AsRef<Path>, Q: AsRef<Path>>(source: T, dest: Q) ->
             }
             // copy files
             else if file_type.is_file() {
-                fs::copy(&from, &to)?;
+                fs::copy(from, &to)?;
                 // replace CRLF with LF
                 if let Ok(data) = fs::read_to_string(from) {
                     fs::write(&to, data.replace("\r\n", "\n"))?;

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -36,6 +36,13 @@ impl<'a> PlanGenerator for NixpacksBuildPlanGenerator<'a> {
 
         Ok(plan)
     }
+
+    fn get_plan_providers(&self, app: &App, env: &Environment) -> Result<Vec<String>> {
+        let plan_before_providers = self.get_plan_before_providers(app, env)?;
+        let providers = self.get_all_providers(app, env, plan_before_providers.providers)?;
+
+        Ok(providers)
+    }
 }
 
 impl NixpacksBuildPlanGenerator<'_> {
@@ -48,13 +55,10 @@ impl NixpacksBuildPlanGenerator<'_> {
 
     /// Get a build plan from the provider and by applying the config from the environment
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<BuildPlan> {
-        let file_plan = self.read_file_plan(app, env)?;
-        let env_plan = BuildPlan::from_environment(env);
-        let cli_plan = self.config.plan.clone().unwrap_or_default();
-        let plan_before_providers = BuildPlan::merge_plans(&vec![file_plan, env_plan, cli_plan]);
+        let plan_before_providers = self.get_plan_before_providers(app, env)?;
 
         let provider_plan =
-            self.get_plan_from_providers(plan_before_providers.providers.clone(), app, env)?;
+            self.get_plan_from_providers(app, env, plan_before_providers.providers.clone())?;
 
         let procfile_plan = (ProcfileProvider {})
             .get_build_plan(app, env)?
@@ -72,6 +76,15 @@ impl NixpacksBuildPlanGenerator<'_> {
         Ok(plan)
     }
 
+    fn get_plan_before_providers(&self, app: &App, env: &Environment) -> Result<BuildPlan> {
+        let file_plan = self.read_file_plan(app, env)?;
+        let env_plan = BuildPlan::from_environment(env);
+        let cli_plan = self.config.plan.clone().unwrap_or_default();
+        let plan_before_providers = BuildPlan::merge_plans(&vec![file_plan, env_plan, cli_plan]);
+
+        Ok(plan_before_providers)
+    }
+
     fn get_detected_providers(&self, app: &App, env: &Environment) -> Result<Vec<String>> {
         let mut providers = Vec::new();
 
@@ -87,20 +100,32 @@ impl NixpacksBuildPlanGenerator<'_> {
         Ok(providers)
     }
 
-    fn get_plan_from_providers(
+    /// Get all the providers that will be used to create the plan
+    pub fn get_all_providers(
         &self,
-        provider_names: Option<Vec<String>>,
         app: &App,
         env: &Environment,
-    ) -> Result<BuildPlan> {
+        manually_providers: Option<Vec<String>>,
+    ) -> Result<Vec<String>> {
         let detected_providers = self.get_detected_providers(app, env)?;
         let provider_names = remove_autos_from_vec(
             fill_auto_in_vec(
                 Some(detected_providers),
-                Some(provider_names.unwrap_or_else(|| vec!["...".to_string()])),
+                Some(manually_providers.unwrap_or_else(|| vec!["...".to_string()])),
             )
             .unwrap_or_default(),
         );
+
+        Ok(provider_names)
+    }
+
+    fn get_plan_from_providers(
+        &self,
+        app: &App,
+        env: &Environment,
+        manual_providers: Option<Vec<String>>,
+    ) -> Result<BuildPlan> {
+        let provider_names = self.get_all_providers(app, env, manual_providers)?;
 
         if provider_names.len() > 1 {
             println!(

--- a/src/nixpacks/plan/mod.rs
+++ b/src/nixpacks/plan/mod.rs
@@ -22,6 +22,7 @@ mod utils;
 
 pub trait PlanGenerator {
     fn generate_plan(&mut self, app: &App, environment: &Environment) -> Result<BuildPlan>;
+    fn get_plan_providers(&self, app: &App, environment: &Environment) -> Result<Vec<String>>;
 }
 
 #[serde_with::skip_serializing_none]

--- a/src/providers/java.rs
+++ b/src/providers/java.rs
@@ -106,7 +106,7 @@ impl JavaProvider {
         } else if app.includes_file("build.gradle.kts") {
             app.read_file("build.gradle.kts")?
         } else {
-            "".to_string()
+            String::new()
         };
 
         let is_spring_boot = file_content.contains("org.springframework.boot:spring-boot")
@@ -117,7 +117,7 @@ impl JavaProvider {
         let port_arg = if is_spring_boot {
             "-Dserver.port=$PORT".to_string()
         } else {
-            "".to_string()
+            String::new()
         };
 
         Ok(port_arg)
@@ -132,7 +132,7 @@ impl JavaProvider {
         {
             "-Dserver.port=$PORT".to_string()
         } else {
-            "".to_string()
+            String::new()
         }
     }
 

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -733,7 +733,7 @@ mod test {
             NodeProvider::find_next_packages(&App::new(
                 "./examples/node-monorepo/packages/client"
             )?)?,
-            vec!["".to_string()]
+            vec![String::new()]
         );
 
         Ok(())

--- a/src/providers/staticfile.rs
+++ b/src/providers/staticfile.rs
@@ -60,7 +60,7 @@ impl Provider for StaticfileProvider {
 
 impl StaticfileProvider {
     pub fn get_root(app: &App, env: &Environment, staticfile_root: String) -> String {
-        let mut root = "".to_string();
+        let mut root = String::new();
         if let Some(staticfile_root) = env.get_config_variable("STATICFILE_ROOT") {
             root = staticfile_root;
         } else if !staticfile_root.is_empty() {
@@ -85,7 +85,7 @@ impl StaticfileProvider {
             mime_types = "include\tmime.types;".to_string();
         }
 
-        let mut auth_basic = "".to_string();
+        let mut auth_basic = String::new();
         if app.includes_file("Staticfile.auth") {
             assets.insert(".htpasswd".to_string(), app.read_file("Staticfile.auth")?);
             auth_basic = format!(
@@ -95,15 +95,11 @@ impl StaticfileProvider {
         }
 
         let staticfile: Staticfile = app.read_yaml("Staticfile").unwrap_or_default();
-        let root = StaticfileProvider::get_root(
-            app,
-            env,
-            staticfile.root.unwrap_or_else(|| "".to_string()),
-        );
+        let root = StaticfileProvider::get_root(app, env, staticfile.root.unwrap_or_default());
         let gzip = staticfile.gzip.unwrap_or_else(|| "on".to_string());
         let directory = staticfile.directory.unwrap_or_else(|| "off".to_string());
         let status_code = staticfile.status_code.unwrap_or_default();
-        let mut error_page = "".to_string();
+        let mut error_page = String::new();
         for (key, value) in status_code {
             writeln!(error_page, "\terror_page {} {};", key, value)?;
         }


### PR DESCRIPTION
This PR adds an experimental `detect` command that simply returns the list of providers that will be used to build the application. It is intended to be used on Railway, but the exact requirements are still TBD, which is why it is experimental. Use at your own risk as this may change in the future.
