### PR TITLE
remove rvm source after install

### DIFF
--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -85,7 +85,8 @@ impl RubyProvider {
             && . /etc/profile.d/rvm.sh \
             && rvm install {ruby_version} \
             && rvm --default use {ruby_version} \
-            && gem install {bundler_version}",
+            && gem install {bundler_version} \
+            && rm -rf /usr/local/rvm/src",
             ruby_version = self.get_ruby_version(app)?,
             bundler_version = self.get_bundler_version(app)
         ));

--- a/tests/snapshots/generate_plan_tests__ruby.snap
+++ b/tests/snapshots/generate_plan_tests__ruby.snap
@@ -35,7 +35,7 @@ expression: plan
         "procps"
       ],
       "cmds": [
-        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install ruby-3.1.2 && rvm --default use ruby-3.1.2 && gem install bundler:2.3.7",
+        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install ruby-3.1.2 && rvm --default use ruby-3.1.2 && gem install bundler:2.3.7 && rm -rf /usr/local/rvm/src",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
       ],
       "onlyIncludeFiles": []

--- a/tests/snapshots/generate_plan_tests__ruby_execjs.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_execjs.snap
@@ -58,7 +58,7 @@ expression: plan
         "procps"
       ],
       "cmds": [
-        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install ruby-3.1.2 && rvm --default use ruby-3.1.2 && gem install bundler:2.3.7",
+        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install ruby-3.1.2 && rvm --default use ruby-3.1.2 && gem install bundler:2.3.7 && rm -rf /usr/local/rvm/src",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
       ],
       "onlyIncludeFiles": []

--- a/tests/snapshots/generate_plan_tests__ruby_local_deps.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_local_deps.snap
@@ -35,7 +35,7 @@ expression: plan
         "procps"
       ],
       "cmds": [
-        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install ruby-3.1.2 && rvm --default use ruby-3.1.2 && gem install bundler:2.3.7",
+        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install ruby-3.1.2 && rvm --default use ruby-3.1.2 && gem install bundler:2.3.7 && rm -rf /usr/local/rvm/src",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
       ],
       "onlyIncludeFiles": []

--- a/tests/snapshots/generate_plan_tests__ruby_rails_postgres.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_rails_postgres.snap
@@ -46,7 +46,7 @@ expression: plan
         "libpq-dev"
       ],
       "cmds": [
-        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install 3.1.2 && rvm --default use 3.1.2 && gem install bundler:2.3.7",
+        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install 3.1.2 && rvm --default use 3.1.2 && gem install bundler:2.3.7 && rm -rf /usr/local/rvm/src",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
       ],
       "onlyIncludeFiles": []

--- a/tests/snapshots/generate_plan_tests__ruby_sinatra.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_sinatra.snap
@@ -35,7 +35,7 @@ expression: plan
         "procps"
       ],
       "cmds": [
-        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install ruby-3.1.2 && rvm --default use ruby-3.1.2 && gem install bundler:2.3.7",
+        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install ruby-3.1.2 && rvm --default use ruby-3.1.2 && gem install bundler:2.3.7 && rm -rf /usr/local/rvm/src",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
       ],
       "onlyIncludeFiles": []

--- a/tests/snapshots/generate_plan_tests__ruby_with_node.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_with_node.snap
@@ -61,7 +61,7 @@ expression: plan
         "procps"
       ],
       "cmds": [
-        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install ruby-3.1.2 && rvm --default use ruby-3.1.2 && gem install bundler:2.3.7",
+        "curl -sSL https://get.rvm.io | bash -s stable && . /etc/profile.d/rvm.sh && rvm install ruby-3.1.2 && rvm --default use ruby-3.1.2 && gem install bundler:2.3.7 && rm -rf /usr/local/rvm/src",
         "echo 'source /usr/local/rvm/scripts/rvm' >> /root/.profile"
       ],
       "onlyIncludeFiles": []


### PR DESCRIPTION
This PR decreases the final Ruby image size by a significant amount by removing the rvm source after installation

Fixes: https://github.com/railwayapp/nixpacks/issues/653
