### PR TITLE
use latest base debian and ubuntu images

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20220801-slim
+FROM debian:bullseye-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/base/ubuntu/Dockerfile
+++ b/base/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy-20221130
+FROM ubuntu:jammy
 
 ARG DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
 


### PR DESCRIPTION
Use the latest debian and ubuntu base images. The Nixpacks base images will be updated once per week with the action schedule. Currently the debian/ubuntu base images are never updated.
