### PR TITLE
significantly reduce ruby memory usage by setting default env variable MALLOC_ARENA_MAX=2

### DIFF
--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -144,6 +144,7 @@ impl RubyProvider {
                 "GEM_HOME".to_string(),
                 format!("/usr/local/rvm/gems/{}", ruby_version),
             ),
+            ("MALLOC_ARENA_MAX".to_string(), "2".to_string()),
         ]);
         if self.is_rails_app(app) {
             env_vars.insert("RAILS_LOG_TO_STDOUT".to_string(), "enabled".to_string());

--- a/tests/snapshots/generate_plan_tests__ruby.snap
+++ b/tests/snapshots/generate_plan_tests__ruby.snap
@@ -9,6 +9,7 @@ expression: plan
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/rvm/gems/ruby-3.1.2",
     "GEM_PATH": "/usr/local/rvm/gems/ruby-3.1.2:/usr/local/rvm/gems/ruby-3.1.2@global",
+    "MALLOC_ARENA_MAX": "2",
     "NIXPACKS_METADATA": "ruby"
   },
   "phases": {

--- a/tests/snapshots/generate_plan_tests__ruby_execjs.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_execjs.snap
@@ -9,6 +9,7 @@ expression: plan
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/rvm/gems/ruby-3.1.2",
     "GEM_PATH": "/usr/local/rvm/gems/ruby-3.1.2:/usr/local/rvm/gems/ruby-3.1.2@global",
+    "MALLOC_ARENA_MAX": "2",
     "NIXPACKS_METADATA": "ruby"
   },
   "phases": {

--- a/tests/snapshots/generate_plan_tests__ruby_local_deps.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_local_deps.snap
@@ -9,6 +9,7 @@ expression: plan
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/rvm/gems/ruby-3.1.2",
     "GEM_PATH": "/usr/local/rvm/gems/ruby-3.1.2:/usr/local/rvm/gems/ruby-3.1.2@global",
+    "MALLOC_ARENA_MAX": "2",
     "NIXPACKS_METADATA": "ruby"
   },
   "phases": {

--- a/tests/snapshots/generate_plan_tests__ruby_rails_postgres.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_rails_postgres.snap
@@ -9,6 +9,7 @@ expression: plan
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/rvm/gems/3.1.2",
     "GEM_PATH": "/usr/local/rvm/gems/3.1.2:/usr/local/rvm/gems/3.1.2@global",
+    "MALLOC_ARENA_MAX": "2",
     "NIXPACKS_METADATA": "ruby",
     "RAILS_LOG_TO_STDOUT": "enabled"
   },

--- a/tests/snapshots/generate_plan_tests__ruby_sinatra.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_sinatra.snap
@@ -9,6 +9,7 @@ expression: plan
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/rvm/gems/ruby-3.1.2",
     "GEM_PATH": "/usr/local/rvm/gems/ruby-3.1.2:/usr/local/rvm/gems/ruby-3.1.2@global",
+    "MALLOC_ARENA_MAX": "2",
     "NIXPACKS_METADATA": "ruby"
   },
   "phases": {

--- a/tests/snapshots/generate_plan_tests__ruby_with_node.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_with_node.snap
@@ -9,6 +9,7 @@ expression: plan
     "BUNDLE_GEMFILE": "/app/Gemfile",
     "GEM_HOME": "/usr/local/rvm/gems/ruby-3.1.2",
     "GEM_PATH": "/usr/local/rvm/gems/ruby-3.1.2:/usr/local/rvm/gems/ruby-3.1.2@global",
+    "MALLOC_ARENA_MAX": "2",
     "NIXPACKS_METADATA": "ruby"
   },
   "phases": {


### PR DESCRIPTION
Setting `MALLOC_ARENA_MAX=2` is basically an essential for ruby apps to not have crazy memory usage. [Heroku buildpacks set it by default](https://github.com/heroku/heroku-buildpack-ruby/pull/752).

We saw people migrating from Heroku to use nixpacks were having way worse memory usage.


