### PR TITLE
Add support for Clojure `tools.build` projects

### DIFF
--- a/docs/pages/docs/providers/clojure.md
+++ b/docs/pages/docs/providers/clojure.md
@@ -23,7 +23,7 @@ The version can be overriden by
 
 If a `build.clj` file for [`tools.build`](https://clojure.org/guides/tools_build) is found:
 ```
-clojure -T:build uber
+clojure -T:build uber; if [ -f /app/target/uberjar/*standalone.jar ]; then mv /app/target/uberjar/*standalone.jar /app/target/*standalone.jar; fi
 ```
 
 If the `lein-ring` plugin is found:

--- a/docs/pages/docs/providers/clojure.md
+++ b/docs/pages/docs/providers/clojure.md
@@ -4,7 +4,7 @@ title: Clojure
 
 # {% $markdoc.frontmatter.title %}
 
-Clojure is detected if a `project.clj` file is found.
+Clojure is detected if a `project.clj` or `build.clj` file is found.
 
 ## Setup
 
@@ -21,7 +21,12 @@ The version can be overriden by
 
 ## Build
 
-If `lein-ring` plugin detected
+If a `build.clj` file for [`tools.build`](https://clojure.org/guides/tools_build) is found:
+```
+clojure -T:build uber
+```
+
+If the `lein-ring` plugin is found:
 
 ```
 lein ring uberjar; if [ -f /app/target/uberjar/*standalone.jar ]; then mv /app/target/uberjar/standalone.jar /app/target/*standalone.jar; fi

--- a/examples/clojure-tools-build/.gitignore
+++ b/examples/clojure-tools-build/.gitignore
@@ -1,0 +1,1 @@
+/.cpcache

--- a/examples/clojure-tools-build/build.clj
+++ b/examples/clojure-tools-build/build.clj
@@ -1,0 +1,23 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]))
+
+(def lib 'clojure-example)
+(def version (format "1.2.%s" (b/git-count-revs nil)))
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def uber-file (format "target/%s-%s-standalone.jar" (name lib) version))
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn uber [_]
+  (clean nil)
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/compile-clj {:basis basis
+                  :src-dirs ["src"]
+                  :class-dir class-dir})
+  (b/uber {:class-dir class-dir
+           :uber-file uber-file
+           :basis basis
+           :main 'clojure-example.core}))

--- a/examples/clojure-tools-build/deps.edn
+++ b/examples/clojure-tools-build/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src"] ;; project paths
+ :deps {}       ;; project deps
+
+ :aliases
+ {;; Run with clj -T:build function-in-build
+  :build {:deps {io.github.clojure/tools.build {:git/tag "v0.9.2" :git/sha "fe6b140"}}
+          :ns-default build}}}

--- a/examples/clojure-tools-build/src/clojure_example/core.clj
+++ b/examples/clojure-tools-build/src/clojure_example/core.clj
@@ -1,0 +1,7 @@
+(ns clojure-example.core
+  (:gen-class))
+
+(defn -main
+  "I don't do a whole lot ... yet."
+  [& args]
+  (println "Hello, World From Clojure!"))

--- a/src/providers/clojure.rs
+++ b/src/providers/clojure.rs
@@ -21,22 +21,23 @@ impl Provider for ClojureProvider {
     }
 
     fn detect(&self, app: &App, _env: &Environment) -> Result<bool> {
-        Ok(app.includes_file("project.clj"))
+        Ok(self.is_using_lein(app) || self.is_using_tools_build(app))
     }
 
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<Option<BuildPlan>> {
         let setup = Phase::setup(Some(vec![
-            Pkg::new("leiningen"),
+            if self.is_using_tools_build(app) {
+                Pkg::new("clojure")
+            } else {
+                Pkg::new("leiningen")
+            },
             ClojureProvider::get_nix_jdk_package(app, env)?,
         ]));
 
-        let has_lein_ring_plugin = app
-            .read_file("project.clj")?
-            .to_lowercase()
-            .contains("[lein-ring ");
-
-        let build_cmd = if has_lein_ring_plugin {
+        let build_cmd = if self.has_lein_ring_plugin(app) {
             "lein ring uberjar"
+        } else if self.is_using_tools_build(app) {
+            "clojure -T:build uber"
         } else {
             "lein uberjar"
         };
@@ -54,6 +55,22 @@ impl Provider for ClojureProvider {
 }
 
 impl ClojureProvider {
+    fn has_lein_ring_plugin(&self, app: &App) -> bool {
+        self.is_using_lein(app) &&
+            app.read_file("project.clj")
+                .unwrap()
+                .to_lowercase()
+                .contains("[lein-ring ")
+    }
+
+    fn is_using_lein(&self, app: &App) -> bool {
+        app.includes_file("project.clj")
+    }
+
+    fn is_using_tools_build(&self, app: &App) -> bool {
+        app.includes_file("build.clj")
+    }
+
     fn get_custom_version(app: &App, env: &Environment) -> Result<String> {
         // Fetch version from configs
         let mut custom_version = env.get_config_variable("JDK_VERSION");

--- a/src/providers/clojure.rs
+++ b/src/providers/clojure.rs
@@ -34,10 +34,10 @@ impl Provider for ClojureProvider {
             ClojureProvider::get_nix_jdk_package(app, env)?,
         ]));
 
-        let build_cmd = if self.has_lein_ring_plugin(app) {
-            "lein ring uberjar"
-        } else if self.is_using_tools_build(app) {
+        let build_cmd = if self.is_using_tools_build(app) {
             "clojure -T:build uber"
+        } else if self.has_lein_ring_plugin(app) {
+            "lein ring uberjar"
         } else {
             "lein uberjar"
         };

--- a/src/providers/clojure.rs
+++ b/src/providers/clojure.rs
@@ -59,7 +59,7 @@ impl ClojureProvider {
         self.is_using_lein(app)
             && app
                 .read_file("project.clj")
-                .unwrap()
+                .unwrap_or_default()
                 .to_lowercase()
                 .contains("[lein-ring ")
     }

--- a/src/providers/clojure.rs
+++ b/src/providers/clojure.rs
@@ -56,8 +56,9 @@ impl Provider for ClojureProvider {
 
 impl ClojureProvider {
     fn has_lein_ring_plugin(&self, app: &App) -> bool {
-        self.is_using_lein(app) &&
-            app.read_file("project.clj")
+        self.is_using_lein(app)
+            && app
+                .read_file("project.clj")
                 .unwrap()
                 .to_lowercase()
                 .contains("[lein-ring ")

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -909,6 +909,13 @@ async fn test_clojure_ring_app() {
 }
 
 #[tokio::test]
+async fn test_clojure_tools_build() {
+    let name = simple_build("./examples/clojure-tools-build").await;
+    let output = run_image(&name, None).await;
+    assert_eq!(output, "Hello, World From Clojure!");
+}
+
+#[tokio::test]
 async fn test_cobol() {
     let name = simple_build("./examples/cobol").await;
     let output = run_image(&name, None).await;

--- a/tests/snapshots/generate_plan_tests__clojure_tools_build.snap
+++ b/tests/snapshots/generate_plan_tests__clojure_tools_build.snap
@@ -1,0 +1,35 @@
+---
+source: tests/generate_plan_tests.rs
+expression: plan
+---
+{
+  "providers": [],
+  "buildImage": "[build_image]",
+  "variables": {
+    "NIXPACKS_METADATA": "clojure"
+  },
+  "phases": {
+    "build": {
+      "name": "build",
+      "dependsOn": [
+        "install",
+        "setup"
+      ],
+      "cmds": [
+        "clojure -T:build uber; if [ -f /app/target/default+uberjar/*standalone.jar ]; then mv /app/target/default+uberjar/*standalone.jar /app/target/*standalone.jar; fi"
+      ]
+    },
+    "setup": {
+      "name": "setup",
+      "nixPkgs": [
+        "clojure",
+        "jdk8"
+      ],
+      "nixOverlays": [],
+      "nixpkgsArchive": "[archive]"
+    }
+  },
+  "start": {
+    "cmd": "bash -c \"java $JAVA_OPTS -jar /app/target/*standalone.jar\""
+  }
+}


### PR DESCRIPTION
The [`tools.build`](https://clojure.org/guides/tools_build) library is the official library for building Clojure projects from a `deps.edn` file. This PR uses the `build.clj` file for detection since technically other libraries besides `tools.build` could be built on top of `deps.edn` in the future.

Resolves https://github.com/railwayapp/nixpacks/issues/372.