### PR TITLE
PNPM fixes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+generate_plan_tests = "test --package nixpacks --lib --test generate_plan_tests"

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -25,7 +25,7 @@ const DEFAULT_NODE_PKG_NAME: &str = "nodejs-16_x";
 const AVAILABLE_NODE_VERSIONS: &[u32] = &[14, 16, 18];
 
 const YARN_CACHE_DIR: &str = "/usr/local/share/.cache/yarn/v6";
-const PNPM_CACHE_DIR: &str = "/root/.cache/pnpm";
+const PNPM_CACHE_DIR: &str = "root/.local/share/pnpm/store/v3";
 const NPM_CACHE_DIR: &str = "/root/.npm";
 const BUN_CACHE_DIR: &str = "/root/.bun";
 const CYPRESS_CACHE_DIR: &str = "/root/.cache/Cypress";

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -25,7 +25,7 @@ const DEFAULT_NODE_PKG_NAME: &str = "nodejs-16_x";
 const AVAILABLE_NODE_VERSIONS: &[u32] = &[14, 16, 18];
 
 const YARN_CACHE_DIR: &str = "/usr/local/share/.cache/yarn/v6";
-const PNPM_CACHE_DIR: &str = "root/.local/share/pnpm/store/v3";
+const PNPM_CACHE_DIR: &str = "/root/.local/share/pnpm/store/v3";
 const NPM_CACHE_DIR: &str = "/root/.npm";
 const BUN_CACHE_DIR: &str = "/root/.bun";
 const CYPRESS_CACHE_DIR: &str = "/root/.cache/Cypress";

--- a/src/providers/node/nx.rs
+++ b/src/providers/node/nx.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::nixpacks::{app::App, environment::Environment};
+use crate::providers::node::NodeProvider;
 
 #[derive(Debug, Serialize, PartialEq, Eq, Deserialize)]
 pub struct NxJson {
@@ -90,8 +91,12 @@ impl Nx {
     }
 
     pub fn get_nx_build_cmd(app: &App, env: &Environment) -> Option<String> {
-        Nx::get_nx_app_name(app, env)
-            .map(|nx_app_name| format!("npx nx run {nx_app_name}:build:production"))
+        Nx::get_nx_app_name(app, env).map(|nx_app_name| {
+            format!(
+                "{} nx run {nx_app_name}:build:production",
+                NodeProvider::get_package_manager_dlx_command(app)
+            )
+        })
     }
 
     pub fn get_nx_start_cmd(app: &App, env: &Environment) -> Result<Option<String>> {
@@ -106,10 +111,16 @@ impl Nx {
             if let Some(start_target) = project_json.targets.start {
                 if let Some(configurations) = start_target.configurations {
                     if configurations.production.is_some() {
-                        return Ok(Some(format!("npx nx run {nx_app_name}:start:production")));
+                        return Ok(Some(format!(
+                            "{} nx run {nx_app_name}:start:production",
+                            NodeProvider::get_package_manager_dlx_command(app)
+                        )));
                     }
                 }
-                return Ok(Some(format!("npx nx run {nx_app_name}:start")));
+                return Ok(Some(format!(
+                    "{} nx run {nx_app_name}:start",
+                    NodeProvider::get_package_manager_dlx_command(app)
+                )));
             }
 
             if project_json.targets.build.executor == "@nrwl/next:build" {

--- a/src/providers/node/turborepo.rs
+++ b/src/providers/node/turborepo.rs
@@ -92,7 +92,7 @@ impl Turborepo {
                 return Ok(Some(if pkg_manager == "pnpm" {
                     format!("pnpm --filter {name} run start")
                 } else {
-                    format!("{} --workspace {} run start", pkg_manager, name)
+                    format!("{pkg_manager} --workspace {name} run start")
                 }));
             }
             println!("Warning: Turborepo app `{name}` not found");

--- a/src/providers/node/turborepo.rs
+++ b/src/providers/node/turborepo.rs
@@ -89,10 +89,11 @@ impl Turborepo {
                 },
                 &name,
             )? {
-                return Ok(Some(format!(
-                    "{} --workspace {} run start",
-                    pkg_manager, name
-                )));
+                return Ok(Some(if pkg_manager == "pnpm" {
+                    format!("pnpm --filter {name} run start")
+                } else {
+                    format!("{} --workspace {} run start", pkg_manager, name)
+                }));
             }
             println!("Warning: Turborepo app `{name}` not found");
         }

--- a/tests/snapshots/generate_plan_tests__node_pnpm.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm.snap
@@ -33,7 +33,7 @@ expression: plan
         "pnpm i --frozen-lockfile"
       ],
       "cacheDirectories": [
-        "root/.local/share/pnpm/store/v3"
+        "/root/.local/share/pnpm/store/v3"
       ],
       "paths": [
         "/app/node_modules/.bin"

--- a/tests/snapshots/generate_plan_tests__node_pnpm.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm.snap
@@ -33,7 +33,7 @@ expression: plan
         "pnpm i --frozen-lockfile"
       ],
       "cacheDirectories": [
-        "/root/.cache/pnpm"
+        "root/.local/share/pnpm/store/v3"
       ],
       "paths": [
         "/app/node_modules/.bin"

--- a/tests/snapshots/generate_plan_tests__node_pnpm_custom_node_version.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_custom_node_version.snap
@@ -33,7 +33,7 @@ expression: plan
         "pnpm i --frozen-lockfile"
       ],
       "cacheDirectories": [
-        "root/.local/share/pnpm/store/v3"
+        "/root/.local/share/pnpm/store/v3"
       ],
       "paths": [
         "/app/node_modules/.bin"

--- a/tests/snapshots/generate_plan_tests__node_pnpm_custom_node_version.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_custom_node_version.snap
@@ -33,7 +33,7 @@ expression: plan
         "pnpm i --frozen-lockfile"
       ],
       "cacheDirectories": [
-        "/root/.cache/pnpm"
+        "root/.local/share/pnpm/store/v3"
       ],
       "paths": [
         "/app/node_modules/.bin"

--- a/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
@@ -33,7 +33,7 @@ expression: plan
         "pnpm i --frozen-lockfile"
       ],
       "cacheDirectories": [
-        "root/.local/share/pnpm/store/v3"
+        "/root/.local/share/pnpm/store/v3"
       ],
       "paths": [
         "/app/node_modules/.bin"

--- a/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
@@ -33,7 +33,7 @@ expression: plan
         "pnpm i --frozen-lockfile"
       ],
       "cacheDirectories": [
-        "/root/.cache/pnpm"
+        "root/.local/share/pnpm/store/v3"
       ],
       "paths": [
         "/app/node_modules/.bin"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR fixes the PNPM cache directory and the way NX apps are started with PNPM. This also contains some general nx fixes which swaps from using `npx` always to the package manager dlx command.

Fixes #702, #701

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
