### PR TITLE
Fix cargo-binstall not installing in devcontainer configuration

### DIFF
--- a/.devcontainer/library-scripts/rust-debian.sh
+++ b/.devcontainer/library-scripts/rust-debian.sh
@@ -207,7 +207,7 @@ fi
 echo "Installing common Rust dependencies..."
 rustup component add rls rust-analysis rust-src rustfmt clippy 2>&1
 cargo install cargo-binstall 2>&1
-cargo binstall cargo-release cargo-deb cargo-insta 2>&1
+cargo binstall cargo-release cargo-deb cargo-insta -y 2>&1
 
 # Add CARGO_HOME, RUSTUP_HOME and bin directory into bashrc/zshrc files (unless disabled)
 updaterc "$(cat << EOF


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR adds `-y` to cargo-binstall.

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
