### PR TITLE
Cache tsbuildinfo files

### DIFF
--- a/examples/node-typescript-incremental-extends/.gitignore
+++ b/examples/node-typescript-incremental-extends/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/node-typescript-incremental-extends/extendme.json
+++ b/examples/node-typescript-incremental-extends/extendme.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "incremental": false,
+        "outDir": "pleasehelp"
+    }
+}

--- a/examples/node-typescript-incremental-extends/index.ts
+++ b/examples/node-typescript-incremental-extends/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello, world!")

--- a/examples/node-typescript-incremental-extends/package-lock.json
+++ b/examples/node-typescript-incremental-extends/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "typescript-incremental",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-incremental",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "typescript": "^4.9.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true
+    }
+  }
+}

--- a/examples/node-typescript-incremental-extends/package.json
+++ b/examples/node-typescript-incremental-extends/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "typescript-incremental",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "^4.9.4"
+  }
+}

--- a/examples/node-typescript-incremental-extends/tsconfig.json
+++ b/examples/node-typescript-incremental-extends/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./extendme.json",
+    "compilerOptions": {
+        "incremental": true
+    }
+}

--- a/examples/node-typescript-incremental-out-dir/.gitignore
+++ b/examples/node-typescript-incremental-out-dir/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/node-typescript-incremental-out-dir/index.ts
+++ b/examples/node-typescript-incremental-out-dir/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello, world!")

--- a/examples/node-typescript-incremental-out-dir/package-lock.json
+++ b/examples/node-typescript-incremental-out-dir/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "typescript-incremental",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-incremental",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "typescript": "^4.9.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true
+    }
+  }
+}

--- a/examples/node-typescript-incremental-out-dir/package.json
+++ b/examples/node-typescript-incremental-out-dir/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "typescript-incremental-out-dir",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "^4.9.4"
+  }
+}

--- a/examples/node-typescript-incremental-out-dir/tsconfig.json
+++ b/examples/node-typescript-incremental-out-dir/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "incremental": true,
+        "outDir": "dist"
+    }
+}

--- a/examples/node-typescript-incremental-tsbuildinfo-path/.gitignore
+++ b/examples/node-typescript-incremental-tsbuildinfo-path/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/node-typescript-incremental-tsbuildinfo-path/index.ts
+++ b/examples/node-typescript-incremental-tsbuildinfo-path/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello, world!")

--- a/examples/node-typescript-incremental-tsbuildinfo-path/package-lock.json
+++ b/examples/node-typescript-incremental-tsbuildinfo-path/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "typescript-incremental",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-incremental",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "typescript": "^4.9.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true
+    }
+  }
+}

--- a/examples/node-typescript-incremental-tsbuildinfo-path/package.json
+++ b/examples/node-typescript-incremental-tsbuildinfo-path/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "typescript-incremental-tsbuildinfo-path",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "^4.9.4"
+  }
+}

--- a/examples/node-typescript-incremental-tsbuildinfo-path/tsconfig.json
+++ b/examples/node-typescript-incremental-tsbuildinfo-path/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": "typescriptbuildinfo"
+    }
+}

--- a/examples/node-typescript-incremental/.gitignore
+++ b/examples/node-typescript-incremental/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/node-typescript-incremental/index.ts
+++ b/examples/node-typescript-incremental/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello, world!")

--- a/examples/node-typescript-incremental/package-lock.json
+++ b/examples/node-typescript-incremental/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "typescript-incremental",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-incremental",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "typescript": "^4.9.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true
+    }
+  }
+}

--- a/examples/node-typescript-incremental/package.json
+++ b/examples/node-typescript-incremental/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "typescript-incremental",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "^4.9.4"
+  }
+}

--- a/examples/node-typescript-incremental/tsconfig.json
+++ b/examples/node-typescript-incremental/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "incremental": true
+    }
+}

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -1,5 +1,6 @@
 use self::{nx::Nx, turborepo::Turborepo};
 use super::Provider;
+use crate::nixpacks::plan::merge::Mergeable;
 use crate::nixpacks::{
     app::App,
     environment::{Environment, EnvironmentVariables},
@@ -30,6 +31,40 @@ const NPM_CACHE_DIR: &str = "/root/.npm";
 const BUN_CACHE_DIR: &str = "/root/.bun";
 const CYPRESS_CACHE_DIR: &str = "/root/.cache/Cypress";
 const NODE_MODULES_CACHE_DIR: &str = "node_modules/.cache";
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+struct TsConfigJson {
+    #[serde(rename = "compilerOptions")]
+    compiler_options: Option<TsConfigCompilerOptions>,
+    extends: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+struct TsConfigCompilerOptions {
+    incremental: Option<bool>,
+    #[serde(rename = "tsBuildInfoFile")]
+    ts_build_info_file: Option<String>,
+    #[serde(rename = "outDir")]
+    out_dir: Option<String>,
+}
+
+impl Mergeable for TsConfigCompilerOptions {
+    fn merge(
+        c1: &TsConfigCompilerOptions,
+        c2: &TsConfigCompilerOptions,
+    ) -> TsConfigCompilerOptions {
+        let mut new_compileroptions = c1.clone();
+        let compileroptions2 = c2.clone();
+        new_compileroptions.incremental = compileroptions2
+            .incremental
+            .or(new_compileroptions.incremental);
+        new_compileroptions.out_dir = compileroptions2.out_dir.or(new_compileroptions.out_dir);
+        new_compileroptions.ts_build_info_file = compileroptions2
+            .ts_build_info_file
+            .or(new_compileroptions.ts_build_info_file);
+        new_compileroptions
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
@@ -136,6 +171,32 @@ impl Provider for NodeProvider {
 
         // Node modules cache directory
         build.add_cache_directory((*NODE_MODULES_CACHE_DIR).to_string());
+
+        let mut ts_config: TsConfigJson = app.read_json("tsconfig.json").unwrap_or_default();
+        if let Some(ref extends) = ts_config.extends {
+            let ex: TsConfigJson = app.read_json(extends.as_str()).unwrap_or_default();
+            ts_config.compiler_options = Some(TsConfigCompilerOptions::merge(
+                &ex.compiler_options.unwrap_or_default(),
+                &ts_config.compiler_options.unwrap_or_default(),
+            ));
+        }
+        if let Some(compiler_options) = ts_config.compiler_options {
+            if let Some(incremental) = compiler_options.incremental {
+                // if incremental is enabled
+                if incremental {
+                    if let Some(ts_build_info_file) = compiler_options.ts_build_info_file {
+                        // if config file is explicitly provided
+                        build.add_cache_directory(ts_build_info_file);
+                    } else if let Some(out_dir) = compiler_options.out_dir {
+                        // if it is not provided but outdir is, use that
+                        build.add_cache_directory(format!("{out_dir}/tsconfig.tsbuildinfo"));
+                    } else {
+                        // if not out dir is set
+                        build.add_cache_directory("tsconfig.tsbuildinfo");
+                    }
+                }
+            }
+        }
 
         // Start
         let start = NodeProvider::get_start_cmd(app, env)?.map(StartPhase::new);

--- a/tests/snapshots/generate_plan_tests__node_npm.snap
+++ b/tests/snapshots/generate_plan_tests__node_npm.snap
@@ -21,7 +21,8 @@ expression: plan
         "npm run build"
       ],
       "cacheDirectories": [
-        "node_modules/.cache"
+        "node_modules/.cache",
+        "dist/tsconfig.tsbuildinfo"
       ]
     },
     "install": {

--- a/tests/snapshots/generate_plan_tests__node_npm_old_lockfile.snap
+++ b/tests/snapshots/generate_plan_tests__node_npm_old_lockfile.snap
@@ -21,7 +21,8 @@ expression: plan
         "npm run build"
       ],
       "cacheDirectories": [
-        "node_modules/.cache"
+        "node_modules/.cache",
+        "dist/tsconfig.tsbuildinfo"
       ]
     },
     "install": {

--- a/tests/snapshots/generate_plan_tests__node_pnpm.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm.snap
@@ -21,7 +21,8 @@ expression: plan
         "pnpm run build"
       ],
       "cacheDirectories": [
-        "node_modules/.cache"
+        "node_modules/.cache",
+        "dist/tsconfig.tsbuildinfo"
       ]
     },
     "install": {

--- a/tests/snapshots/generate_plan_tests__node_pnpm_custom_node_version.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_custom_node_version.snap
@@ -21,7 +21,8 @@ expression: plan
         "pnpm run build"
       ],
       "cacheDirectories": [
-        "node_modules/.cache"
+        "node_modules/.cache",
+        "dist/tsconfig.tsbuildinfo"
       ]
     },
     "install": {

--- a/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
@@ -21,7 +21,8 @@ expression: plan
         "pnpm run build"
       ],
       "cacheDirectories": [
-        "node_modules/.cache"
+        "node_modules/.cache",
+        "dist/tsconfig.tsbuildinfo"
       ]
     },
     "install": {

--- a/tests/snapshots/generate_plan_tests__node_typescript_incremental.snap
+++ b/tests/snapshots/generate_plan_tests__node_typescript_incremental.snap
@@ -17,12 +17,9 @@ expression: plan
       "dependsOn": [
         "install"
       ],
-      "cmds": [
-        "yarn run build"
-      ],
       "cacheDirectories": [
         "node_modules/.cache",
-        "dist/tsconfig.tsbuildinfo"
+        "tsconfig.tsbuildinfo"
       ]
     },
     "install": {
@@ -31,11 +28,10 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "npm install -g corepack && corepack enable",
-        "yarn install --check-cache"
+        "npm ci"
       ],
       "cacheDirectories": [
-        "/usr/local/share/.cache/yarn/v6"
+        "/root/.npm"
       ],
       "paths": [
         "/app/node_modules/.bin"
@@ -45,15 +41,12 @@ expression: plan
       "name": "setup",
       "nixPkgs": [
         "nodejs-16_x",
-        "yarn-1_x"
+        "npm-8_x"
       ],
       "nixOverlays": [
         "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
       ],
       "nixpkgsArchive": "[archive]"
     }
-  },
-  "start": {
-    "cmd": "yarn run start"
   }
 }

--- a/tests/snapshots/generate_plan_tests__node_typescript_incremental_extends.snap
+++ b/tests/snapshots/generate_plan_tests__node_typescript_incremental_extends.snap
@@ -17,12 +17,9 @@ expression: plan
       "dependsOn": [
         "install"
       ],
-      "cmds": [
-        "yarn run build"
-      ],
       "cacheDirectories": [
         "node_modules/.cache",
-        "dist/tsconfig.tsbuildinfo"
+        "pleasehelp/tsconfig.tsbuildinfo"
       ]
     },
     "install": {
@@ -31,11 +28,10 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "npm install -g corepack && corepack enable",
-        "yarn install --check-cache"
+        "npm ci"
       ],
       "cacheDirectories": [
-        "/usr/local/share/.cache/yarn/v6"
+        "/root/.npm"
       ],
       "paths": [
         "/app/node_modules/.bin"
@@ -45,15 +41,12 @@ expression: plan
       "name": "setup",
       "nixPkgs": [
         "nodejs-16_x",
-        "yarn-1_x"
+        "npm-8_x"
       ],
       "nixOverlays": [
         "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
       ],
       "nixpkgsArchive": "[archive]"
     }
-  },
-  "start": {
-    "cmd": "yarn run start"
   }
 }

--- a/tests/snapshots/generate_plan_tests__node_typescript_incremental_out_dir.snap
+++ b/tests/snapshots/generate_plan_tests__node_typescript_incremental_out_dir.snap
@@ -17,9 +17,6 @@ expression: plan
       "dependsOn": [
         "install"
       ],
-      "cmds": [
-        "yarn run build"
-      ],
       "cacheDirectories": [
         "node_modules/.cache",
         "dist/tsconfig.tsbuildinfo"
@@ -31,11 +28,10 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "npm install -g corepack && corepack enable",
-        "yarn install --check-cache"
+        "npm ci"
       ],
       "cacheDirectories": [
-        "/usr/local/share/.cache/yarn/v6"
+        "/root/.npm"
       ],
       "paths": [
         "/app/node_modules/.bin"
@@ -45,15 +41,12 @@ expression: plan
       "name": "setup",
       "nixPkgs": [
         "nodejs-16_x",
-        "yarn-1_x"
+        "npm-8_x"
       ],
       "nixOverlays": [
         "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
       ],
       "nixpkgsArchive": "[archive]"
     }
-  },
-  "start": {
-    "cmd": "yarn run start"
   }
 }

--- a/tests/snapshots/generate_plan_tests__node_typescript_incremental_tsbuildinfo_path.snap
+++ b/tests/snapshots/generate_plan_tests__node_typescript_incremental_tsbuildinfo_path.snap
@@ -17,12 +17,9 @@ expression: plan
       "dependsOn": [
         "install"
       ],
-      "cmds": [
-        "yarn run build"
-      ],
       "cacheDirectories": [
         "node_modules/.cache",
-        "dist/tsconfig.tsbuildinfo"
+        "typescriptbuildinfo"
       ]
     },
     "install": {
@@ -31,11 +28,10 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "npm install -g corepack && corepack enable",
-        "yarn install --check-cache"
+        "npm ci"
       ],
       "cacheDirectories": [
-        "/usr/local/share/.cache/yarn/v6"
+        "/root/.npm"
       ],
       "paths": [
         "/app/node_modules/.bin"
@@ -45,15 +41,12 @@ expression: plan
       "name": "setup",
       "nixPkgs": [
         "nodejs-16_x",
-        "yarn-1_x"
+        "npm-8_x"
       ],
       "nixOverlays": [
         "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
       ],
       "nixpkgsArchive": "[archive]"
     }
-  },
-  "start": {
-    "cmd": "yarn run start"
   }
 }

--- a/tests/snapshots/generate_plan_tests__node_yarn.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn.snap
@@ -21,7 +21,8 @@ expression: plan
         "yarn run build"
       ],
       "cacheDirectories": [
-        "node_modules/.cache"
+        "node_modules/.cache",
+        "dist/tsconfig.tsbuildinfo"
       ]
     },
     "install": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR caches .tsbuildinfo files. They are found in a variety of ways:
- If incremental is turned on in comilerOptions, and nothing else is provided, it will default to `tsconfig.tsbuildinfo`
- If incremental is turned on and an outDir is specified, it will be `{OUTDIR}/tsconfig.tsbuildinfo`
- If incremental is turned on and a tsbuildnfo file is provided, it will cache that file.
- This also supports extending other tsconfigs.

Fixes #626

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
