### PR TITLE
allow insecure nix package installs

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -26,6 +26,7 @@ ENV \
   NIX_PATH=/nix/var/nix/profiles/per-user/root/channels \
   NIXPKGS_ALLOW_BROKEN=1 \
   NIXPKGS_ALLOW_UNFREE=1 \
+  NIXPKGS_ALLOW_INSECURE=1 \
   LD_LIBRARY_PATH=/usr/lib \
   CPATH=~/.nix-profile/include:$CPATH \
   LIBRARY_PATH=~/.nix-profile/lib:$LIBRARY_PATH \

--- a/base/ubuntu/Dockerfile
+++ b/base/ubuntu/Dockerfile
@@ -26,6 +26,7 @@ ENV \
   NIX_PATH=/nix/var/nix/profiles/per-user/root/channels \
   NIXPKGS_ALLOW_BROKEN=1 \
   NIXPKGS_ALLOW_UNFREE=1 \
+  NIXPKGS_ALLOW_INSECURE=1 \
   LD_LIBRARY_PATH=/usr/lib \
   CPATH=~/.nix-profile/include:$CPATH \
   LIBRARY_PATH=~/.nix-profile/lib:$LIBRARY_PATH \


### PR DESCRIPTION
This PR allows insecure Nix package installs. This is needed to install Python 2.7, which has reached its end of life.

![image](https://user-images.githubusercontent.com/3044853/211440740-0824debf-cc4d-4a1f-b3a2-98a0f7c523da.png)
