### PR TITLE
Ruby: Environment variables and PATH addition

### DIFF
--- a/examples/ruby-2/Gemfile.lock
+++ b/examples/ruby-2/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  aarch64-linux
 
 DEPENDENCIES
 

--- a/examples/ruby-execjs/Gemfile.lock
+++ b/examples/ruby-execjs/Gemfile.lock
@@ -1,14 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    execjs (2.8.1)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
 
-DEPENDENCIES
-
 RUBY VERSION
-   ruby 3.1.2p20
+ruby 3.1.2p20
+
+DEPENDENCIES
+  execjs (~> 2.8.1)
 
 BUNDLED WITH
    2.3.7

--- a/examples/ruby-local-deps/Gemfile.lock
+++ b/examples/ruby-local-deps/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  aarch64-linux
 
 DEPENDENCIES
   local!

--- a/examples/ruby-no-version/Gemfile.lock
+++ b/examples/ruby-no-version/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
 
 PLATFORMS
   x86_64-linux
+  aarch64-linux
 
 DEPENDENCIES
   puma (~> 5.6)

--- a/examples/ruby-rails-postgres/Gemfile.lock
+++ b/examples/ruby-rails-postgres/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.7-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.7-arm64-darwin)
       racc (~> 1.4)
     pg (1.4.1)
@@ -212,6 +214,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
 
 DEPENDENCIES

--- a/examples/ruby-sinatra/Gemfile.lock
+++ b/examples/ruby-sinatra/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  aarch64-linux
 
 DEPENDENCIES
   puma (~> 5.6.4)

--- a/examples/ruby-with-node/Gemfile.lock
+++ b/examples/ruby-with-node/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  aarch64-linux
 
 DEPENDENCIES
 

--- a/examples/ruby/Gemfile.lock
+++ b/examples/ruby/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  aarch64-linux
 
 DEPENDENCIES
 

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -119,6 +119,7 @@ impl RubyProvider {
         ));
 
         setup.add_path("$HOME/.rbenv/bin".to_string());
+        setup.add_path("/app/bin".to_string());
 
         Ok(Some(setup))
     }
@@ -169,6 +170,9 @@ impl RubyProvider {
         let ruby_version = self.get_ruby_version(app, env)?;
         let mut env_vars = EnvironmentVariables::from([
             ("BUNDLE_GEMFILE".to_string(), "/app/Gemfile".to_string()),
+            ("BUNDLE_WITHOUT".to_string(), "test:development".to_string()),
+            ("BUNDLE_CLEAN".to_string(), "1".to_string()),
+            ("BUNDLE_DEPLOYMENT".to_string(), "1".to_string()),
             (
                 "GEM_PATH".to_string(),
                 format!(
@@ -183,6 +187,8 @@ impl RubyProvider {
         ]);
 
         if self.is_rails_app(app) {
+            env_vars.insert("RAILS_ENV".to_string(), "production".to_string());
+            env_vars.insert("SECRET_KEY_BASE".to_string(), "1".to_string());
             env_vars.insert("RAILS_LOG_TO_STDOUT".to_string(), "enabled".to_string());
             env_vars.insert("RAILS_SERVE_STATIC_FILES".to_string(), "1".to_string());
         }

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -130,8 +130,12 @@ impl RubyProvider {
 
         if !self.uses_gem_dep(app, "local") {
             // Only run install if Gemfile or Gemfile.lock has changed
-            install.only_include_files =
-                Some(vec!["Gemfile".to_string(), "Gemfile.lock".to_string(), "vendor/cache".to_string()]);
+            install.add_file_dependency("Gemfile".to_string());
+            install.add_file_dependency("Gemfile.lock".to_string());
+
+            if app.includes_file("vendor/cache") {
+              install.add_file_dependency("vendor/cache".to_string())
+            }
         }
 
         install.add_cmd("bundle install".to_string());

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -131,7 +131,7 @@ impl RubyProvider {
         if !self.uses_gem_dep(app, "local") {
             // Only run install if Gemfile or Gemfile.lock has changed
             install.only_include_files =
-                Some(vec!["Gemfile".to_string(), "Gemfile.lock".to_string()]);
+                Some(vec!["Gemfile".to_string(), "Gemfile.lock".to_string(), "vendor/cache".to_string()]);
         }
 
         install.add_cmd("bundle install".to_string());

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -134,7 +134,7 @@ impl RubyProvider {
             install.add_file_dependency("Gemfile.lock".to_string());
 
             if app.includes_file("vendor/cache") {
-              install.add_file_dependency("vendor/cache".to_string())
+                install.add_file_dependency("vendor/cache".to_string())
             }
         }
 


### PR DESCRIPTION
that is the default for bundle binstubs

<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This is based on the environment variables added by Heroku in their buildpacks.

Also it adds `/app/bin` to the path like the `NodeProvider` does for `node_modules/.bin`.

Another change I would like to make, is to split up the `rbenv` commands into one line per command instead of the long and unreadable `&&` cmd

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
