### PR TITLE
Fix Rust custom toolchain file support

### DIFF
--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -207,7 +207,7 @@ impl RustProvider {
 
         if let Some(toolchain_file) = RustProvider::get_rust_toolchain_file(app) {
             return Ok(Pkg::new(&format!(
-                "(rust-bin.fromRustupToolchainFile ./{})",
+                "(rust-bin.fromRustupToolchainFile ../{})",
                 toolchain_file
             )));
         }

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -373,7 +373,7 @@ mod test {
                 &App::new("./examples/rust-custom-toolchain")?,
                 &Environment::default()
             )?,
-            Pkg::new("(rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)")
+            Pkg::new("(rust-bin.fromRustupToolchainFile ../rust-toolchain.toml)")
         );
 
         Ok(())

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -688,6 +688,13 @@ async fn test_rust_custom_version() {
 }
 
 #[tokio::test]
+async fn test_rust_toolchain_file() {
+    let name = simple_build("./examples/rust-custom-toolchain").await;
+    let output = run_image(&name, None).await;
+    assert!(output.contains("cargo 1.60.0-nightly"));
+}
+
+#[tokio::test]
 async fn test_rust_ring() {
     let name = simple_build("./examples/rust-ring").await;
     let output = run_image(&name, None).await;


### PR DESCRIPTION
This PR fixes `rust-toolchain.toml` file support by
- Adding support to copy files into the build image before packages are installed with Nix
- Fix the rust-toolchain file path
- Add a docker run test for custom rust toolchain support

Fixes https://github.com/railwayapp/nixpacks/issues/686