### PR TITLE
migrate to clap derive api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,21 +356,37 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "389ca505fd2c00136e0d0cd34bcd8b6bd0b59d5779aab396054b716334230c1c"
 dependencies = [
+ "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
- "indexmap",
- "textwrap 0.15.1",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -717,6 +733,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,7 +976,7 @@ dependencies = [
  "serde_yaml",
  "tempdir",
  "test-helper",
- "textwrap 0.16.0",
+ "textwrap",
  "tokio",
  "toml",
  "uuid",
@@ -1104,6 +1126,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1427,6 +1473,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,12 +1500,6 @@ dependencies = [
  "quote",
  "walkdir",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = ["test-helper"]
 
 [dependencies]
 anyhow = "1.0.64"
-clap = { version = "3.2.20", features = ["std"], default-features = false }
+clap = { version = "4.0.25", features = ["derive"] }
 colored = "2.0.0"
 globset = { default-features = false, version = "0.4.9" }
 walkdir = "2.3.2"
@@ -35,7 +35,9 @@ regex = "1.6.0"
 serde = { version = "1.0.144", default-features = false }
 serde_json = "1.0.85"
 serde_yaml = "0.8.26"
-serde_with = { features = ["macros"], default-features = false, version = "1.14.0" }
+serde_with = { features = [
+    "macros",
+], default-features = false, version = "1.14.0" }
 tempdir = "0.3.7"
 toml = "0.5.9"
 uuid = { version = "1.1.2", features = ["v4"], default-features = false }
@@ -52,7 +54,7 @@ actix-web = "4"
 sanitize-filename = "0.4"
 futures-util = "0.3"
 futures = "0.3"
-portpicker =  "0.1.1"
+portpicker = "0.1.1"
 tokio = { version = "1.21.2", features = ["full"] }
 async-trait = "0.1.58"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use anyhow::{bail, Result};
-use clap::{arg, Arg, Command};
+use anyhow::Result;
+use clap::{arg, Parser, Subcommand, ValueEnum};
 use nixpacks::{
     create_docker_image, generate_build_plan, get_plan_providers,
     nixpacks::{
@@ -16,264 +16,178 @@ use std::{
     collections::hash_map::DefaultHasher,
     env,
     hash::{Hash, Hasher},
+    ops::Deref,
     string::ToString,
 };
 
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum PlanFormat {
     Json,
     Toml,
 }
 
-impl PlanFormat {
-    fn from_str(s: &str) -> Result<Self> {
-        match s {
-            "json" => Ok(PlanFormat::Json),
-            "toml" => Ok(PlanFormat::Toml),
-            _ => bail!("Invalid plan format"),
-        }
-    }
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
+struct Args {
+    #[command(subcommand)]
+    command: Commands,
+
+    /// Specify an entire build plan in json format that should be used to configure the build
+    #[arg(long, global = true)]
+    json_plan: Option<String>,
+
+    /// Specify the install command to use
+    #[arg(long, short, global = true)]
+    install_cmd: Option<String>,
+
+    /// Specify the build command to use
+    #[arg(long, short, global = true)]
+    build_cmd: Option<String>,
+
+    /// Specify the start command to use
+    #[arg(long, short, global = true)]
+    start_cmd: Option<String>,
+
+    /// Provide additional nix packages to install in the environment
+    #[arg(long, short, global = true)]
+    pkgs: Vec<String>,
+
+    /// Provide additional apt packages to install in the environment
+    #[arg(long, short, global = true)]
+    apt: Vec<String>,
+
+    /// Provide additional nix libraries to install in the environment
+    #[arg(long, short, global = true)]
+    libs: Vec<String>,
+
+    /// Provide environment variables to your build
+    #[arg(long, short, global = true)]
+    env: Vec<String>,
+
+    /// Path to config file
+    #[arg(long, short, global = true)]
+    config: Option<String>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate a build plan for an app
+    Plan {
+        /// App source
+        path: String,
+
+        /// Specify the output format of the build plan.
+        #[arg(short, long, value_enum, default_value = "json")]
+        format: PlanFormat,
+    },
+
+    /// List all of the providers that will be used to build the app
+    Detect {
+        /// App source
+        path: String,
+    },
+
+    /// Build an app
+    Build {
+        /// App source
+        path: String,
+
+        /// Name for the built image
+        #[arg(short, long)]
+        name: Option<String>,
+
+        /// Save output directory instead of building it with Docker
+        #[arg(short, long)]
+        out: Option<String>,
+
+        /// Print the generated Dockerfile to stdout
+        #[arg(short, long, hide = true)]
+        dockerfile: bool,
+
+        /// Additional tags to add to the output image
+        #[arg(short, long)]
+        tag: Vec<String>,
+
+        /// Additional labels to add to the output image
+        #[arg(short, long)]
+        label: Vec<String>,
+
+        /// Set target platform for your output image
+        #[arg(long)]
+        platform: Vec<String>,
+
+        /// Unique identifier to key cache by. Defaults to the current directory
+        #[arg(long)]
+        cache_key: Option<String>,
+
+        /// Output Nixpacks related files to the current directory
+        #[arg(long)]
+        current_dir: bool,
+
+        /// Disable building with the cache
+        #[arg(long)]
+        no_cache: bool,
+
+        /// Image to hold the cached directories between builds.
+        #[arg(long)]
+        incremental_cache_image: Option<String>,
+
+        /// Image to consider as cache sources
+        #[arg(long)]
+        cache_from: Option<String>,
+
+        /// Enable writing cache metadata into the output image
+        #[arg(long)]
+        inline_cache: bool,
+
+        /// Do not error when no start command can be found
+        #[arg(long)]
+        no_error_without_start: bool,
+
+        /// Display more info during build
+        #[arg(long, short)]
+        verbose: bool,
+    },
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-    let matches = Command::new("nixpacks")
-        .subcommand_required(true)
-        .arg_required_else_help(true)
-        .version(VERSION)
-        .subcommand(
-            Command::new("plan")
-                .about("Generate a build plan for an app")
-                .arg(arg!([PATH] "App source"))
-                .arg(
-                    Arg::new("format")
-                        .short('f')
-                        .takes_value(true)
-                        .help("json|toml. Specify the output format of the plan"),
-                ),
-        )
-        .subcommand(
-            Command::new("detect")
-                .about("List all of the providers that will be used to build the app")
-                .arg(arg!([PATH] "App source")),
-        )
-        .subcommand(
-            Command::new("build")
-                .about("Create a docker image for an app")
-                .arg(arg!([PATH] "App source"))
-                .arg(
-                    Arg::new("name")
-                        .long("name")
-                        .short('n')
-                        .help("Name for the built image")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::new("out")
-                        .long("out")
-                        .short('o')
-                        .help("Save output directory instead of building it with Docker")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::new("dockerfile")
-                        .long("dockerfile")
-                        .help("Print the generated Dockerfile to stdout")
-                        .hide(true),
-                )
-                .arg(
-                    Arg::new("tag")
-                        .long("tag")
-                        .short('t')
-                        .help("Additional tags to add to the output image")
-                        .takes_value(true)
-                        .multiple_values(true),
-                )
-                .arg(
-                    Arg::new("label")
-                        .long("label")
-                        .short('l')
-                        .help("Additional labels to add to the output image")
-                        .takes_value(true)
-                        .multiple_values(true),
-                )
-                .arg(
-                    Arg::new("platform")
-                        .long("platform")
-                        .help("Set target platform for your output image")
-                        .takes_value(true)
-                        .multiple_values(true),
-                )
-                .arg(
-                    Arg::new("cache-key")
-                        .long("cache-key")
-                        .help(
-                            "Unique identifier to key cache by. Defaults to the current directory",
-                        )
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::new("current-dir")
-                        .long("current-dir")
-                        .help("Output Nixpacks related files to the current directory ")
-                        .takes_value(false),
-                )
-                .arg(
-                    Arg::new("no-cache")
-                        .long("no-cache")
-                        .help("Disable building with the cache"),
-                )
-                .arg(
-                    Arg::new("incremental-cache-image")
-                        .long("incremental-cache-image")
-                        .help("Image to hold the cached directories between builds.")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::new("verbose")
-                        .long("verbose")
-                        .help("Display more info during build."),
-                )
-                .arg(
-                    Arg::new("inline-cache")
-                        .long("inline-cache")
-                        .help("Enable writing cache metadata into the output image"),
-                )
-                .arg(
-                    Arg::new("cache-from")
-                        .long("cache-from")
-                        .help("Image to consider as cache sources")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::new("no-error-without-start")
-                        .long("no-error-without-start")
-                        .help("Do not error when no start command can be found"),
-                ),
-        )
-        .arg(
-            Arg::new("json-plan")
-                .long("json-plan")
-                .help("Specify an entire build plan in json format that should be used to configure the build")
-                .takes_value(true)
-                .global(true),
-        )
-        .arg(
-            Arg::new("install_cmd")
-                .long("install-cmd")
-                .short('i')
-                .help("Specify the install command to use")
-                .takes_value(true)
-                .global(true),
-        )
-        .arg(
-            Arg::new("build_cmd")
-                .long("build-cmd")
-                .short('b')
-                .help("Specify the build command to use")
-                .takes_value(true)
-                .global(true),
-        )
-        .arg(
-            Arg::new("start_cmd")
-                .long("start-cmd")
-                .short('s')
-                .help("Specify the start command to use")
-                .takes_value(true)
-                .global(true),
-        )
-        .arg(
-            Arg::new("pkgs")
-                .long("pkgs")
-                .short('p')
-                .help("Provide additional nix packages to install in the environment")
-                .takes_value(true)
-                .multiple_values(true)
-                .global(true),
-        )
-        .arg(
-            Arg::new("apt")
-                .long("apt")
-                .help("Provide additional apt packages to install in the environment")
-                .takes_value(true)
-                .multiple_values(true)
-                .global(true),
-        )
-        .arg(
-            Arg::new("libs")
-                .long("libs")
-                .help("Provide additional nix libraries to install in the environment")
-                .takes_value(true)
-                .multiple_values(true)
-                .global(true),
-        )
-        .arg(
-            Arg::new("env")
-                .long("env")
-                .help("Provide environment variables to your build")
-                .takes_value(true)
-                .multiple_values(true)
-                .global(true),
-        )
-        .arg(
-            Arg::new("config")
-                .short('c')
-                .long("config")
-                .help("Path to config file")
-                .takes_value(true)
-                .global(true),
-        )
-        .get_matches();
+    let args = Args::parse();
 
-    let install_cmd = matches.value_of("install_cmd").map(|s| vec![s.to_string()]);
-    let build_cmd = matches.value_of("build_cmd").map(|s| vec![s.to_string()]);
-    let start_cmd = matches.value_of("start_cmd").map(ToString::to_string);
-    let pkgs = match matches.values_of("pkgs") {
-        Some(values) => values.map(Pkg::new).collect::<Vec<_>>(),
-        None => Vec::new(),
-    };
-    let libs = match matches.values_of("libs") {
-        Some(values) => values.map(String::from).collect::<Vec<String>>(),
-        None => Vec::new(),
-    };
-    let apt_pkgs = match matches.values_of("apt") {
-        Some(values) => values.map(String::from).collect::<Vec<String>>(),
-        None => Vec::new(),
-    };
-
-    let envs: Vec<_> = match matches.values_of("env") {
-        Some(envs) => envs.collect(),
-        None => Vec::new(),
-    };
+    let pkgs = args
+        .pkgs
+        .iter()
+        .map(|p| p.deref())
+        .map(Pkg::new)
+        .collect::<Vec<_>>();
 
     // CLI build plan
     let mut cli_plan = BuildPlan::default();
-    if !pkgs.is_empty() || !libs.is_empty() || !apt_pkgs.is_empty() {
+    if !args.pkgs.is_empty() || !args.libs.is_empty() || !args.apt.is_empty() {
         let mut setup = Phase::setup(Some(vec![pkgs, vec![Pkg::new("...")]].concat()));
-        setup.apt_pkgs = Some(vec![apt_pkgs, vec!["...".to_string()]].concat());
-        setup.nix_libs = Some(vec![libs, vec!["...".to_string()]].concat());
+        setup.apt_pkgs = Some(vec![args.apt, vec!["...".to_string()]].concat());
+        setup.nix_libs = Some(vec![args.libs, vec!["...".to_string()]].concat());
         cli_plan.add_phase(setup);
     }
-    if let Some(install_cmds) = install_cmd {
+    if let Some(install_cmds) = args.install_cmd {
         let mut install = Phase::install(None);
-        install.cmds = Some(install_cmds);
+        install.cmds = Some(vec![install_cmds]);
         cli_plan.add_phase(install);
     }
-    if let Some(build_cmds) = build_cmd {
+    if let Some(build_cmds) = args.build_cmd {
         let mut build = Phase::build(None);
-        build.cmds = Some(build_cmds);
+        build.cmds = Some(vec![build_cmds]);
         cli_plan.add_phase(build);
     }
-    if let Some(start_cmd) = start_cmd {
+    if let Some(start_cmd) = args.start_cmd {
         let start = StartPhase::new(start_cmd);
         cli_plan.set_start_phase(start);
     }
 
-    let json_plan = match matches.value_of("json-plan") {
-        Some(json) => Some(BuildPlan::from_json(json)?),
-        None => None,
-    };
+    let json_plan = args.json_plan.map(BuildPlan::from_json).transpose()?;
 
     // Merge the CLI build plan with the json build plan
     let cli_plan = if let Some(json_plan) = json_plan {
@@ -282,18 +196,15 @@ async fn main() -> Result<()> {
         cli_plan
     };
 
-    let config_file = matches.value_of("config").map(ToString::to_string);
+    let env: Vec<&str> = args.env.iter().map(|e| e.deref()).collect();
     let options = GeneratePlanOptions {
         plan: Some(cli_plan),
-        config_file,
+        config_file: args.config,
     };
 
-    match &matches.subcommand() {
-        Some(("plan", matches)) => {
-            let path = matches.value_of("PATH").unwrap_or(".");
-            let format = PlanFormat::from_str(matches.value_of("format").unwrap_or("json"))?;
-
-            let plan = generate_build_plan(path, envs, &options)?;
+    match args.command {
+        Commands::Plan { path, format } => {
+            let plan = generate_build_plan(&path, env, &options)?;
 
             let plan_s = match format {
                 PlanFormat::Json => plan.to_json()?,
@@ -302,65 +213,46 @@ async fn main() -> Result<()> {
 
             println!("{}", plan_s);
         }
-        Some(("detect", matches)) => {
-            let path = matches.value_of("PATH").unwrap_or(".");
-
-            let providers = get_plan_providers(path, envs, &options)?;
+        Commands::Detect { path } => {
+            let providers = get_plan_providers(&path, env, &options)?;
             println!("{}", providers.join(", "));
         }
-        Some(("build", matches)) => {
-            let path = matches.value_of("PATH").unwrap_or(".");
-            let name = matches.value_of("name").map(ToString::to_string);
-            let out_dir = matches.value_of("out").map(ToString::to_string);
-            let current_dir = matches.is_present("current-dir");
-            let mut cache_key = matches.value_of("cache-key").map(ToString::to_string);
-            let no_cache = matches.is_present("no-cache");
-            let inline_cache = matches.is_present("inline-cache");
-            let verbose = matches.is_present("verbose") || envs.contains(&"NIXPACKS_VERBOSE=1");
-
-            let cache_from = if !no_cache {
-                matches.value_of("cache-from").map(ToString::to_string)
-            } else {
-                None
-            };
-
-            let incremental_cache_image = matches
-                .value_of("incremental-cache-image")
-                .map(ToString::to_string);
+        Commands::Build {
+            path,
+            name,
+            out,
+            dockerfile,
+            tag,
+            label,
+            platform,
+            cache_key,
+            current_dir,
+            no_cache,
+            incremental_cache_image,
+            cache_from,
+            inline_cache,
+            no_error_without_start,
+            verbose,
+        } => {
+            let verbose = verbose || args.env.contains(&"NIXPACKS_VERBOSE=1".to_string());
 
             // Default to absolute `path` of the source that is being built as the cache-key if not disabled
-            if !no_cache && cache_key.is_none() {
-                cache_key = get_default_cache_key(path)?;
-            }
-
-            let print_dockerfile = matches.is_present("dockerfile");
-
-            let tags = matches
-                .values_of("tag")
-                .map(|values| values.map(ToString::to_string).collect::<Vec<_>>())
-                .unwrap_or_default();
-
-            let labels = matches
-                .values_of("label")
-                .map(|values| values.map(ToString::to_string).collect::<Vec<_>>())
-                .unwrap_or_default();
-            let platform = matches
-                .values_of("platform")
-                .map(|values| values.map(ToString::to_string).collect::<Vec<_>>())
-                .unwrap_or_default();
-
-            let no_error_without_start = matches.is_present("no-error-without-start");
+            let cache_key = if !no_cache && cache_key.is_none() {
+                get_default_cache_key(&path)?
+            } else {
+                cache_key
+            };
 
             let build_options = &DockerBuilderOptions {
                 name,
-                tags,
-                labels,
-                out_dir,
+                tags: tag,
+                labels: label,
+                out_dir: out,
                 quiet: false,
                 cache_key,
                 no_cache,
                 platform,
-                print_dockerfile,
+                print_dockerfile: dockerfile,
                 current_dir,
                 inline_cache,
                 cache_from,
@@ -368,10 +260,8 @@ async fn main() -> Result<()> {
                 incremental_cache_image,
                 verbose,
             };
-
-            create_docker_image(path, envs, &options, build_options).await?;
+            create_docker_image(&path, env, &options, build_options).await?;
         }
-        _ => eprintln!("Invalid command"),
     }
 
     Ok(())


### PR DESCRIPTION
- Migrates to the Clap Derive API instead of the Builder API.
- Upgrades to Clap v4