### PR TITLE
Create an Ubuntu base image

### DIFF
--- a/.github/workflows/publish_debian.yml
+++ b/.github/workflows/publish_debian.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: base/debian
-          platforms: linux/arm64, linux/amd64
+          platforms: linux/arm64, linux/amd64, linux/386
           push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           tags: ghcr.io/railwayapp/nixpacks:debian, ghcr.io/railwayapp/nixpacks:latest, ghcr.io/railwayapp/nixpacks:debian-${{ steps.date.outputs.date }}
       

--- a/.github/workflows/publish_debian.yml
+++ b/.github/workflows/publish_debian.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: base/debian
-          platforms: linux/arm64, linux/amd64, linux/386
+          platforms: linux/arm64, linux/amd64
           push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           tags: ghcr.io/railwayapp/nixpacks:debian, ghcr.io/railwayapp/nixpacks:latest, ghcr.io/railwayapp/nixpacks:debian-${{ steps.date.outputs.date }}
       

--- a/.github/workflows/publish_ubuntu.yml
+++ b/.github/workflows/publish_ubuntu.yml
@@ -3,20 +3,20 @@ on:
     branches:
       - main
     paths:
-      - 'base/debian/*'
+      - 'base/ubuntu/*'
   pull_request:
     branches:
       - main
     paths:
-      - 'base/debian/*'
+      - 'base/ubuntu/*'
   schedule:
     - cron:  '0 0 * * 2'
   workflow_dispatch:
 
-name: Publish Debian Base Images
+name: Publish Ubuntu Base Images
 
 jobs:
-  debian:
+  ubuntu:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -49,15 +49,10 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          context: base/debian
+          context: base/ubuntu
           platforms: linux/arm64, linux/amd64, linux/386
           push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-          tags: ghcr.io/railwayapp/nixpacks:debian, ghcr.io/railwayapp/nixpacks:latest, ghcr.io/railwayapp/nixpacks:debian-${{ steps.date.outputs.date }}
-      
-      - name: Bump base image
-        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-        run: |
-          sed -i 's/nixpacks:debian-.*/nixpacks:debian-${{ steps.date.outputs.date }}";/g' src/nixpacks/images.rs
+          tags: ghcr.io/railwayapp/nixpacks:ubuntu, ghcr.io/railwayapp/nixpacks:ubuntu-${{ steps.date.outputs.date }}
       
       - name: Create Pull Request
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
@@ -80,7 +75,7 @@ jobs:
       - name: Build and push to Docker Hub
         uses: docker/build-push-action@v3
         with:
-          context: base/debian
+          context: base/ubuntu
           platforms: linux/arm64, linux/amd64, linux/386
           push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-          tags: railwayapp/nixpacks:debian, railwayapp/nixpacks:latest, railwayapp/nixpacks:debian-${{ steps.date.outputs.date }}
+          tags: railwayapp/nixpacks:ubuntu, railwayapp/nixpacks:ubuntu-${{ steps.date.outputs.date }}

--- a/.github/workflows/publish_ubuntu.yml
+++ b/.github/workflows/publish_ubuntu.yml
@@ -76,6 +76,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: base/ubuntu
-          platforms: linux/arm64, linux/amd64, linux/386
+          platforms: linux/arm64, linux/amd64
           push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           tags: railwayapp/nixpacks:ubuntu, railwayapp/nixpacks:ubuntu-${{ steps.date.outputs.date }}

--- a/.github/workflows/publish_ubuntu.yml
+++ b/.github/workflows/publish_ubuntu.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: base/ubuntu
-          platforms: linux/arm64, linux/amd64, linux/386
+          platforms: linux/arm64, linux/amd64
           push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           tags: ghcr.io/railwayapp/nixpacks:ubuntu, ghcr.io/railwayapp/nixpacks:ubuntu-${{ steps.date.outputs.date }}
       

--- a/base/ubuntu/Dockerfile
+++ b/base/ubuntu/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:jammy-20221130
+
+RUN apt-get update && apt-get -y upgrade \
+  && apt-get install --no-install-recommends -y sudo locales curl xz-utils ca-certificates openssl make git pkg-config \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /usr/share/doc/* \
+  && mkdir -m 0755 /nix && mkdir -m 0755 /etc/nix && groupadd -r nixbld && chown root /nix \
+  && printf 'sandbox = false \nfilter-syscalls = false\n' > /etc/nix/nix.conf \
+  && printf 'experimental-features = nix-command\n' >> /etc/nix/nix.conf \
+  && for n in $(seq 1 10); do useradd -c "Nix build user $n" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(command -v nologin)" "nixbld$n"; done
+
+SHELL ["/bin/bash", "-ol", "pipefail", "-c"]
+RUN set -o pipefail && curl -L https://nixos.org/nix/install | bash \
+    && /nix/var/nix/profiles/default/bin/nix-channel --remove nixpkgs \
+    && /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-old \
+    && printf 'if [ -d $HOME/.nix-profile/etc/profile.d ]; then\n for i in $HOME/.nix-profile/etc/profile.d/*.sh; do\n if [ -r $i ]; then\n . $i\n fi\n done\n fi\n' >> /root/.profile
+
+ENV \
+  ENV=/etc/profile \
+  USER=root \
+  PATH=/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:/bin:/sbin:/usr/bin:/usr/sbin \
+  GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt \
+  NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+  NIX_PATH=/nix/var/nix/profiles/per-user/root/channels \
+  NIXPKGS_ALLOW_BROKEN=1 \
+  NIXPKGS_ALLOW_UNFREE=1 \
+  LD_LIBRARY_PATH=/usr/lib \
+  CPATH=~/.nix-profile/include:$CPATH \
+  LIBRARY_PATH=~/.nix-profile/lib:$LIBRARY_PATH \
+  QTDIR=~/.nix-profile:$QTDIR


### PR DESCRIPTION
Create an Ubuntu base image to test against.
There are a few reasons for wanting to switch from Debian to Ubuntu

- Better security updates. Most notably it has out of the box support for OpenSSL, which is now the default in Nixpkgs.
- The default for many other platforms such as GitHub actions, Heroku, and Paketo buildpacks
- Produces a 20MB smaller image

This PR does not change the default in Nixpacks. It just simply sets up publishing of an Ubuntu base image to a GitHub and Dockerhub registries

![image](https://user-images.githubusercontent.com/3044853/207455726-b129a380-143e-4f40-92ca-519f89eb1808.png)

