### PR TITLE
Store default arguments in generated Dockerfile

### DIFF
--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -143,7 +143,7 @@ impl DockerfileGenerator for BuildPlan {
                 // Pull the variables in from docker `--build-arg`
                 variables
                     .iter()
-                    .map(|var| var.0.to_string())
+                    .map(|var| format!("{}={}", var.0, var.1))
                     .collect::<Vec<_>>()
                     .join(" "),
                 // Make the variables available at runtime


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR updates Dockerfile generation to include default `ARG` values.

I'm currently working on a project that uses `nixpacks build --out` to generate Dockerfiles but I came to realize that when I built the images myself they didn't work. The culprit turned out to be the missing `--build-arg`s that `nixpacks` supplies when it builds the image. I made this change on my local fork and my images started working without my having to supply `--build-arg`s and figured others using the `--out` argument may find value in the Dockerfile working without any additional input.

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
