### PR TITLE
Remove 7.4 from PHP supported versions in docs

### DIFF
--- a/docs/pages/docs/providers/php.md
+++ b/docs/pages/docs/providers/php.md
@@ -10,7 +10,6 @@ Php is detected if a `composer.json` OR `index.php` file is found.
 
 The following PHP versions are available
 
-- `7.4`
 - `8.0`
 - `8.1` (Default)
 


### PR DESCRIPTION
The documentation states that PHP 7.4 is supported, which had us spending time trying to port a PHP 7.4 maintenance project to railway. This turned out to not be true:

Details by @coffee-cup 
https://github.com/railwayapp/nixpacks/issues/542#issuecomment-1331064901

This PR simply removes 7.4 as a supported version in the documentation.