### PR TITLE
feat(scala): reduced scala sbt image size

### DIFF
--- a/src/providers/scala.rs
+++ b/src/providers/scala.rs
@@ -44,9 +44,14 @@ impl Provider for ScalaProvider {
             build.add_cache_directory("/root/.cache/coursier");
             build.depends_on_phase("setup");
 
-            let start_cmd = self.get_start_cmd(app).map(StartPhase::new);
+            let start_phase = self.get_start_cmd(app).map(StartPhase::new).map(|phase| {
+                let mut updated_phase = phase;
+                updated_phase.run_in_image("eclipse-temurin:17.0.5_8-jre-jammy".to_string());
+                updated_phase.add_file_dependency("./target/universal");
+                updated_phase
+            });
 
-            let plan = BuildPlan::new(&vec![setup, build], start_cmd);
+            let plan = BuildPlan::new(&vec![setup, build], start_phase);
             Ok(Some(plan))
         } else {
             Ok(None)

--- a/tests/snapshots/generate_plan_tests__scala_sbt.snap
+++ b/tests/snapshots/generate_plan_tests__scala_sbt.snap
@@ -35,6 +35,10 @@ expression: plan
     }
   },
   "start": {
-    "cmd": "./target/universal/stage/bin/main"
+    "cmd": "./target/universal/stage/bin/main",
+    "runImage": "eclipse-temurin:17.0.5_8-jre-jammy",
+    "onlyIncludeFiles": [
+      "./target/universal"
+    ]
   }
 }


### PR DESCRIPTION
The Start phase runs the scala jar in a lean eclipse temurin 17.0.5 (official adoptium) image with only the package files. This reduced the image size from 2GB to ~200mb for the example project.

Resolves #788 


<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
