### PR TITLE
Nim Provider

### DIFF
--- a/docs/pages/docs/providers/nim.md
+++ b/docs/pages/docs/providers/nim.md
@@ -1,0 +1,25 @@
+---
+title: Nim
+---
+
+# {% $markdoc.frontmatter.title %}
+
+Nim is detected if a `*.nimble` file is found.
+
+## Install
+
+```
+nimble install -dy
+```
+
+## Build
+
+```
+nimble build -d:release
+```
+
+## Start
+
+```
+./{}.exe
+```

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -45,6 +45,7 @@ export const sidebarItems: ISidebarSection[] = [
       { href: "/docs/providers/haskell", text: "Haskell" },
       { href: "/docs/providers/java", text: "Java" },
       { href: "/docs/providers/node", text: "Node" },
+      { href: "/docs/providers/nim", text: "Nim" },
       { href: "/docs/providers/php", text: "PHP" },
       { href: "/docs/providers/python", text: "Python" },
       { href: "/docs/providers/ruby", text: "Ruby" },

--- a/examples/nim/nim.nimble
+++ b/examples/nim/nim.nimble
@@ -1,0 +1,13 @@
+# Package
+
+version       = "0.1.0"
+author        = "nebulatgs"
+description   = "Nixpacks Nim Example"
+license       = "MIT"
+srcDir        = "src"
+bin           = @["nim"]
+
+
+# Dependencies
+
+requires "nim >= 1.6.6"

--- a/examples/nim/src/nim.nim
+++ b/examples/nim/src/nim.nim
@@ -1,0 +1,5 @@
+# This is just an example to get you started. A typical binary package
+# uses this file as the main entry point of the application.
+
+when isMainModule:
+  echo("Hello world from Nim!")

--- a/examples/nim_prologue/nim_prologue.nimble
+++ b/examples/nim_prologue/nim_prologue.nimble
@@ -1,0 +1,14 @@
+# Package
+
+version       = "0.1.0"
+author        = "nebulatgs"
+description   = "Nixpacks Nim Prologue Example"
+license       = "MIT"
+srcDir        = "src"
+bin           = @["nim_prologue"]
+
+
+# Dependencies
+
+requires "nim >= 1.6.6"
+requires "prologue >= 0.6.2"

--- a/examples/nim_prologue/src/config.nims
+++ b/examples/nim_prologue/src/config.nims
@@ -1,0 +1,3 @@
+switch("path", "$projectDir/../../src")
+when not defined(windows):
+  switch("threads", "on")

--- a/examples/nim_prologue/src/nim_prologue.nim
+++ b/examples/nim_prologue/src/nim_prologue.nim
@@ -1,0 +1,14 @@
+import prologue
+import ./urls
+
+
+let
+  settings = newSettings(appName = "nim_prologue",
+                         debug = true,
+                         port = Port(8080),
+    )
+
+var app = newApp(settings = settings)
+
+app.addRoute(urls.urlPatterns, "")
+app.run()

--- a/examples/nim_prologue/src/urls.nim
+++ b/examples/nim_prologue/src/urls.nim
@@ -1,0 +1,7 @@
+import prologue
+import ./views
+
+
+const urlPatterns* = @[
+  pattern("/", index),
+]

--- a/examples/nim_prologue/src/views.nim
+++ b/examples/nim_prologue/src/views.nim
@@ -1,0 +1,4 @@
+import prologue
+
+proc index*(ctx: Context) {.async.} =
+  resp "<h1>Hello from Nim with Prologue built using Nixpacks!</h1>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,9 @@ use providers::{
     clojure::ClojureProvider, cobol::CobolProvider, crystal::CrystalProvider,
     csharp::CSharpProvider, dart::DartProvider, deno::DenoProvider, elixir::ElixirProvider,
     fsharp::FSharpProvider, go::GolangProvider, haskell::HaskellStackProvider, java::JavaProvider,
-    node::NodeProvider, php::PhpProvider, python::PythonProvider, ruby::RubyProvider,
-    rust::RustProvider, staticfile::StaticfileProvider, swift::SwiftProvider, zig::ZigProvider,
-    Provider,
+    nim::NimProvider, node::NodeProvider, php::PhpProvider, python::PythonProvider,
+    ruby::RubyProvider, rust::RustProvider, staticfile::StaticfileProvider, swift::SwiftProvider,
+    zig::ZigProvider, Provider,
 };
 
 mod chain;
@@ -62,6 +62,7 @@ pub fn get_providers() -> &'static [&'static dyn Provider] {
         &PhpProvider {},
         &RubyProvider {},
         &NodeProvider {},
+        &NimProvider {},
         &PythonProvider {},
         &RustProvider {},
         &SwiftProvider {},

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,6 +12,7 @@ pub mod fsharp;
 pub mod go;
 pub mod haskell;
 pub mod java;
+pub mod nim;
 pub mod node;
 pub mod php;
 pub mod procfile;

--- a/src/providers/nim.rs
+++ b/src/providers/nim.rs
@@ -1,0 +1,65 @@
+use std::path::PathBuf;
+
+use super::Provider;
+use crate::nixpacks::{
+    app::App,
+    environment::Environment,
+    nix::pkg::Pkg,
+    plan::{
+        phase::{Phase, StartPhase},
+        BuildPlan,
+    },
+};
+use anyhow::{Context, Result};
+
+pub const DEFAULT_NIM_PKG_NAME: &str = "nim";
+
+pub struct NimProvider {}
+
+impl Provider for NimProvider {
+    fn name(&self) -> &str {
+        "nim"
+    }
+
+    fn detect(&self, app: &App, _env: &Environment) -> Result<bool> {
+        Ok(app.find_files("*.nimble")?.len() > 0)
+    }
+
+    fn get_build_plan(&self, app: &App, _env: &Environment) -> Result<Option<BuildPlan>> {
+        let setup = Phase::setup(Some(vec![Pkg::new(DEFAULT_NIM_PKG_NAME)]));
+
+        let mut install = Phase::install(Some("nimble install -dy".to_string()));
+        let nimble = NimProvider::get_nimble(app)?;
+        install.add_file_dependency(&nimble);
+
+        let build = Phase::build(Some("nimble build -d:release".to_string()));
+
+        let start = StartPhase::new(format!("./{}.exe", nimble.replace(".nimble", "")));
+
+        let plan = BuildPlan::new(&vec![setup, install, build], Some(start));
+        Ok(Some(plan))
+    }
+}
+
+impl NimProvider {
+    fn get_nimble(app: &App) -> Result<String> {
+        app.find_files("*.nimble")?
+            .first()
+            .cloned()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .context("No nimble file found")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_nimble() -> Result<()> {
+        let nimble = NimProvider::get_nimble(&App::new("./examples/nim")?)?;
+        assert_eq!(nimble, "nim.nimble");
+
+        Ok(())
+    }
+}

--- a/src/providers/nim.rs
+++ b/src/providers/nim.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use super::Provider;
 use crate::nixpacks::{
     app::App,
@@ -22,7 +20,7 @@ impl Provider for NimProvider {
     }
 
     fn detect(&self, app: &App, _env: &Environment) -> Result<bool> {
-        Ok(app.find_files("*.nimble")?.len() > 0)
+        Ok(!app.find_files("*.nimble")?.is_empty())
     }
 
     fn get_build_plan(&self, app: &App, _env: &Environment) -> Result<Option<BuildPlan>> {

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -552,6 +552,20 @@ async fn test_puppeteer() {
 }
 
 #[tokio::test]
+async fn test_nim() {
+    let name = simple_build("./examples/nim").await;
+    let output = run_image(&name, None).await;
+    assert!(output.contains("Hello world from Nim!"));
+}
+
+#[tokio::test]
+async fn test_nim_prologue() {
+    let name = simple_build("./examples/nim_prologue").await;
+    let output = run_image(&name, None).await;
+    assert!(output.contains("Prologue is serving"));
+}
+
+#[tokio::test]
 async fn test_csharp() {
     let name = simple_build("./examples/csharp-cli").await;
     let output = run_image(&name, None).await;

--- a/tests/snapshots/generate_plan_tests__nim.snap
+++ b/tests/snapshots/generate_plan_tests__nim.snap
@@ -1,0 +1,45 @@
+---
+source: tests/generate_plan_tests.rs
+expression: plan
+---
+{
+  "providers": [],
+  "buildImage": "[build_image]",
+  "variables": {
+    "NIXPACKS_METADATA": "nim"
+  },
+  "phases": {
+    "build": {
+      "name": "build",
+      "dependsOn": [
+        "install"
+      ],
+      "cmds": [
+        "nimble build -d:release"
+      ]
+    },
+    "install": {
+      "name": "install",
+      "dependsOn": [
+        "setup"
+      ],
+      "cmds": [
+        "nimble install -dy"
+      ],
+      "onlyIncludeFiles": [
+        "nim.nimble"
+      ]
+    },
+    "setup": {
+      "name": "setup",
+      "nixPkgs": [
+        "nim"
+      ],
+      "nixOverlays": [],
+      "nixpkgsArchive": "[archive]"
+    }
+  },
+  "start": {
+    "cmd": "./nim.exe"
+  }
+}

--- a/tests/snapshots/generate_plan_tests__nim_prologue.snap
+++ b/tests/snapshots/generate_plan_tests__nim_prologue.snap
@@ -1,0 +1,45 @@
+---
+source: tests/generate_plan_tests.rs
+expression: plan
+---
+{
+  "providers": [],
+  "buildImage": "[build_image]",
+  "variables": {
+    "NIXPACKS_METADATA": "nim"
+  },
+  "phases": {
+    "build": {
+      "name": "build",
+      "dependsOn": [
+        "install"
+      ],
+      "cmds": [
+        "nimble build -d:release"
+      ]
+    },
+    "install": {
+      "name": "install",
+      "dependsOn": [
+        "setup"
+      ],
+      "cmds": [
+        "nimble install -dy"
+      ],
+      "onlyIncludeFiles": [
+        "nim_prologue.nimble"
+      ]
+    },
+    "setup": {
+      "name": "setup",
+      "nixPkgs": [
+        "nim"
+      ],
+      "nixOverlays": [],
+      "nixpkgsArchive": "[archive]"
+    }
+  },
+  "start": {
+    "cmd": "./nim_prologue.exe"
+  }
+}


### PR DESCRIPTION
Resolves #693 
Add [Nim](https://nim-lang.org/) Provider

- [x] Tests are added/updated if needed
- [x] Docs are updated if needed

Uses `nimble` as the package manager

Further improvements such as caching `nimble` packages can be added in the future.

Examples: 
- nim hello world `examples/nim`
- nim webserver `examples/nim_prologue`