### PR TITLE
Use ubuntu image for all Ruby

### DIFF
--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -2,7 +2,6 @@ use super::{node::NodeProvider, Provider};
 use crate::nixpacks::{
     app::App,
     environment::{Environment, EnvironmentVariables},
-    images::DEBIAN_BASE_IMAGE,
     nix::pkg::Pkg,
     plan::{
         phase::{Phase, StartPhase},

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -10,7 +10,7 @@ use crate::nixpacks::{
 };
 use anyhow::{bail, Ok, Result};
 use regex::Regex;
-use semver::Version;
+
 
 pub struct RubyProvider {}
 
@@ -240,21 +240,6 @@ impl RubyProvider {
             "bundler".to_string()
         } else {
             "bundler".to_string()
-        }
-    }
-
-    fn requires_openssl_1(&self, app: &App) -> Result<bool> {
-        let ruby_version = self.get_ruby_version(app)?;
-        match Version::parse(ruby_version.trim_start_matches("ruby-")) {
-            std::result::Result::Ok(v) => {
-                // Version 3.1.0 and above work with openssl 3.0
-                if v.major >= 3 && v.minor >= 1 {
-                    Ok(false)
-                } else {
-                    Ok(true)
-                }
-            }
-            std::result::Result::Err(_) => Ok(false),
         }
     }
 

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -11,7 +11,6 @@ use crate::nixpacks::{
 use anyhow::{bail, Ok, Result};
 use regex::Regex;
 
-
 pub struct RubyProvider {}
 
 const BUNDLE_CACHE_DIR: &str = "/root/.bundle/cache";

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -53,11 +53,6 @@ impl Provider for RubyProvider {
 
         plan.add_variables(self.get_environment_variables(app)?);
 
-        // Temporary fix to allow using older versions of ruby
-        if self.requires_openssl_1(app)? {
-            plan.build_image = Some(DEBIAN_BASE_IMAGE.to_string());
-        }
-
         Ok(Some(plan))
     }
 }


### PR DESCRIPTION
This PR removes the forcing of the Debian image for Ruby 2 builds since rbenv can correctly handle Openssl 3
