### PR TITLE
servce static files

### DIFF
--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -153,7 +153,6 @@ impl RubyProvider {
 
         if self.is_rails_app(app) {
             env_vars.insert("RAILS_LOG_TO_STDOUT".to_string(), "enabled".to_string());
-            env_vars.insert("RAILS_ENV".to_string(), "production".to_string());
             env_vars.insert("RAILS_SERVE_STATIC_FILES".to_string(), "1".to_string());
         }
 

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -150,9 +150,13 @@ impl RubyProvider {
             ),
             ("MALLOC_ARENA_MAX".to_string(), "2".to_string()),
         ]);
+
         if self.is_rails_app(app) {
             env_vars.insert("RAILS_LOG_TO_STDOUT".to_string(), "enabled".to_string());
+            env_vars.insert("RAILS_ENV".to_string(), "production".to_string());
+            env_vars.insert("RAILS_SERVE_STATIC_FILES".to_string(), "1".to_string());
         }
+
         Ok(env_vars)
     }
 

--- a/tests/snapshots/generate_plan_tests__ruby_rails_postgres.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_rails_postgres.snap
@@ -11,7 +11,6 @@ expression: plan
     "GEM_PATH": "/usr/local/rvm/gems/3.1.2:/usr/local/rvm/gems/3.1.2@global",
     "MALLOC_ARENA_MAX": "2",
     "NIXPACKS_METADATA": "ruby",
-    "RAILS_ENV": "production",
     "RAILS_LOG_TO_STDOUT": "enabled",
     "RAILS_SERVE_STATIC_FILES": "1"
   },

--- a/tests/snapshots/generate_plan_tests__ruby_rails_postgres.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_rails_postgres.snap
@@ -11,7 +11,9 @@ expression: plan
     "GEM_PATH": "/usr/local/rvm/gems/3.1.2:/usr/local/rvm/gems/3.1.2@global",
     "MALLOC_ARENA_MAX": "2",
     "NIXPACKS_METADATA": "ruby",
-    "RAILS_LOG_TO_STDOUT": "enabled"
+    "RAILS_ENV": "production",
+    "RAILS_LOG_TO_STDOUT": "enabled",
+    "RAILS_SERVE_STATIC_FILES": "1"
   },
   "phases": {
     "build": {


### PR DESCRIPTION
This PR sets two additional environment variables for rails apps
- `RAILS_SERVE_STATIC_FILES=1`

Fixes https://github.com/railwayapp/nixpacks/issues/672