### PR TITLE
Update default node version to 18 

### DIFF
--- a/docs/pages/docs/providers/node.md
+++ b/docs/pages/docs/providers/node.md
@@ -21,8 +21,8 @@ The Node provider sets the following environment variables:
 The following major versions are available
 
 - `14`
-- `16` (Default)
-- `18`
+- `16`
+- `18` (Default)
 
 The version can be overridden by
 

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -22,7 +22,7 @@ mod turborepo;
 
 pub const NODE_OVERLAY: &str = "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz";
 
-const DEFAULT_NODE_PKG_NAME: &str = "nodejs-16_x";
+const DEFAULT_NODE_PKG_NAME: &str = "nodejs-18_x";
 const AVAILABLE_NODE_VERSIONS: &[u32] = &[14, 16, 18];
 
 const YARN_CACHE_DIR: &str = "/usr/local/share/.cache/yarn/v6";

--- a/tests/snapshots/generate_plan_tests__multiple_providers.snap
+++ b/tests/snapshots/generate_plan_tests__multiple_providers.snap
@@ -83,7 +83,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__nested.snap
+++ b/tests/snapshots/generate_plan_tests__nested.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node.snap
+++ b/tests/snapshots/generate_plan_tests__node.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_canvas.snap
+++ b/tests/snapshots/generate_plan_tests__node_canvas.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixLibs": [

--- a/tests/snapshots/generate_plan_tests__node_custom_cache_directories.snap
+++ b/tests/snapshots/generate_plan_tests__node_custom_cache_directories.snap
@@ -40,7 +40,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_main_file.snap
+++ b/tests/snapshots/generate_plan_tests__node_main_file.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_main_file_not_exist.snap
+++ b/tests/snapshots/generate_plan_tests__node_main_file_not_exist.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_monorepo.snap
+++ b/tests/snapshots/generate_plan_tests__node_monorepo.snap
@@ -41,7 +41,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "yarn-1_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_no_scripts.snap
+++ b/tests/snapshots/generate_plan_tests__node_no_scripts.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_npm.snap
+++ b/tests/snapshots/generate_plan_tests__node_npm.snap
@@ -42,7 +42,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_npm_old_lockfile.snap
+++ b/tests/snapshots/generate_plan_tests__node_npm_old_lockfile.snap
@@ -42,7 +42,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-6_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_nx.snap
+++ b/tests/snapshots/generate_plan_tests__node_nx.snap
@@ -44,7 +44,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixLibs": [

--- a/tests/snapshots/generate_plan_tests__node_pnpm.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm.snap
@@ -42,7 +42,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "pnpm-6_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_v7.snap
@@ -42,7 +42,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "pnpm-7_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_puppeteer.snap
+++ b/tests/snapshots/generate_plan_tests__node_puppeteer.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_python.snap
+++ b/tests/snapshots/generate_plan_tests__node_python.snap
@@ -59,7 +59,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_typescript_incremental.snap
+++ b/tests/snapshots/generate_plan_tests__node_typescript_incremental.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_typescript_incremental_extends.snap
+++ b/tests/snapshots/generate_plan_tests__node_typescript_incremental_extends.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_typescript_incremental_out_dir.snap
+++ b/tests/snapshots/generate_plan_tests__node_typescript_incremental_out_dir.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_typescript_incremental_tsbuildinfo_path.snap
+++ b/tests/snapshots/generate_plan_tests__node_typescript_incremental_tsbuildinfo_path.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_variables.snap
+++ b/tests/snapshots/generate_plan_tests__node_variables.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_yarn.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn.snap
@@ -42,7 +42,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "yarn-1_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_yarn_berry.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn_berry.snap
@@ -43,7 +43,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "yarn-1_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_yarn_prisma.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn_prisma.snap
@@ -42,7 +42,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "yarn-1_x",
         "openssl"
       ],

--- a/tests/snapshots/generate_plan_tests__overriding_environment_variables.snap
+++ b/tests/snapshots/generate_plan_tests__overriding_environment_variables.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__php_laravel.snap
+++ b/tests/snapshots/generate_plan_tests__php_laravel.snap
@@ -43,7 +43,7 @@ expression: plan
         "perl",
         "nginx",
         "php81Packages.composer",
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__procfile.snap
+++ b/tests/snapshots/generate_plan_tests__procfile.snap
@@ -53,7 +53,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__ruby_execjs.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_execjs.snap
@@ -56,7 +56,7 @@ expression: plan
     "node:setup": {
       "name": "node:setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__ruby_with_node.snap
+++ b/tests/snapshots/generate_plan_tests__ruby_with_node.snap
@@ -59,7 +59,7 @@ expression: plan
     "node:setup": {
       "name": "node:setup",
       "nixPkgs": [
-        "nodejs-16_x",
+        "nodejs-18_x",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__yarn_berry.snap
+++ b/tests/snapshots/generate_plan_tests__yarn_berry.snap
@@ -27,7 +27,7 @@ expression: plan
       "name": "setup",
       "nixPackages": [
         {
-          "name": "nodejs-16_x"
+          "name": "nodejs-18_x"
         },
         {
           "name": "yarn-1_x",


### PR DESCRIPTION
This PR updates default node version from 16, which is in maintenance, to version 18, which has active long-term support (LTS).
![image](https://user-images.githubusercontent.com/101371689/220800640-486eff7a-e256-4aea-8c40-1012ce90ab8b.png)


- [x] Tests are added/updated if needed
- [x] Docs are updated if needed
