### PR TITLE
Allow unfree nixpkgs

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -25,6 +25,7 @@ ENV \
   NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
   NIX_PATH=/nix/var/nix/profiles/per-user/root/channels \
   NIXPKGS_ALLOW_BROKEN=1 \
+  NIXPKGS_ALLOW_UNFREE=1 \
   LD_LIBRARY_PATH=/usr/lib \
   CPATH=~/.nix-profile/include:$CPATH \
   LIBRARY_PATH=~/.nix-profile/lib:$LIBRARY_PATH \


### PR DESCRIPTION
This PR sets the `NIXPKGS_ALLOW_UNFREE` variable so that you can install packages like `google-chrome`


![image](https://user-images.githubusercontent.com/3044853/202815265-e7276378-0ca5-4513-b106-6b965cba4cef.png)
