### PR TITLE
feat(scala): added NIXPACKS_JDK_VERSION env

### DIFF
--- a/docs/pages/docs/providers/scala.md
+++ b/docs/pages/docs/providers/scala.md
@@ -9,6 +9,17 @@ at Java. Scala is detected by `build.sbt` in project root.
 
 ## SBT Setup
 
+### JDK
+
+The following major JDK versions are available
+
+- `19`
+- `17` (Default)
+- `11`
+- `8`
+
+The version can be overridden by setting the `NIXPACKS_JDK_VERSION` environment variable.
+
 ### Requirements
 
 The project should contain the `sbt-native-packager` sbt plugin. This can be done

--- a/tests/snapshots/generate_plan_tests__scala_sbt.snap
+++ b/tests/snapshots/generate_plan_tests__scala_sbt.snap
@@ -27,8 +27,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "sbt",
-        "jdk"
+        "(sbt.override { jre = jdk17; })"
       ],
       "nixOverlays": [],
       "nixpkgsArchive": "[archive]"


### PR DESCRIPTION
NIXPACKS_JDK_VERSION dictates the jdk version used for compiling the scala project as well as the lean image that runs compiled application. Default version is 17.

Fixes #793 

<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
