### PR TITLE
fix node_modules install cache by moving node_modules path addition to build phase

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -150,7 +150,6 @@ impl Provider for NodeProvider {
         }
 
         install.add_cache_directory(NodeProvider::get_package_manager_cache_dir(app));
-        install.add_path("/app/node_modules/.bin".to_string());
 
         // Cypress cache directory
         let all_deps = NodeProvider::get_all_deps(app)?;
@@ -180,6 +179,9 @@ impl Provider for NodeProvider {
                 build.add_cache_directory(dir);
             }
         }
+
+        // This is in build instead of install because it often invalidates docker cache in CI
+        build.add_path("/app/node_modules/.bin".to_string());
 
         NodeProvider::cache_tsbuildinfo_file(app, &mut build);
 


### PR DESCRIPTION
As first discussed [in Discord](https://discord.com/channels/713503345364697088/1040725161478987836/1040727372875448410), this node_modules path addition in the install phase is invalidating the docker cache every single time for us in CI, causing npm modules to always be installed even when optimizing only_include_files.

Here you can see two different build runs where `RUN printf '\nPATH=/app/node_modules/.bin:$PATH' >> /root/.profile` invalidates the cache.

```
1:04:26 PM: #6 [stage-0  2/16] WORKDIR /app/
1:04:26 PM: #6 sha256:4b5e767673d5546e1b805d90dc48abd7b28b9f26e46273af3af21220c4df0b85
1:04:26 PM: #6 CACHED
1:04:26 PM: 
1:04:26 PM: #9 [stage-0  4/16] RUN nix-env -if .nixpacks/nixpkgs-293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847.nix && nix-collect-garbage -d
1:04:26 PM: #9 sha256:e48ef8aadb2a73954263ab6faf873f16c8501cf662a4147318b1736222ba099d
1:04:26 PM: #9 pulling sha256:b65bcf19d1445822c0d6f15ea82c9ed82ac1d903cfd6c1284ba7b2409a092845
1:04:26 PM: #9 pulling sha256:eacfd968fa4e8b968bd5881543c7a84ca7350e3638e9ff1550e219639c68823f
1:04:26 PM: #9 pulling sha256:88eeafe67020271b9d01ee5450f7ddac5d7485a4f1a4f0b3083cf14d0c0e3bb6
1:04:26 PM: #9 pulling sha256:b65bcf19d1445822c0d6f15ea82c9ed82ac1d903cfd6c1284ba7b2409a092845 1.0s done
1:04:26 PM: #9 pulling sha256:012ca49434089586bd23bb8e180e7a4d81bb5957d69b8a538c811820ea7c360d
1:04:28 PM: #9 pulling sha256:eacfd968fa4e8b968bd5881543c7a84ca7350e3638e9ff1550e219639c68823f 1.0s done
1:04:28 PM: #9 pulling sha256:88eeafe67020271b9d01ee5450f7ddac5d7485a4f1a4f0b3083cf14d0c0e3bb6 1.1s done
1:04:28 PM: #9 pulling sha256:012ca49434089586bd23bb8e180e7a4d81bb5957d69b8a538c811820ea7c360d 0.1s done
1:04:28 PM: #9 pulling sha256:8ed289fc5fdae9a2f05c803eb73a1239e6baa29eaaf49416ee06f6b761706359 0.1s done
1:04:28 PM: #9 pulling sha256:6e53634a717d9bc3590c2532cf9f6454db4e46db16b71431d27d92dc69931a10
1:04:30 PM: #9 pulling sha256:6e53634a717d9bc3590c2532cf9f6454db4e46db16b71431d27d92dc69931a10 3.7s done
1:04:36 PM: #9 CACHED
1:04:36 PM: 
1:04:36 PM: #10 [stage-0  5/16] RUN printf '\nPATH=/app/node_modules/.bin:$PATH' >> /root/.profile
1:04:36 PM: #10 sha256:c765a3a9df262b682adb82c261b51d1702c1afd4b71bffec13a65b41cd16b55f
1:04:38 PM: #10 DONE 3.1s
1:04:38 PM: 
1:04:38 PM: #11 [stage-0  6/16] COPY .npmrc /app/.npmrc
1:04:38 PM: #11 sha256:f3d28b6d933fdd404bf7c2d6d94b6a91c0bb0a2af85410d536f23b66c1fe297d
1:04:38 PM: #11 DONE 0.1s

--- 

12:55:47 PM: #6 [stage-0  2/16] WORKDIR /app/
12:55:47 PM: #6 sha256:4b5e767673d5546e1b805d90dc48abd7b28b9f26e46273af3af21220c4df0b85
12:55:47 PM: #6 CACHED
12:55:47 PM: 
12:55:47 PM: #8 [stage-0  3/16] COPY .nixpacks/nixpkgs-293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847.nix .nixpacks/nixpkgs-293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847.nix
12:55:47 PM: #8 sha256:96642b880335fd870dd59479723e60ae30ffa3216a103a807848de2c8dd8c3af
12:55:47 PM: #8 CACHED
12:55:47 PM: 
12:55:47 PM: #9 [stage-0  4/16] RUN nix-env -if .nixpacks/nixpkgs-293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847.nix && nix-collect-garbage -d
12:55:47 PM: #9 sha256:e46612b80c0168bc4c2f0d3c2ef872f614dc13541401c7cc238d5b448bc7a7a7
12:55:47 PM: #9 CACHED
12:55:47 PM: 
12:55:47 PM: #10 [stage-0  5/16] RUN printf '\nPATH=/app/node_modules/.bin:$PATH' >> /root/.profile
12:55:47 PM: #10 sha256:7837f6161528cfa2afe9dfa3189061392f9e28bfc2013dcf2b5b8200eb4e2f76
12:55:47 PM: #10 DONE 0.8s
12:55:47 PM: 
12:55:47 PM: #11 [stage-0  6/16] COPY .npmrc /app/.npmrc
12:55:47 PM: #11 sha256:d409936d66d70833358ca72dcd4c4efd0798a204f2eb5055c53a06c881a1a2b7
12:55:47 PM: #11 DONE 0.1s
```

Since RUN commands are not supported to break caching, it seems maybe it's a bug in docker?

**This PR works around it by moving this path addition from install to build phase, because node_modules in path is not needed until build in (almost?) all cases.**