### PR TITLE
Use `cargo binstall` in codespace installation

### DIFF
--- a/.devcontainer/library-scripts/rust-debian.sh
+++ b/.devcontainer/library-scripts/rust-debian.sh
@@ -206,7 +206,8 @@ if [ "${UPDATE_RUST}" = "true" ]; then
 fi
 echo "Installing common Rust dependencies..."
 rustup component add rls rust-analysis rust-src rustfmt clippy 2>&1
-cargo install cargo-release cargo-deb cargo-insta 2>&1
+cargo install cargo-binstall 2>&1
+cargo binstall cargo-release cargo-deb cargo-insta 2>&1
 
 # Add CARGO_HOME, RUSTUP_HOME and bin directory into bashrc/zshrc files (unless disabled)
 updaterc "$(cat << EOF


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR uses cargo-binstall in the `rust-debian.sh` script to install packages faster.

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
