### PR TITLE
Pass the nixpacks.toml variables to the providers

### DIFF
--- a/examples/go-cgo-enabled/nixpacks.toml
+++ b/examples/go-cgo-enabled/nixpacks.toml
@@ -1,0 +1,2 @@
+[variables]
+CGO_ENABLED = "1"

--- a/examples/go-cgo-enabled/test.env
+++ b/examples/go-cgo-enabled/test.env
@@ -1,3 +1,0 @@
-# Note: You do NOT need this for your project. This file is only used for testing purposes.
-
-ENVS="CGO_ENABLED=1"

--- a/src/nixpacks/environment.rs
+++ b/src/nixpacks/environment.rs
@@ -67,6 +67,12 @@ impl Environment {
     pub fn clone_variables(env: &Environment) -> EnvironmentVariables {
         env.variables.clone()
     }
+
+    pub fn append_variables(env: &Environment, variables: EnvironmentVariables) -> Environment {
+        let mut new_env = Environment::new(Environment::clone_variables(env));
+        new_env.variables.extend(variables);
+        new_env
+    }
 }
 
 #[cfg(test)]

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -57,6 +57,12 @@ impl NixpacksBuildPlanGenerator<'_> {
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<BuildPlan> {
         let plan_before_providers = self.get_plan_before_providers(app, env)?;
 
+        // Add the variables from the nixpacks.toml to environment
+        let env = &Environment::append_variables(
+            env,
+            plan_before_providers.variables.clone().unwrap_or_default(),
+        );
+
         let provider_plan =
             self.get_plan_from_providers(app, env, plan_before_providers.providers.clone())?;
 


### PR DESCRIPTION
This PR extends the environment variables passed to the providers with the variables defined in any `nixpacks.toml` file.

Fixes #722 