### PR TITLE
improve failed to find django app name error message

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -266,7 +266,7 @@ impl PythonProvider {
                 }
             }
         }
-        bail!("Failed to find django application name!")
+        bail!("Failed to find your WSGI_APPLICATION django setting. Add this to continue.")
     }
 
     fn parse_pipfile_python_version(file_content: &str) -> Result<Option<String>> {


### PR DESCRIPTION
Django applications without wsgi will totally fail, but the message was unclear as to why or how to fix it. This improves it.