### PR TITLE
Rust: support top-level main bin

### DIFF
--- a/examples/rust-multiple-bins/src/main.rs
+++ b/examples/rust-multiple-bins/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("This is the main Bin!");
+}

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -130,6 +130,13 @@ impl RustProvider {
     fn get_bins(app: &App) -> Result<Option<Vec<String>>> {
         let mut bins = vec![];
 
+        // Support the main bin
+        if let Some(name) = RustProvider::get_app_name(app)? {
+            if app.includes_file("src/main.rs") {
+                bins.push(name);
+            }
+        }
+
         if app.includes_directory("src/bin") {
             let find_bins = app.find_files("src/bin/*")?;
 
@@ -146,11 +153,9 @@ impl RustProvider {
 
                 bins.push(bin_name);
             }
+        }
 
-            return Ok(Some(bins));
-        } else if let Some(name) = RustProvider::get_app_name(app)? {
-            bins.push(name);
-
+        if bins.len() > 0 {
             return Ok(Some(bins));
         }
 

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -155,11 +155,11 @@ impl RustProvider {
             }
         }
 
-        if bins.len() > 0 {
-            return Ok(Some(bins));
+        if bins.is_empty() {
+            return Ok(None);
         }
 
-        Ok(None)
+        Ok(Some(bins))
     }
 
     fn get_start(app: &App, env: &Environment) -> Result<Option<StartPhase>> {

--- a/tests/generate_plan_tests.rs
+++ b/tests/generate_plan_tests.rs
@@ -85,6 +85,14 @@ fn test_rust_cargo_workspaces() {
 }
 
 #[test]
+fn test_rust_multiple_bins() {
+    let plan = simple_gen_plan("./examples/rust-multiple-bins");
+    let build = plan.get_phase("build").unwrap();
+
+    assert_eq!(build.clone().cmds.unwrap().len(), 5);
+}
+
+#[test]
 fn test_haskell_stack() {
     let plan = simple_gen_plan("./examples/haskell-stack");
     let install = plan.get_phase("install").unwrap();


### PR DESCRIPTION
If there are multiple bins in a `src/bin` directory, we did not also support the top-level `main.rs` file as a bin. This PR fixes that
