### PR TITLE
Added Entrypoint to slim image

### DIFF
--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -310,6 +310,7 @@ impl DockerfileGenerator for StartPhase {
                 formatdoc! {"
                   # start
                   FROM {run_image}
+                  ENTRYPOINT [\"/bin/bash\", \"-l\", \"-c\"]
                   WORKDIR {APP_DIR}
                   COPY --from=0 /etc/ssl/certs /etc/ssl/certs
                   RUN true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR will add an ENTRYPOINT for the run_in_slim_image action. Having ```CMD ["my cmd"]``` doesn't function properly without an ENTRYPOINT executing the first argument in a shell.

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
