### PR TITLE
Add traits Send And Sync to the Provider type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ mod chain;
 pub mod nixpacks;
 pub mod providers;
 
-pub fn get_providers() -> &'static [&'static dyn Provider] {
+pub fn get_providers() -> &'static [&'static (dyn Provider + Send + Sync)] {
     &[
         &CrystalProvider {},
         &CSharpProvider {},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ mod chain;
 pub mod nixpacks;
 pub mod providers;
 
-pub fn get_providers() -> &'static [&'static (dyn Provider + Send + Sync)] {
+pub fn get_providers() -> &'static [&'static (dyn Provider)] {
     &[
         &CrystalProvider {},
         &CSharpProvider {},

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -25,7 +25,7 @@ pub struct GeneratePlanOptions {
 }
 
 pub struct NixpacksBuildPlanGenerator<'a> {
-    providers: &'a [&'a dyn Provider],
+    providers: &'a [&'a (dyn Provider + Send + Sync)],
     config: GeneratePlanOptions,
 }
 
@@ -47,7 +47,7 @@ impl<'a> PlanGenerator for NixpacksBuildPlanGenerator<'a> {
 
 impl NixpacksBuildPlanGenerator<'_> {
     pub fn new<'a>(
-        providers: &'a [&'a dyn Provider],
+        providers: &'a [&'a (dyn Provider + Send + Sync)],
         config: GeneratePlanOptions,
     ) -> NixpacksBuildPlanGenerator<'a> {
         NixpacksBuildPlanGenerator { providers, config }

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -25,7 +25,7 @@ pub struct GeneratePlanOptions {
 }
 
 pub struct NixpacksBuildPlanGenerator<'a> {
-    providers: &'a [&'a (dyn Provider + Send + Sync)],
+    providers: &'a [&'a (dyn Provider)],
     config: GeneratePlanOptions,
 }
 
@@ -47,7 +47,7 @@ impl<'a> PlanGenerator for NixpacksBuildPlanGenerator<'a> {
 
 impl NixpacksBuildPlanGenerator<'_> {
     pub fn new<'a>(
-        providers: &'a [&'a (dyn Provider + Send + Sync)],
+        providers: &'a [&'a (dyn Provider)],
         config: GeneratePlanOptions,
     ) -> NixpacksBuildPlanGenerator<'a> {
         NixpacksBuildPlanGenerator { providers, config }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -22,7 +22,7 @@ pub mod staticfile;
 pub mod swift;
 pub mod zig;
 
-pub trait Provider {
+pub trait Provider: Send + Sync {
     fn name(&self) -> &str;
     fn detect(&self, _app: &App, _env: &Environment) -> Result<bool> {
         Ok(false)


### PR DESCRIPTION
This adds support for running `create_docker_image` inside of tokio threads. 