### PR TITLE
cargo snapshot alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
 generate_plan_tests = "test --package nixpacks --lib --test generate_plan_tests"
+snapshot = "insta test --review -- --test generate_plan_tests"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ Test and review the generate plan tests.
 
 ```
 cargo insta test --review -- --test generate_plan_tests
+# or
+cargo snapshot
 ```
 
 The snapshots are checked into CI and are reviewed as part of the PR. They ensure that a change to one part of Nixpacks does not unexpectedly change an unrelated part.


### PR DESCRIPTION
Add a `cargo snapshot` alias to quickly run and review the insta snapshots.
