### PR TITLE
Add comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing to this project! PRs and issues are welcome.
 
-For larger changes, please first make an [RFC issue](https://github.com/railwayapp/nixpacks/issues). You can follow along with the roadmap in the [GitHub project](https://github.com/railwayapp/nixpacks/projects/1).
+For larger changes, please start a discussion by [creating an issue](https://github.com/railwayapp/nixpacks/issues/new?assignees=&labels=&template=feature_request.yml&title=Nixpacks+Feature+Request).
 
 ## How to contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,57 +1,46 @@
 # Contributing
 
-Thanks for your interest in contributing to this project! PRs and issues are welcome, but please keep in mind that this project is still and alpha and the the implementation details and API will most likely change between now and a stable release.
+Thanks for your interest in contributing to this project! PRs and issues are welcome.
 
 For larger changes, please first make an [RFC issue](https://github.com/railwayapp/nixpacks/issues). You can follow along with the roadmap in the [GitHub project](https://github.com/railwayapp/nixpacks/projects/1).
 
 ## How to contribute
 
-First, make sure you can build and run the project
+First, make sure you can build and run the project:
 
 1. Ensure you have [Rust](https://www.rust-lang.org/tools/install) and [Docker](https://docs.docker.com/get-docker/) installed.
-1. Checkout this repo `git clone https://github.com/railwayapp/nixpacks.git`
-1. Build the source `cargo build`
-1. Run the tests `cargo test`
-1. Build an example `cargo run -- build examples/node --name node`
-1. Run the example `docker run node`
+2. Checkout this repo: `git clone https://github.com/railwayapp/nixpacks.git`
+3. Build the source: `cargo build`
+4. Run the tests: `cargo test`
+5. Build an example: `cargo run -- build examples/node --name node`
+6. Run the example: `docker run node`
 
 You should see `Hello from Node` printed to the console.
 
 ## Debugging
 
-When debugging it can be useful to see the intermediate files that Nixpacks generates (e.g. `Dockerfile`) You can do this my saving the build artifact to a specific directory instead of to a temp dir.
+When debugging it can be useful to see the intermediate files that Nixpacks generates (e.g. `Dockerfile`). You can do this by saving the build artifact to a specific directory instead of to a temp dir, by executing the following command:
 
 ```
 cargo run -- build examples/node --out test
 ```
 
-_The `test` directory will contain everything that would be built with Docker. All the files that Nixpacks generates are in `.nixpacks`. You can manually build the image with `docker build test -f test/.nixpacks/Dockerfile`_.
+_Note: The `test` directory will contain everything that would be built with Docker. All the files that Nixpacks generates are in `.nixpacks`. You can manually build the image with `docker build test -f test/.nixpacks/Dockerfile`_.
 
 ## Snapshot Tests
 
 Nixpacks uses [insta](https://github.com/mitsuhiko/insta) for snapshot tests. We use snapshot tests to generate and compare all build plans for the test apps in `examples/`. If a snapshot test fails due to a change to a provider, that is okay. It just means the snapshot needs to be reviewed and accepted. To test and review all snapshots, you can
 
-First install insta
+1. Install insta: `cargo install cargo-insta`
+2. Test and review the generate plan tests: `cargo insta test --review --test generate_plan_tests` or `cargo snapshot`
 
-```
-cargo install cargo-insta
-```
+The snapshots are checked into CI and are reviewed as part of every PR. They ensure that a change to one part of Nixpacks does not unexpectedly change an unrelated part.
 
-Test and review the generate plan tests.
-
-```
-cargo insta test --review --test generate_plan_tests
-# or
-cargo snapshot
-```
-
-The snapshots are checked into CI and are reviewed as part of the PR. They ensure that a change to one part of Nixpacks does not unexpectedly change an unrelated part.
-
-[Read the docs](https://insta.rs/docs/) for more information on cargo insta.
+[Read the docs](https://insta.rs/docs/) for more information on `cargo insta`.
 
 ## Contribution Ideas
 
-The easiest way to contribute is to add support for new languages. There is a list of languages we would like to add [here](https://github.com/railwayapp/nixpacks/issues?q=is%3Aissue+is%3Aopen+label%3A%22new+provider%22), but languages not on the list are welcome as well. To guage interest you can always create an issue before working on an implementation.
+The easiest way to contribute is to add support for new languages. There is a list of languages we would like to add [here](https://github.com/railwayapp/nixpacks/issues?q=is%3Aissue+is%3Aopen+label%3A%22new+provider%22), but languages not on the list are welcome as well. To gauge interest you can always create an issue before working on an implementation.
 
 ## Making PRs
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ mod chain;
 pub mod nixpacks;
 pub mod providers;
 
+/// Supplies all currently-defined providers to build plan generators and image builders.
 pub fn get_providers() -> &'static [&'static (dyn Provider)] {
     &[
         &CrystalProvider {},
@@ -72,6 +73,7 @@ pub fn get_providers() -> &'static [&'static (dyn Provider)] {
     ]
 }
 
+/// Produces a build plan for the project based on environment variables and CLI options.
 pub fn generate_build_plan(
     path: &str,
     envs: Vec<&str>,
@@ -86,6 +88,7 @@ pub fn generate_build_plan(
     Ok(plan.0)
 }
 
+/// Get all specified and detected providers for a project.
 pub fn get_plan_providers(
     path: &str,
     envs: Vec<&str>,
@@ -99,6 +102,7 @@ pub fn get_plan_providers(
     generator.get_plan_providers(&app, &environment)
 }
 
+/// Builds a Docker image based on environment data and build options from config files or existing build plans.
 pub async fn create_docker_image(
     path: &str,
     envs: Vec<&str>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,14 @@ use std::{
     string::ToString,
 };
 
+/// The build plan config file format to use.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum PlanFormat {
     Json,
     Toml,
 }
 
+/// Arguments passed to `nixpacks`.
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -70,6 +72,7 @@ struct Args {
     config: Option<String>,
 }
 
+/// The valid subcommands passed to `nixpacks`, and their arguments.
 #[derive(Subcommand)]
 enum Commands {
     /// Generate a build plan for an app
@@ -201,6 +204,7 @@ async fn main() -> Result<()> {
     };
 
     match args.command {
+        // Produce a build plan for a project and print it to stdout.
         Commands::Plan { path, format } => {
             let plan = generate_build_plan(&path, env, &options)?;
 
@@ -211,10 +215,12 @@ async fn main() -> Result<()> {
 
             println!("{plan_s}");
         }
+        // Detect which providers should be used to build a project and print them to stdout.
         Commands::Detect { path } => {
             let providers = get_plan_providers(&path, env, &options)?;
             println!("{}", providers.join(", "));
         }
+        // Generate a Dockerfile and builds a container, using any specified build options.
         Commands::Build {
             path,
             name,
@@ -265,6 +271,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+/// Creates a key for storing image layers in the Docker cache.
 fn get_default_cache_key(path: &str) -> Result<Option<String>> {
     let current_dir = env::current_dir()?;
     let source = current_dir.join(path).canonicalize();

--- a/src/nixpacks/app.rs
+++ b/src/nixpacks/app.rs
@@ -14,6 +14,7 @@ pub type StaticAssets = BTreeMap<String, String>;
 
 pub const ASSETS_DIR: &str = "/assets/";
 
+/// Represents a project's file and directory paths.
 #[derive(Debug, Clone)]
 pub struct App {
     pub source: PathBuf,
@@ -21,6 +22,7 @@ pub struct App {
 }
 
 impl App {
+    /// Generate a path representation of a project.
     pub fn new(path: &str) -> Result<App> {
         let current_dir = env::current_dir()?;
         let source = current_dir
@@ -39,7 +41,7 @@ impl App {
         self.source.join(name).is_file()
     }
 
-    /// Returns a list of paths matching a glob pattern
+    /// Returns a list of file paths matching a glob pattern
     ///
     /// # Errors
     /// Creating the Glob fails
@@ -53,7 +55,7 @@ impl App {
         Ok(directories)
     }
 
-    /// Returns a list of paths matching a glob pattern
+    /// Returns a list of directory paths matching a glob pattern
     ///
     /// # Errors
     /// Creating the Glob fails
@@ -67,6 +69,7 @@ impl App {
         Ok(directories)
     }
 
+    /// Check whether a shell-style pattern matches any paths in the app.
     fn find_glob(&self, pattern: &str) -> Result<Vec<PathBuf>> {
         let full_pattern = self.source.join(pattern);
 
@@ -116,6 +119,7 @@ impl App {
         Ok(data.replace("\r\n", "\n"))
     }
 
+    /// Check whether filenames matching a pattern exist in the project.
     pub fn find_match(&self, re: &Regex, pattern: &str) -> Result<bool> {
         let paths = match self.find_files(pattern) {
             Ok(v) => v,
@@ -160,6 +164,7 @@ impl App {
         }
     }
 
+    /// Try to json-parse a file.
     pub fn read_json<T>(&self, name: &str) -> Result<T>
     where
         T: DeserializeOwned,
@@ -172,6 +177,7 @@ impl App {
         Ok(value)
     }
 
+    /// Try to toml-parse a file.
     pub fn read_toml<T>(&self, name: &str) -> Result<T>
     where
         T: DeserializeOwned,
@@ -184,6 +190,7 @@ impl App {
         Ok(toml_file)
     }
 
+    /// Try to yaml-parse a file.
     pub fn read_yaml<T>(&self, name: &str) -> Result<T>
     where
         T: DeserializeOwned,

--- a/src/nixpacks/builder/docker/cache.rs
+++ b/src/nixpacks/builder/docker/cache.rs
@@ -1,3 +1,4 @@
+/// Remove space and period characters from the Docker build cache key.
 pub fn sanitize_cache_key(cache_key: &str) -> String {
     cache_key
         .chars()

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -18,11 +18,13 @@ use std::{
 use tempdir::TempDir;
 use uuid::Uuid;
 
+/// Builds Docker images from options, logging to stdout if the build is successful.
 pub struct DockerImageBuilder {
     logger: Logger,
     options: DockerBuilderOptions,
 }
 
+/// Determine where to write project files and generated assets like Dockerfiles.
 fn get_output_dir(app_src: &str, options: &DockerBuilderOptions) -> Result<OutputDir> {
     if let Some(value) = &options.out_dir {
         OutputDir::new(value.into(), false)
@@ -38,6 +40,7 @@ use async_trait::async_trait;
 
 #[async_trait]
 impl ImageBuilder for DockerImageBuilder {
+    /// Build a Docker image from a given BuildPlan and data from environment variables.
     async fn create_image(&self, app_src: &str, plan: &BuildPlan, env: &Environment) -> Result<()> {
         let id = Uuid::new_v4();
 
@@ -112,6 +115,7 @@ impl DockerImageBuilder {
         DockerImageBuilder { logger, options }
     }
 
+    /// Generates the Docker command and arguments for building the project.
     fn get_docker_build_cmd(
         &self,
         plan: &BuildPlan,
@@ -178,6 +182,7 @@ impl DockerImageBuilder {
         Ok(docker_build_cmd)
     }
 
+    /// Copies project files to temporary output dir, if that option was used.
     fn write_app(&self, app_src: &str, output: &OutputDir) -> Result<()> {
         if output.is_temp {
             files::recursive_copy_dir(app_src, &output.root)
@@ -186,6 +191,7 @@ impl DockerImageBuilder {
         }
     }
 
+    /// Writes the generated Dockerfile to the output dir.
     fn write_dockerfile(&self, dockerfile: String, output: &OutputDir) -> Result<()> {
         let dockerfile_path = output.get_absolute_path("Dockerfile");
         File::create(dockerfile_path.clone()).context("Creating Dockerfile file")?;

--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -23,6 +23,7 @@ use std::{
 const NIXPACKS_OUTPUT_DIR: &str = ".nixpacks";
 pub const APP_DIR: &str = "/app/";
 
+/// Represents a directory into which project files and generated assets like Dockerfiles are written.
 #[derive(Debug, Clone)]
 pub struct OutputDir {
     pub root: PathBuf,
@@ -62,21 +63,25 @@ impl OutputDir {
         Ok(())
     }
 
+    /// Returns the path to the provided path from the asset_root directory.
     pub fn get_relative_path<P: AsRef<Path>>(&self, path: P) -> PathBuf {
         self.asset_root.join(path)
     }
 
+    /// Returns the absolute path to the provided path.
     pub fn get_absolute_path<P: AsRef<Path>>(&self, path: P) -> PathBuf {
         self.root.join(self.get_relative_path(path))
     }
 }
 
 impl Default for OutputDir {
+    /// The output directory defaults to wherever `nixpacks` was called from.
     fn default() -> Self {
         Self::from(".", false).unwrap()
     }
 }
 
+/// Types that impl this trait can produce (parts of) Dockerfiles from environment data and specified build options.
 pub trait DockerfileGenerator {
     fn generate_dockerfile(
         &self,
@@ -95,6 +100,7 @@ pub trait DockerfileGenerator {
     }
 }
 
+/// Turns a BuildPlan into a Dockerfile.
 impl DockerfileGenerator for BuildPlan {
     fn generate_dockerfile(
         &self,
@@ -242,6 +248,7 @@ impl DockerfileGenerator for BuildPlan {
         Ok(dockerfile)
     }
 
+    /// Writes the Nix expression files to the output directory.
     fn write_supporting_files(
         &self,
         options: &DockerBuilderOptions,
@@ -272,6 +279,7 @@ impl DockerfileGenerator for BuildPlan {
 }
 
 impl BuildPlan {
+    /// Copies the plan's static assets to the output directory.
     fn write_assets(&self, plan: &BuildPlan, output: &OutputDir) -> Result<()> {
         if let Some(assets) = &plan.static_assets {
             if !assets.is_empty() {
@@ -294,6 +302,7 @@ impl BuildPlan {
         Ok(())
     }
 
+    /// Returns a collection of apt packages required by all phases in the BuildPlan.
     fn all_apt_packages(&self) -> Vec<String> {
         self.phases
             .clone()
@@ -305,6 +314,7 @@ impl BuildPlan {
 }
 
 impl DockerfileGenerator for StartPhase {
+    /// Write the StartPhase data to the Dockerfile.
     fn generate_dockerfile(
         &self,
         _options: &DockerBuilderOptions,
@@ -356,6 +366,7 @@ impl DockerfileGenerator for StartPhase {
 }
 
 impl DockerfileGenerator for Phase {
+    /// Write the Phase data to the Dockerfile.
     fn generate_dockerfile(
         &self,
         options: &DockerBuilderOptions,

--- a/src/nixpacks/builder/docker/file_server.rs
+++ b/src/nixpacks/builder/docker/file_server.rs
@@ -21,6 +21,7 @@ const NIXPACKS_SERVER_LISTEN_TO_IP: &str = "0.0.0.0";
 #[derive(Debug, Clone)]
 pub struct FileServer {}
 
+/// Holds the configuration for the fileserver used for the incremental Docker image cache.
 #[derive(Debug, Clone, Default)]
 pub struct FileServerConfig {
     pub listen_to_ip: String,
@@ -31,6 +32,7 @@ pub struct FileServerConfig {
 }
 
 impl FileServer {
+    /// Launch the file server using the default settings and the incremental cache storage directories.
     pub fn start(self, incremental_cache_dirs: &IncrementalCacheDirs) -> FileServerConfig {
         let port = self.get_free_port();
 
@@ -53,6 +55,7 @@ impl FileServer {
         config
     }
 
+    /// Try to find an unused port.
     fn get_free_port(&self) -> u16 {
         for _ in 1..3 {
             // try 2 times
@@ -65,6 +68,7 @@ impl FileServer {
         pick_unused_port().expect("No ports available")
     }
 
+    /// Using the provided config, launch a new file server.
     async fn run_app(data: FileServerConfig) -> std::io::Result<()> {
         let server_config = web::Data::new(data.clone());
         let server = HttpServer::new(move || {
@@ -85,6 +89,7 @@ impl FileServer {
         server.await
     }
 
+    /// Check if the provided access_token matches the one in the server response header.
     fn has_valid_access_token(token: Option<&HeaderValue>, access_token: &str) -> bool {
         if let Some(header) = token {
             match header.to_str() {

--- a/src/nixpacks/builder/docker/incremental_cache.rs
+++ b/src/nixpacks/builder/docker/incremental_cache.rs
@@ -15,6 +15,7 @@ const INCREMENTAL_CACHE_IMAGE_DIR: &str = "image";
 #[derive(Default)]
 pub struct IncrementalCache {}
 
+/// Directories in which to cache Docker image layers.
 #[derive(Default)]
 pub struct IncrementalCacheDirs {
     out_dir: OutputDir,
@@ -35,6 +36,7 @@ impl IncrementalCacheDirs {
         }
     }
 
+    /// Makes the incremental cache directories.
     pub fn create(&self) -> Result<()> {
         let incremental_cache_root = self.out_dir.get_absolute_path(INCREMENTAL_CACHE_DIR);
 
@@ -68,6 +70,7 @@ impl IncrementalCacheDirs {
 }
 
 impl IncrementalCache {
+    /// Create a filesystem image for each of the files in the incremental cache uploads directory, then upload these to the Docker cache.
     pub fn create_image(
         &self,
         incremental_cache_dirs: &IncrementalCacheDirs,
@@ -97,6 +100,7 @@ impl IncrementalCache {
         Ok(())
     }
 
+    /// Check if the provided image_tag matches a tag in the incremental Docker image cache.
     pub fn is_image_exists(image_tag: &str) -> Result<bool> {
         let mut docker_inspect_cmd = Command::new("docker");
         docker_inspect_cmd
@@ -114,9 +118,10 @@ impl IncrementalCache {
         Ok(result.success())
     }
 
+    /// Produce Dockerfile line(s) copying cached files from the incremental cache to the final build image.
     pub fn get_copy_to_image_command(
         cache_directories: &Option<Vec<String>>,
-        incremental_cahge_image: &str,
+        incremental_cache_image: &str,
     ) -> Vec<String> {
         let dirs = &cache_directories.clone().unwrap_or_default();
         if dirs.is_empty() {
@@ -134,12 +139,13 @@ impl IncrementalCache {
                     .join("/");
 
                 vec![format!(
-                    "COPY --from={incremental_cahge_image} {target_cache_dir_optional} {target_cache_dir}"
+                    "COPY --from={incremental_cache_image} {target_cache_dir_optional} {target_cache_dir}"
                 )]
             })
             .collect::<Vec<String>>()
     }
 
+    /// Produce Dockerfile line(s) copying files from the build image into the incremental cache.
     pub fn get_copy_from_image_command(
         cache_directories: &Option<Vec<String>>,
         file_server_config: Option<FileServerConfig>,

--- a/src/nixpacks/builder/docker/mod.rs
+++ b/src/nixpacks/builder/docker/mod.rs
@@ -1,5 +1,6 @@
 use super::ImageBuilder;
 
+/// Holds options for generating a Docker image.
 #[derive(Clone, Default, Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct DockerBuilderOptions {

--- a/src/nixpacks/builder/docker/utils.rs
+++ b/src/nixpacks/builder/docker/utils.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use super::cache::sanitize_cache_key;
 
+/// Using the provided cache_key and cache_directories, produce a string of Docker command flags mounting the cache.
 pub fn get_cache_mount(
     cache_key: &Option<String>,
     cache_directories: &Option<Vec<String>>,
@@ -23,6 +24,7 @@ pub fn get_cache_mount(
     }
 }
 
+/// Produce Dockerfile line(s) copying files into the build image.
 pub fn get_copy_commands(files: &[String], app_dir: &str) -> Vec<String> {
     if files.is_empty() {
         Vec::new()
@@ -41,6 +43,7 @@ pub fn get_copy_commands(files: &[String], app_dir: &str) -> Vec<String> {
     }
 }
 
+/// Produce Dockerfile line(s) copying files into the build image from a given Docker image layer.
 pub fn get_copy_from_commands(from: &str, files: &[String], app_dir: &str) -> Vec<String> {
     if files.is_empty() {
         vec![format!("COPY --from=0 {app_dir} {app_dir}")]
@@ -59,6 +62,7 @@ pub fn get_copy_from_commands(from: &str, files: &[String], app_dir: &str) -> Ve
     }
 }
 
+/// Produce the Dockerfile line containing the CMD instruction which executes the application.
 pub fn get_exec_command(command: &str) -> String {
     let params = command.replace('\"', "\\\"");
 

--- a/src/nixpacks/builder/mod.rs
+++ b/src/nixpacks/builder/mod.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 
 pub mod docker;
 
+/// Types that impl this trait can produce Docker images.
 #[async_trait]
 pub trait ImageBuilder {
     async fn create_image(

--- a/src/nixpacks/environment.rs
+++ b/src/nixpacks/environment.rs
@@ -4,6 +4,7 @@ use std::{collections::BTreeMap, env};
 
 pub type EnvironmentVariables = BTreeMap<String, String>;
 
+/// Holds a map of environment variables.
 #[derive(Default, Debug)]
 pub struct Environment {
     variables: EnvironmentVariables,
@@ -14,6 +15,7 @@ impl Environment {
         Environment { variables }
     }
 
+    /// Collects all variables from the calling environment.
     pub fn from_envs(envs: Vec<&str>) -> Result<Environment> {
         let mut environment = Environment::default();
         for env in envs {
@@ -39,15 +41,18 @@ impl Environment {
         Ok(environment)
     }
 
+    /// Returns the value of the given variable name, if it exists.
     pub fn get_variable(&self, name: &str) -> Option<&str> {
         self.variables.get(name).map(String::as_str)
     }
 
+    /// Returns all the "NIXPACKS_" variables for use in a BuildPlan.
     pub fn get_config_variable(&self, name: &str) -> Option<String> {
         self.get_variable(format!("NIXPACKS_{name}").as_str())
             .map(|var| var.replace('\n', ""))
     }
 
+    /// Checks if the given variable is 1 or true.
     pub fn is_config_variable_truthy(&self, name: &str) -> bool {
         if let Some(var) = self.get_config_variable(name) {
             matches!(var.as_str(), "1" | "true")
@@ -56,18 +61,22 @@ impl Environment {
         }
     }
 
+    /// Store a variable in the Environment.
     pub fn set_variable(&mut self, name: String, value: String) {
         self.variables.insert(name, value);
     }
 
+    /// Returns all the variables currently stored in the Environment.
     pub fn get_variable_names(&self) -> Vec<String> {
         self.variables.keys().cloned().collect()
     }
 
+    /// Returns a copy of all the environment variables.
     pub fn clone_variables(env: &Environment) -> EnvironmentVariables {
         env.variables.clone()
     }
 
+    /// Add variables to the given Environment.
     pub fn append_variables(env: &Environment, variables: EnvironmentVariables) -> Environment {
         let mut new_env = Environment::new(Environment::clone_variables(env));
         new_env.variables.extend(variables);

--- a/src/nixpacks/files.rs
+++ b/src/nixpacks/files.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use ignore::WalkBuilder;
 use std::{fs, io, path::Path};
 
+/// Copies a directory and all its contents to the destination path, recursively.
 pub fn recursive_copy_dir<T: AsRef<Path>, Q: AsRef<Path>>(source: T, dest: Q) -> Result<()> {
     let walker = WalkBuilder::new(&source)
         .follow_links(false)

--- a/src/nixpacks/logger.rs
+++ b/src/nixpacks/logger.rs
@@ -1,5 +1,6 @@
 use colored::Colorize;
 
+/// Used for reporting Docker build information to stdout.
 pub struct Logger {}
 
 impl Logger {
@@ -7,10 +8,12 @@ impl Logger {
         Logger {}
     }
 
+    /// Pretty-print the given log section title.
     pub fn log_section(&self, msg: &str) {
         println!("=== {} ===", msg.magenta().bold());
     }
 
+    /// Pretty-print the given log line.
     pub fn log_step(&self, msg: &str) {
         println!("=> {msg}");
     }

--- a/src/nixpacks/nix/mod.rs
+++ b/src/nixpacks/nix/mod.rs
@@ -13,6 +13,7 @@ pub const NIXPKGS_ARCHIVE: &str = "293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847";
 // Version of the Nix archive that uses OpenSSL 1.1
 pub const NIXPACKS_ARCHIVE_LEGACY_OPENSSL: &str = "a0b7e70db7a55088d3de0cc370a59f9fbcc906c3";
 
+/// Contains all the data needed to generate a Nix expression file for installing Nix dependencies.
 #[derive(Eq, PartialEq, Default, Debug, Clone)]
 struct NixGroup {
     archive: Option<String>,
@@ -22,6 +23,7 @@ struct NixGroup {
     files: Vec<String>,
 }
 
+/// Collect all Nix packages based on the nixpkgs revision they should be fetched from.
 fn group_nix_packages_by_archive(phases: &[Phase]) -> Vec<NixGroup> {
     let mut archive_to_packages: BTreeMap<Option<String>, NixGroup> = BTreeMap::new();
 
@@ -56,6 +58,7 @@ fn group_nix_packages_by_archive(phases: &[Phase]) -> Vec<NixGroup> {
         .collect()
 }
 
+/// Turn the Nix dependencies for each phase into a Nix expression that installs them.
 pub fn create_nix_expressions_for_phases(phases: &Phases) -> BTreeMap<String, String> {
     let archive_to_packages = group_nix_packages_by_archive(
         &phases
@@ -72,6 +75,7 @@ pub fn create_nix_expressions_for_phases(phases: &Phases) -> BTreeMap<String, St
         })
 }
 
+/// Generates the filenames for all the Nix expressions used to install Nix dependencies for each phase.
 pub fn nix_file_names_for_phases(phases: &Phases) -> Vec<String> {
     let archives = phases
         .values()
@@ -81,6 +85,7 @@ pub fn nix_file_names_for_phases(phases: &Phases) -> Vec<String> {
     archives.iter().map(nix_file_name).collect()
 }
 
+/// Returns all the Nix expression files used to install Nix dependencies for each phase.
 pub fn setup_files_for_phases(phases: &Phases) -> Vec<String> {
     let groups = group_nix_packages_by_archive(
         &phases
@@ -95,6 +100,7 @@ pub fn setup_files_for_phases(phases: &Phases) -> Vec<String> {
     })
 }
 
+/// Generates the filename for each Nix expression file.
 fn nix_file_name(archive: &Option<String>) -> String {
     match archive {
         Some(archive) => format!("nixpkgs-{archive}.nix"),
@@ -102,6 +108,7 @@ fn nix_file_name(archive: &Option<String>) -> String {
     }
 }
 
+/// Generates an expression that installs Nix packages in the container environment and makes them available in PATH.
 fn nix_expression_for_group(group: &NixGroup) -> String {
     let archive = group
         .archive

--- a/src/nixpacks/nix/pkg.rs
+++ b/src/nixpacks/nix/pkg.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Represents a Nix package, any derivation overrides for it, and the nixpkgs overlay to fetch it from.
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct Pkg {
@@ -18,6 +19,7 @@ impl Pkg {
         }
     }
 
+    /// Renders the Pkg as a Nix expression.
     pub fn to_nix_string(&self) -> String {
         match &self.overrides {
             Some(overrides) => {
@@ -32,6 +34,7 @@ impl Pkg {
         }
     }
 
+    /// Add desired overrides on the derivation for the given package.
     #[must_use]
     pub fn set_override(mut self, name: &str, pkg: &str) -> Self {
         if let Some(mut overrides) = self.overrides {
@@ -44,12 +47,14 @@ impl Pkg {
         self
     }
 
+    /// Add an overlay to fetch the package from.
     #[must_use]
     pub fn from_overlay(mut self, overlay: &str) -> Self {
         self.overlay = Some(overlay.to_string());
         self
     }
 
+    /// Pretty-print the package and any overrides as a Nix expression.
     pub fn to_pretty_string(&self) -> String {
         match &self.overrides {
             Some(overrides) => {

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -18,17 +18,20 @@ use super::{
 
 const NIXPACKS_METADATA: &str = "NIXPACKS_METADATA";
 
+/// Holds plan options defined in config files or existing build plans.
 #[derive(Clone, Default, Debug)]
 pub struct GeneratePlanOptions {
     pub plan: Option<BuildPlan>,
     pub config_file: Option<String>,
 }
 
+/// Holds plan options and providers for a build.
 pub struct NixpacksBuildPlanGenerator<'a> {
     providers: &'a [&'a (dyn Provider)],
     config: GeneratePlanOptions,
 }
 
+/// NixpacksBuildPlanGenerators produce build plans using the options and providers they contain.
 impl<'a> PlanGenerator for NixpacksBuildPlanGenerator<'a> {
     fn generate_plan(&mut self, app: &App, environment: &Environment) -> Result<(BuildPlan, App)> {
         // If the provider defines a build plan in the new format, use that
@@ -37,6 +40,7 @@ impl<'a> PlanGenerator for NixpacksBuildPlanGenerator<'a> {
         Ok(plan)
     }
 
+    /// Combine detected providers with providers specified in config files, environment variables, and CLI arguments.
     fn get_plan_providers(&self, app: &App, env: &Environment) -> Result<Vec<String>> {
         let plan_before_providers = self.get_plan_before_providers(app, env)?;
         let providers = self.get_all_providers(app, env, plan_before_providers.providers)?;
@@ -53,7 +57,7 @@ impl NixpacksBuildPlanGenerator<'_> {
         NixpacksBuildPlanGenerator { providers, config }
     }
 
-    /// Get a build plan from the provider and by applying the config from the environment
+    /// Get a build plan from the provider and by applying a config from the environment.
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<(BuildPlan, App)> {
         let plan_before_providers = self.get_plan_before_providers(app, env)?;
 
@@ -92,6 +96,7 @@ impl NixpacksBuildPlanGenerator<'_> {
         Ok((plan, app.clone()))
     }
 
+    /// Generate a build plan based on config files, environment variables, and CLI arguments.
     fn get_plan_before_providers(&self, app: &App, env: &Environment) -> Result<BuildPlan> {
         let file_plan = self.read_file_plan(app, env)?;
         let env_plan = BuildPlan::from_environment(env);
@@ -101,6 +106,7 @@ impl NixpacksBuildPlanGenerator<'_> {
         Ok(plan_before_providers)
     }
 
+    /// Use each provider's detect method to determine which providers are needed for the build.
     fn get_detected_providers(&self, app: &App, env: &Environment) -> Result<Vec<String>> {
         let mut providers = Vec::new();
 
@@ -116,18 +122,18 @@ impl NixpacksBuildPlanGenerator<'_> {
         Ok(providers)
     }
 
-    /// Get all the providers that will be used to create the plan
+    /// Get a list of providers that will be used to create the plan.
     pub fn get_all_providers(
         &self,
         app: &App,
         env: &Environment,
-        manually_providers: Option<Vec<String>>,
+        manual_providers: Option<Vec<String>>,
     ) -> Result<Vec<String>> {
         let detected_providers = self.get_detected_providers(app, env)?;
         let provider_names = remove_autos_from_vec(
             fill_auto_in_vec(
                 Some(detected_providers),
-                Some(manually_providers.unwrap_or_else(|| vec!["...".to_string()])),
+                Some(manual_providers.unwrap_or_else(|| vec!["...".to_string()])),
             )
             .unwrap_or_default(),
         );
@@ -135,6 +141,7 @@ impl NixpacksBuildPlanGenerator<'_> {
         Ok(provider_names)
     }
 
+    /// Use all detected and specified providers to generate a build plan.
     fn get_plan_from_providers(
         &self,
         app: &App,
@@ -188,6 +195,7 @@ impl NixpacksBuildPlanGenerator<'_> {
         Ok(plan)
     }
 
+    /// If a supported config file exists, use it to generate a build plan.
     fn read_file_plan(&self, app: &App, env: &Environment) -> Result<BuildPlan> {
         let file_path = if let Some(file_path) = &self.config.config_file {
             Some(file_path.clone())

--- a/src/nixpacks/plan/merge.rs
+++ b/src/nixpacks/plan/merge.rs
@@ -4,11 +4,13 @@ use super::{
     BuildPlan,
 };
 
+/// Types that impl this trait can be pairwise combined.
 pub trait Mergeable {
     fn merge(c1: &Self, c2: &Self) -> Self;
 }
 
 impl Mergeable for BuildPlan {
+    /// Given two BuildPlans, produce a third BuildPlan containing the data of both.
     fn merge(c1: &BuildPlan, c2: &BuildPlan) -> BuildPlan {
         let mut new_plan = c1.clone();
         let plan2 = c2.clone();
@@ -66,6 +68,7 @@ impl Mergeable for BuildPlan {
 }
 
 impl Mergeable for Phase {
+    /// Given two Phases, produce a third Phase containing the data of both.
     fn merge(c1: &Phase, c2: &Phase) -> Phase {
         let mut phase = c1.clone();
         let c2 = c2.clone();
@@ -88,6 +91,7 @@ impl Mergeable for Phase {
 }
 
 impl Mergeable for StartPhase {
+    /// Given two StartPhases, produce a third StartPhase containing the data of both.
     fn merge(c1: &StartPhase, c2: &StartPhase) -> StartPhase {
         let mut start_phase = c1.clone();
         let c2 = c2.clone();

--- a/src/nixpacks/plan/mod.rs
+++ b/src/nixpacks/plan/mod.rs
@@ -20,6 +20,7 @@ pub mod pretty_print;
 mod topological_sort;
 mod utils;
 
+/// Types that impl this trait can generate build plans.
 pub trait PlanGenerator {
     fn generate_plan(&mut self, app: &App, environment: &Environment) -> Result<(BuildPlan, App)>;
     fn get_plan_providers(&self, app: &App, environment: &Environment) -> Result<Vec<String>>;
@@ -28,6 +29,10 @@ pub trait PlanGenerator {
 #[serde_with::skip_serializing_none]
 #[derive(PartialEq, Eq, Default, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
+/// Contains all information needed to build a project.
+///
+/// Nixpacks is essentially a compiler from {the closure of the direct and indirect dependencies of an application} to a Docker image reifying that closure.
+/// BuildPlans are an intermediate representation of this compiler, and are either compiled to a Dockerfile and then built into an image or are serialized as json or toml to a config file.
 pub struct BuildPlan {
     pub providers: Option<Vec<String>>,
 
@@ -46,6 +51,7 @@ pub struct BuildPlan {
 }
 
 impl BuildPlan {
+    /// Used by providers to create language-specific build plans.
     pub fn new(phases: &[Phase], start_phase: Option<StartPhase>) -> Self {
         Self {
             phases: Some(phases.iter().map(|p| (p.get_name(), p.clone())).collect()),
@@ -54,39 +60,46 @@ impl BuildPlan {
         }
     }
 
+    /// Create a BuildPlan from a toml config file.
     pub fn from_toml<S: Into<String>>(toml: S) -> Result<Self> {
         let mut plan: BuildPlan = toml::from_str(&toml.into())?;
         plan.resolve_phase_names();
         Ok(plan)
     }
 
+    /// Create a BuildPlan from a json config file.
     pub fn from_json<S: Into<String>>(json: S) -> Result<Self> {
         let mut plan: BuildPlan = serde_json::from_str(&json.into())?;
         plan.resolve_phase_names();
         Ok(plan)
     }
 
+    /// Render a BuildPlan to a toml-formatted string.
     pub fn to_toml(&self) -> Result<String> {
         let mut plan = self.clone();
         plan.remove_phase_names();
         Ok(toml::to_string_pretty(&plan)?)
     }
 
+    /// Render a BuildPlan to a json-formatted string.
     pub fn to_json(&self) -> Result<String> {
         let mut plan = self.clone();
         plan.remove_phase_names();
         Ok(serde_json::to_string_pretty(&plan)?)
     }
 
+    /// Add the given phase to this BuildPlan.
     pub fn add_phase(&mut self, phase: Phase) {
         let phases = self.phases.get_or_insert(BTreeMap::default());
         phases.insert(phase.get_name(), phase);
     }
 
+    /// Stores the app entrypoint command in this BuildPlan.
     pub fn set_start_phase(&mut self, start_phase: StartPhase) {
         self.start_phase = Some(start_phase);
     }
 
+    /// Stores environment variables passed to the `nixpacks` command, set in project files, or from ProviderMetadata.
     pub fn add_variables(&mut self, variables: EnvironmentVariables) {
         match self.variables.as_mut() {
             Some(vars) => {
@@ -100,6 +113,7 @@ impl BuildPlan {
         }
     }
 
+    /// Providers use this to define which files get copied into the container image.
     pub fn add_static_assets(&mut self, static_assets: StaticAssets) {
         match self.static_assets.as_mut() {
             Some(assets) => {
@@ -113,6 +127,7 @@ impl BuildPlan {
         }
     }
 
+    /// Returns the Phase of this BuildPlan with the given name.
     pub fn get_phase(&self, name: &str) -> Option<&Phase> {
         match self.phases {
             Some(ref phases) => phases.get(name),
@@ -120,14 +135,17 @@ impl BuildPlan {
         }
     }
 
+    /// Returns the (mutable) Phase of this BuildPlan with the given name.
     pub fn get_phase_mut(&mut self, name: &str) -> Option<&mut Phase> {
         self.phases.get_or_insert(BTreeMap::default()).get_mut(name)
     }
 
+    /// Remove the Phase with the given name from this BuildPlan.
     pub fn remove_phase(&mut self, name: &str) -> Option<Phase> {
         self.phases.get_or_insert(BTreeMap::default()).remove(name)
     }
 
+    /// Returns a vector of Phases in this BuildPlan, sorted by dependency.
     pub fn get_sorted_phases(&self) -> Result<Vec<Phase>> {
         let phases_with_names = self
             .phases
@@ -145,6 +163,7 @@ impl BuildPlan {
         Ok(res)
     }
 
+    /// Given a Phase name, returns a vector containing that Phase and its direct and transitive dependencies.
     pub fn get_phases_with_dependencies(&self, phase_name: &str) -> Phases {
         let p = self.get_phase(phase_name);
 
@@ -168,6 +187,7 @@ impl BuildPlan {
         phases
     }
 
+    /// Given another BuildPlan, merge its phases with this BuildPlan.
     pub fn add_phases_from_another_plan(
         &mut self,
         plan: &BuildPlan,
@@ -183,12 +203,14 @@ impl BuildPlan {
         format!("{prefix}:{phase_name}")
     }
 
+    /// Insert a Phase into this BuildPlan and set its Phase dependency.
     pub fn add_dependency_between_phases(&mut self, dependant: &str, dependency: &str) {
         if let Some(p) = self.get_phase_mut(dependant) {
             p.depends_on_phase(dependency);
         }
     }
 
+    /// Ensures correctness of the Phases map.
     pub fn resolve_phase_names(&mut self) {
         let phases = self.phases.get_or_insert(BTreeMap::default());
         for (name, phase) in phases.iter_mut() {
@@ -196,6 +218,7 @@ impl BuildPlan {
         }
     }
 
+    /// Strip keys out of the Phases map before serializing with to_json or to_toml.
     pub fn remove_phase_names(&mut self) {
         let phases = self.phases.get_or_insert(BTreeMap::default());
         for (_, phase) in phases.iter_mut() {
@@ -203,6 +226,7 @@ impl BuildPlan {
         }
     }
 
+    /// Produces a BuildPlan from data in environment variables.
     pub fn from_environment(env: &Environment) -> Self {
         let mut phases: Vec<Phase> = Vec::new();
 
@@ -268,6 +292,7 @@ impl BuildPlan {
         BuildPlan::new(&phases, start)
     }
 
+    /// Store the base image and phase dependencies in this BuildPlan, for later reproducibility.
     pub fn pin(&mut self, use_debian: bool) {
         self.providers = Some(Vec::new());
         if self.build_image.is_none() {
@@ -290,6 +315,7 @@ impl BuildPlan {
         }
     }
 
+    /// Prefix each phase name with the name of the provider that generated the phase, in the case of multiple providers.
     pub fn prefix_phases(&mut self, prefix: &str) {
         if let Some(phases) = self.phases.clone() {
             self.resolve_phase_names();
@@ -306,6 +332,7 @@ impl BuildPlan {
         }
     }
 
+    /// Combine plans from multiple sources (environment variables, config files, providers) into a single plan.
     pub fn merge_plans(plans: &[BuildPlan]) -> BuildPlan {
         plans.iter().fold(BuildPlan::default(), |acc, plan| {
             BuildPlan::merge(&acc, plan)
@@ -314,10 +341,12 @@ impl BuildPlan {
 }
 
 impl topological_sort::TopItem for (String, Phase) {
+    /// Returns the name of this BuildPlan.
     fn get_name(&self) -> String {
         self.0.clone()
     }
 
+    /// Returns a collection of dependencies for this BuildPlan.
     fn get_dependencies(&self) -> &[String] {
         match &self.1.depends_on {
             Some(depends_on) => depends_on.as_slice(),
@@ -326,6 +355,7 @@ impl topological_sort::TopItem for (String, Phase) {
     }
 }
 
+/// Splits a string taken from an environment variable into a vector of packages, libraries, or directories.
 fn split_env_string(s: &str) -> Vec<String> {
     s.split([' ', ','])
         .map(std::string::ToString::to_string)

--- a/src/nixpacks/plan/pretty_print.rs
+++ b/src/nixpacks/plan/pretty_print.rs
@@ -10,6 +10,7 @@ const MIN_BOX_WIDTH: usize = 20;
 const MAX_BOX_WIDTH: usize = 80;
 
 impl BuildPlan {
+    /// The pretty-printed build plan, emitted by `nixpacks build`.
     pub fn get_build_string(&self) -> Result<String> {
         let title_str = format!(" Nixpacks v{NIX_PACKS_VERSION} ");
         let title_width = console::measure_text_width(title_str.as_str());
@@ -147,6 +148,7 @@ impl BuildPlan {
         })
     }
 
+    /// Produces a string of the packages to install and/or commands to run in the given phase.
     fn get_phase_content(&self, phase: &Phase) -> Result<String> {
         let mut c = String::new();
 
@@ -183,6 +185,7 @@ impl BuildPlan {
     }
 }
 
+/// Renders phase data as a row in the pretty-printed build plan.
 fn print_row(
     title: &str,
     content: &str,

--- a/src/nixpacks/plan/topological_sort.rs
+++ b/src/nixpacks/plan/topological_sort.rs
@@ -6,6 +6,7 @@ pub trait TopItem {
     fn get_dependencies(&self) -> &[String];
 }
 
+/// Sort items by functional dependencies.
 pub fn topological_sort<T>(items: Vec<T>) -> Result<Vec<T>>
 where
     T: Clone + TopItem,


### PR DESCRIPTION
This PR adds the following:
- **doc comments**, to nearly all functions and structs, hopefully making it easier for new contributors to get started (and also making docs generated by `cargo doc` more useful).
- **corrected typos** in a few files.
- **an updated `CONTRIBUTING.md`**, with fewer (maybe not zero!) typos and slightly improved formatting.

I did *not* add comments to the following:
- the `new` functions on structs; these are pretty self-explanatory and the comment on each struct already explains what it's for.
- anything defined in `mod tests`; everything here just calls functions which did receive comments.
- anything in `src/providers`; I encourage provider maintainers to update with comments accordingly.