### PR TITLE
Add `--copies` flag to python venv

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -140,7 +140,7 @@ impl PythonProvider {
 
     fn install(&self, app: &App, _env: &Environment) -> Result<Option<Phase>> {
         let env_loc = "/opt/venv";
-        let create_env = format!("python -m venv {env_loc}");
+        let create_env = format!("python -m venv --copies {env_loc}");
         let activate_env = format!(". {env_loc}/bin/activate");
 
         if app.includes_file("requirements.txt") {

--- a/tests/snapshots/generate_plan_tests__python.snap
+++ b/tests/snapshots/generate_plan_tests__python.snap
@@ -16,7 +16,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
+        "python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
       ],
       "cacheDirectories": [
         "/root/.cache/pip"

--- a/tests/snapshots/generate_plan_tests__python_django.snap
+++ b/tests/snapshots/generate_plan_tests__python_django.snap
@@ -16,7 +16,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
+        "python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
       ],
       "cacheDirectories": [
         "/root/.cache/pip"

--- a/tests/snapshots/generate_plan_tests__python_django_mysql.snap
+++ b/tests/snapshots/generate_plan_tests__python_django_mysql.snap
@@ -16,7 +16,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
+        "python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
       ],
       "cacheDirectories": [
         "/root/.cache/pip"

--- a/tests/snapshots/generate_plan_tests__python_django_pipfile.snap
+++ b/tests/snapshots/generate_plan_tests__python_django_pipfile.snap
@@ -16,7 +16,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "python -m venv /opt/venv && . /opt/venv/bin/activate && PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy"
+        "python -m venv --copies /opt/venv && . /opt/venv/bin/activate && PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy"
       ],
       "cacheDirectories": [
         "/root/.cache/pip"

--- a/tests/snapshots/generate_plan_tests__python_numpy.snap
+++ b/tests/snapshots/generate_plan_tests__python_numpy.snap
@@ -16,7 +16,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
+        "python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
       ],
       "cacheDirectories": [
         "/root/.cache/pip"

--- a/tests/snapshots/generate_plan_tests__python_poetry.snap
+++ b/tests/snapshots/generate_plan_tests__python_poetry.snap
@@ -17,7 +17,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install poetry==$NIXPACKS_POETRY_VERSION && poetry install --no-dev --no-interaction --no-ansi"
+        "python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install poetry==$NIXPACKS_POETRY_VERSION && poetry install --no-dev --no-interaction --no-ansi"
       ],
       "cacheDirectories": [
         "/root/.cache/pip"

--- a/tests/snapshots/generate_plan_tests__python_postgres.snap
+++ b/tests/snapshots/generate_plan_tests__python_postgres.snap
@@ -16,7 +16,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
+        "python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
       ],
       "cacheDirectories": [
         "/root/.cache/pip"

--- a/tests/snapshots/generate_plan_tests__python_procfile.snap
+++ b/tests/snapshots/generate_plan_tests__python_procfile.snap
@@ -16,7 +16,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
+        "python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
       ],
       "cacheDirectories": [
         "/root/.cache/pip"

--- a/tests/snapshots/generate_plan_tests__python_setuptools.snap
+++ b/tests/snapshots/generate_plan_tests__python_setuptools.snap
@@ -16,7 +16,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "python -m venv /opt/venv && . /opt/venv/bin/activate && pip install --upgrade build setuptools && pip install ."
+        "python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install --upgrade build setuptools && pip install ."
       ],
       "onlyIncludeFiles": [
         "pyproject.toml"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

I've noticed that when building a Docker image for Python using Nixpacks, the current implementation relies on `venv` for the virtual environment setup, which by default uses symbolic links to `/root/.nix-profile/bin/python` for Python installation. However, this can cause permission issues when running the image as a non-root user.

To address this issue, I propose enabling the `--copies` flag for `venv`, which will create a copy of the Python executable instead of using symbolic links. This should resolve the permission issues and allow the image to be run as a non-root user.

### Related docs

- https://docs.python.org/3/library/venv.html#creating-virtual-environments

<!-- PR Checklist  -->
<!-- - [x] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
