### PR TITLE
Log app contents when no plan can be generated

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
     clippy::missing_panics_doc,
 )]
 
+
+
 use crate::nixpacks::{
     app::App,
     builder::{
@@ -32,7 +34,7 @@ use crate::nixpacks::{
         BuildPlan, PlanGenerator,
     },
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use providers::{
     clojure::ClojureProvider, cobol::CobolProvider, crystal::CrystalProvider,
     csharp::CSharpProvider, dart::DartProvider, deno::DenoProvider, elixir::ElixirProvider,
@@ -112,6 +114,31 @@ pub async fn create_docker_image(
 
     let logger = Logger::new();
     let builder = DockerImageBuilder::new(logger, build_options.clone());
+
+    let phase_count = plan.phases.clone().map_or(0, |phases| phases.len());
+    if phase_count > 0 {
+        println!("{}", plan.get_build_string()?);
+
+        let start = plan.start_phase.clone().unwrap_or_default();
+        if start.cmd.is_none() && !build_options.no_error_without_start {
+            bail!("No start command could be found")
+        }
+    } else {
+        println!("\nNixpacks was unable to generate a build plan for this app.\nPlease check the documentation for supported languages: https://nixpacks.com");
+        println!("\nThe file contents of the app directory are:\n");
+
+        for file in &app.paths {
+            let path = app.strip_source_path(file.as_path())?;
+            println!(
+                "  {}{}",
+                path.display(),
+                if file.is_dir() { "/" } else { "" }
+            );
+        }
+
+        std::process::exit(1);
+    }
+
     builder
         .create_image(app.source.to_str().unwrap(), &plan, &environment)
         .await?;

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -35,7 +35,6 @@ impl App {
     }
 
     /// Check if a file exists
-
     pub fn includes_file(&self, name: &str) -> bool {
         self.source.join(name).is_file()
     }
@@ -94,7 +93,6 @@ impl App {
     }
 
     /// Check if a path matching a glob exists
-
     pub fn has_match(&self, pattern: &str) -> bool {
         match self.find_files(pattern) {
             Ok(v) => !v.is_empty(),
@@ -139,7 +137,6 @@ impl App {
     }
 
     /// Check if a directory exists
-
     pub fn includes_directory(&self, name: &str) -> bool {
         self.source.join(name).is_dir()
     }
@@ -195,7 +192,6 @@ impl App {
     }
 
     /// Get the path in the container to an asset defined in `static_assets`.
-
     pub fn asset_path(&self, name: &str) -> String {
         format!("{}{}", ASSETS_DIR, name)
     }

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -68,19 +68,6 @@ impl ImageBuilder for DockerImageBuilder {
             return Ok(());
         }
 
-        let phase_count = plan.phases.clone().map_or(0, |phases| phases.len());
-        if phase_count > 0 {
-            println!("{}", plan.get_build_string()?);
-
-            let start = plan.start_phase.clone().unwrap_or_default();
-            if start.cmd.is_none() && !self.options.no_error_without_start {
-                bail!("No start command could be found")
-            }
-        } else {
-            println!("\nNixpacks was unable to generate a build plan for this app.\nPlease check the documentation for supported languages: https://nixpacks.com");
-            std::process::exit(1);
-        }
-
         self.write_app(app_src, &output).context("Writing app")?;
         self.write_dockerfile(dockerfile, &output)
             .context("Writing Dockerfile")?;


### PR DESCRIPTION
This PR logs the app directory contents if no build plan can be generated. This should hopefully help make it clearer which files Nixpacks has access to and why no providers were successfully detected.

![image](https://user-images.githubusercontent.com/3044853/201265612-ace7bcb0-4493-4782-9a78-80d1ac63c8a2.png)
