### PR TITLE
do not use corepack for node 14

### DIFF
--- a/docs/pages/docs/providers/node.md
+++ b/docs/pages/docs/providers/node.md
@@ -84,6 +84,8 @@ For example, To install a specific version of PNPM, add a `packageManager` key t
 }
 ```
 
+Corepack will only be used on Node 16 and above.
+
 ## Bun Support
 
 We support Bun, but due to Bun being in alpha, it is unstable and very experimental.


### PR DESCRIPTION
This PR prevents the use of Corepack to install a Node package manager for Node 14
