### PR TITLE
Add provider `lunatic`

### DIFF
--- a/docs/pages/docs/providers/lunatic.md
+++ b/docs/pages/docs/providers/lunatic.md
@@ -38,7 +38,6 @@ _None_
 
 ## Build
 
-
 ```
 cargo build --release
 ```

--- a/docs/pages/docs/providers/lunatic.md
+++ b/docs/pages/docs/providers/lunatic.md
@@ -4,7 +4,7 @@ title: Lunatic
 
 # {% $markdoc.frontmatter.title %}
 
-Lunatic is detected if both
+[Lunatic](https://github.com/lunatic-solutions/) is detected if both
 
 - a `Cargo.toml` file is found and
 - [`.cargo/config.toml`](https://doc.rust-lang.org/cargo/reference/config.html) has the `runner = "lunatic"`

--- a/docs/pages/docs/providers/lunatic.md
+++ b/docs/pages/docs/providers/lunatic.md
@@ -48,7 +48,7 @@ cargo build --release
 The binaries get .wasm suffix and will be ran with the lunatic runtime.
 
 If your project has multiple binaries, you can specify which one to run with the `NIXPACKS_RUST_BIN` environment variable.
-Optionally, it can override with the `default_run` property in `Cargo.toml` under the `[package]` section.
+Optionally, it can be overriden with the `default_run` property in `Cargo.toml` under the `[package]` section.
 
 ```
 ./target/wasm32-wasi/release/{name}.wasm

--- a/docs/pages/docs/providers/lunatic.md
+++ b/docs/pages/docs/providers/lunatic.md
@@ -6,10 +6,10 @@ title: Lunatic
 
 Lunatic is detected if both
 
-- a `Cargo.toml` files is found and
-- [.cargo/config.toml](https://doc.rust-lang.org/cargo/reference/config.html) has `runner = "lunatic"`
+- a `Cargo.toml` file is found and
+- [`.cargo/config.toml`](https://doc.rust-lang.org/cargo/reference/config.html) has the `runner = "lunatic"`
 
-.cargo/config.toml:
+For example `.cargo/config.toml`:
 
 ```toml
 [build]

--- a/docs/pages/docs/providers/lunatic.md
+++ b/docs/pages/docs/providers/lunatic.md
@@ -1,0 +1,72 @@
+---
+title: Lunatic
+---
+
+# {% $markdoc.frontmatter.title %}
+
+Lunatic is detected if both
+
+- a `Cargo.toml` files is found and
+- [.cargo/config.toml](https://doc.rust-lang.org/cargo/reference/config.html) has `runner = "lunatic"`
+
+.cargo/config.toml:
+
+```toml
+[build]
+target = "wasm32-wasi"
+
+[target.wasm32-wasi]
+runner = "lunatic"
+```
+
+## Environment Variables
+
+None
+
+## Setup
+
+By default the latest stable version of Rust available in this [rust-overlay](https://github.com/oxalica/rust-overlay) is used. The version can be overridden with either
+
+- a `.rust-version` file
+- The `rust-version` property of `Cargo.toml`
+- setting the `NIXPACKS_RUST_VERSION` environment variable
+- A `rust-toolchain.toml` file
+
+## Install
+
+_None_
+
+## Build
+
+
+```
+cargo build --release
+```
+
+## Start
+
+The binaries get .wasm suffix and will be ran with the lunatic runtime.
+
+If your project has multiple binaries, you can specify which one to run with the `NIXPACKS_RUST_BIN` environment variable.
+Optionally, it can override with the `default_run` property in `Cargo.toml` under the `[package]` section.
+
+```
+./target/wasm32-wasi/release/{name}.wasm
+```
+
+## Caching
+
+These directories are cached between builds
+
+- Build: `~/.cargo/git`
+- Build: `~/.cargo/registry`
+- Build: `target`
+
+## Workspaces
+
+Nixpacks will auto-detect if you are using [Cargo Workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html).
+This checks `workspace.default_members` first and then `workspace.members`.
+It also respects the `workspace.exclude` field.
+
+To set which workspace Nixpacks will build, just set the `NIXPACKS_CARGO_WORKSPACE`
+environment variable and Nixpacks will use it as the `--package` argument.

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -44,6 +44,7 @@ export const sidebarItems: ISidebarSection[] = [
       { href: "/docs/providers/go", text: "Go" },
       { href: "/docs/providers/haskell", text: "Haskell" },
       { href: "/docs/providers/java", text: "Java" },
+      { href: "/docs/providers/lunatic", "text: "Lunatic" },
       { href: "/docs/providers/node", text: "Node" },
       { href: "/docs/providers/php", text: "PHP" },
       { href: "/docs/providers/python", text: "Python" },

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -44,7 +44,7 @@ export const sidebarItems: ISidebarSection[] = [
       { href: "/docs/providers/go", text: "Go" },
       { href: "/docs/providers/haskell", text: "Haskell" },
       { href: "/docs/providers/java", text: "Java" },
-      { href: "/docs/providers/lunatic", "text: "Lunatic" },
+      { href: "/docs/providers/lunatic", text: "Lunatic" },
       { href: "/docs/providers/node", text: "Node" },
       { href: "/docs/providers/php", text: "PHP" },
       { href: "/docs/providers/python", text: "Python" },

--- a/examples/lunatic-basic/.cargo/config.toml
+++ b/examples/lunatic-basic/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "wasm32-wasi"
+
+[target.wasm32-wasi]
+runner = "lunatic"

--- a/examples/lunatic-basic/Cargo.toml
+++ b/examples/lunatic-basic/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lunatic = "0.13"

--- a/examples/lunatic-basic/Cargo.toml
+++ b/examples/lunatic-basic/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "lunatic-basic"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/examples/lunatic-basic/src/main.rs
+++ b/examples/lunatic-basic/src/main.rs
@@ -1,0 +1,6 @@
+use std::process::Command;
+
+fn main() {
+    let mut cargo_version_command = Command::new("cargo").arg("version").spawn().unwrap();
+    cargo_version_command.wait().unwrap();
+}

--- a/examples/lunatic-basic/src/main.rs
+++ b/examples/lunatic-basic/src/main.rs
@@ -1,6 +1,21 @@
-use std::process::Command;
+use lunatic::net;
 
 fn main() {
-    let mut cargo_version_command = Command::new("cargo").arg("version").spawn().unwrap();
-    cargo_version_command.wait().unwrap();
+    let sender = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let receiver = net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let receiver_addr = receiver.local_addr().unwrap();
+
+    sender.connect(receiver_addr).expect("couldn't connect");
+    sender
+        .send("P1NG".as_bytes())
+        .expect("couldn't send message");
+
+    let mut buf = [0; 4];
+    let len_in = receiver.recv(&mut buf).unwrap();
+
+    assert_eq!(len_in, 4);
+    assert_eq!(buf, "P1NG".as_bytes());
+
+    // wasi stdout
+    println!("PING-PONG");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,9 @@ use providers::{
     clojure::ClojureProvider, cobol::CobolProvider, crystal::CrystalProvider,
     csharp::CSharpProvider, dart::DartProvider, deno::DenoProvider, elixir::ElixirProvider,
     fsharp::FSharpProvider, go::GolangProvider, haskell::HaskellStackProvider, java::JavaProvider,
-    node::NodeProvider, php::PhpProvider, python::PythonProvider, ruby::RubyProvider,
-    rust::RustProvider, scala::ScalaProvider, staticfile::StaticfileProvider, swift::SwiftProvider,
-    zig::ZigProvider, Provider,
+    lunatic::LunaticProvider, node::NodeProvider, php::PhpProvider, python::PythonProvider,
+    ruby::RubyProvider, rust::RustProvider, scala::ScalaProvider, staticfile::StaticfileProvider,
+    swift::SwiftProvider, zig::ZigProvider, Provider,
 };
 
 mod chain;
@@ -59,6 +59,7 @@ pub fn get_providers() -> &'static [&'static (dyn Provider)] {
         &GolangProvider {},
         &HaskellStackProvider {},
         &JavaProvider {},
+        &LunaticProvider {},
         &ScalaProvider {},
         &PhpProvider {},
         &RubyProvider {},

--- a/src/providers/lunatic.rs
+++ b/src/providers/lunatic.rs
@@ -40,7 +40,13 @@ impl Provider for LunaticProvider {
 
 impl LunaticProvider {
     fn get_setup(app: &App, env: &Environment) -> Result<Phase> {
-        RustProvider::get_setup(app, env)
+        let mut setup = RustProvider::get_setup(app, env)?;
+
+        if let Some(pkgs) = &mut setup.nix_pkgs {
+            (*pkgs).push("lunatic".into());
+        }
+
+        Ok(setup)
     }
 
     fn get_build(app: &App, env: &Environment) -> Result<Phase> {

--- a/src/providers/lunatic.rs
+++ b/src/providers/lunatic.rs
@@ -63,8 +63,3 @@ impl LunaticProvider {
         }
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-}

--- a/src/providers/lunatic.rs
+++ b/src/providers/lunatic.rs
@@ -24,7 +24,7 @@ impl Provider for LunaticProvider {
         }
 
         let re_runner = Regex::new(r##"runner\s*=\s*"lunatic""##).expect("BUG: Broken regex");
-        Ok(app.find_match(&re_runner, ".cargo/config.toml")?)
+        app.find_match(&re_runner, ".cargo/config.toml")
     }
 
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<Option<BuildPlan>> {

--- a/src/providers/lunatic.rs
+++ b/src/providers/lunatic.rs
@@ -1,0 +1,59 @@
+use super::Provider;
+use crate::nixpacks::{
+    app::App,
+    environment::Environment,
+    plan::{
+        phase::{Phase, StartPhase},
+        BuildPlan,
+    },
+};
+use crate::providers::rust::RustProvider;
+use anyhow::{Result};
+
+pub struct LunaticProvider {}
+
+impl Provider for LunaticProvider {
+    fn name(&self) -> &str {
+        "lunatic"
+    }
+
+    fn detect(&self, app: &App, _env: &Environment) -> Result<bool> {
+        if !app.includes_file("Cargo.toml") {
+            return Ok(false)
+        }
+
+        Ok(false)
+        
+    }
+
+    fn get_build_plan(&self, app: &App, env: &Environment) -> Result<Option<BuildPlan>> {
+        let setup = LunaticProvider::get_setup(app, env)?;
+        let build = LunaticProvider::get_build(app, env)?;
+        let start = LunaticProvider::get_start(app, env)?;
+
+        let plan = BuildPlan::new(&vec![setup, build], start);
+
+        Ok(Some(plan))
+    }
+}
+
+impl LunaticProvider {
+    fn get_setup(app: &App, env: &Environment) -> Result<Phase> {
+        RustProvider::get_setup(app, env)
+    }
+
+    fn get_build(app: &App, env: &Environment) -> Result<Phase> {
+        RustProvider::get_build(app, env)
+    }
+
+    fn get_start(app: &App, env: &Environment) -> Result<Option<StartPhase>> {
+        RustProvider::get_start(app, env)
+        
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+}

--- a/src/providers/lunatic.rs
+++ b/src/providers/lunatic.rs
@@ -8,7 +8,7 @@ use crate::nixpacks::{
     },
 };
 use crate::providers::rust::RustProvider;
-use anyhow::{Result};
+use anyhow::Result;
 use regex::Regex;
 
 pub struct LunaticProvider {}
@@ -20,11 +20,11 @@ impl Provider for LunaticProvider {
 
     fn detect(&self, app: &App, _env: &Environment) -> Result<bool> {
         if !app.includes_file("Cargo.toml") {
-            return Ok(false)
+            return Ok(false);
         }
 
-        let re_runner = Regex::new(r##"runner\s*=\s*"lunatic")"##).expect("BUG: Broken regex");
-        Ok(app.find_match(&re_runner, ".config/cargo.toml")?)
+        let re_runner = Regex::new(r##"runner\s*=\s*"lunatic""##).expect("BUG: Broken regex");
+        Ok(app.find_match(&re_runner, ".cargo/config.toml")?)
     }
 
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<Option<BuildPlan>> {
@@ -48,13 +48,17 @@ impl LunaticProvider {
     }
 
     fn get_start(app: &App, env: &Environment) -> Result<Option<StartPhase>> {
-        RustProvider::get_start(app, env)
-        
+        match RustProvider::get_start(app, env)? {
+            Some(start_phase) => match start_phase.cmd {
+                Some(bin) => Ok(Some(StartPhase::new(format!("lunatic {bin}")))),
+                None => Ok(None),
+            },
+            None => Ok(None),
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-
 }

--- a/src/providers/lunatic.rs
+++ b/src/providers/lunatic.rs
@@ -9,6 +9,7 @@ use crate::nixpacks::{
 };
 use crate::providers::rust::RustProvider;
 use anyhow::{Result};
+use regex::Regex;
 
 pub struct LunaticProvider {}
 
@@ -22,8 +23,8 @@ impl Provider for LunaticProvider {
             return Ok(false)
         }
 
-        Ok(false)
-        
+        let re_runner = Regex::new(r##"runner\s*=\s*"lunatic")"##).expect("BUG: Broken regex");
+        Ok(app.find_match(&re_runner, ".config/cargo.toml")?)
     }
 
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<Option<BuildPlan>> {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,6 +12,7 @@ pub mod fsharp;
 pub mod go;
 pub mod haskell;
 pub mod java;
+pub mod lunatic;
 pub mod node;
 pub mod php;
 pub mod procfile;

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -48,7 +48,7 @@ impl Provider for RustProvider {
 }
 
 impl RustProvider {
-    fn get_setup(app: &App, env: &Environment) -> Result<Phase> {
+    pub(crate) fn get_setup(app: &App, env: &Environment) -> Result<Phase> {
         let mut rust_pkg: Pkg = RustProvider::get_rust_pkg(app, env)?;
 
         if let Some(target) = RustProvider::get_target(app, env)? {
@@ -78,7 +78,7 @@ impl RustProvider {
         Ok(setup)
     }
 
-    fn get_build(app: &App, env: &Environment) -> Result<Phase> {
+    pub(crate) fn get_build(app: &App, env: &Environment) -> Result<Phase> {
         let mut build = Phase::build(None);
         if !app.includes_file("Cargo.toml") {
             return Ok(build);
@@ -127,7 +127,7 @@ impl RustProvider {
         Ok(build)
     }
 
-    fn get_bins(app: &App) -> Result<Option<Vec<String>>> {
+    pub(crate) fn get_bins(app: &App) -> Result<Option<Vec<String>>> {
         let mut bins = vec![];
 
         // Support the main bin
@@ -162,7 +162,7 @@ impl RustProvider {
         Ok(Some(bins))
     }
 
-    fn get_start(app: &App, env: &Environment) -> Result<Option<StartPhase>> {
+    pub(crate) fn get_start(app: &App, env: &Environment) -> Result<Option<StartPhase>> {
         if (RustProvider::get_target(app, env)?).is_some() {
             if let Some(workspace) = RustProvider::resolve_cargo_workspace(app, env)? {
                 let mut start = StartPhase::new(format!("./bin/{workspace}"));
@@ -187,7 +187,7 @@ impl RustProvider {
         }
     }
 
-    fn get_app_name(app: &App) -> Result<Option<String>> {
+    pub(crate) fn get_app_name(app: &App) -> Result<Option<String>> {
         if let Some(toml_file) = RustProvider::parse_cargo_toml(app)? {
             if let Some(package) = toml_file.package {
                 let name = package.name;
@@ -198,7 +198,7 @@ impl RustProvider {
         Ok(None)
     }
 
-    fn get_start_bin(app: &App, env: &Environment) -> Result<Option<String>> {
+    pub(crate) fn get_start_bin(app: &App, env: &Environment) -> Result<Option<String>> {
         if let Some(bins) = RustProvider::get_bins(app)? {
             let mut bin: Option<String> = None;
 
@@ -228,7 +228,7 @@ impl RustProvider {
         }
     }
 
-    fn get_target(app: &App, env: &Environment) -> Result<Option<String>> {
+    pub(crate) fn get_target(app: &App, env: &Environment) -> Result<Option<String>> {
         if RustProvider::should_use_musl(app, env)? {
             Ok(Some(format!("{ARCH}-unknown-linux-musl")))
         } else {
@@ -236,7 +236,7 @@ impl RustProvider {
         }
     }
 
-    fn parse_cargo_toml(app: &App) -> Result<Option<Manifest>> {
+    pub(crate) fn parse_cargo_toml(app: &App) -> Result<Option<Manifest>> {
         if app.includes_file("Cargo.toml") {
             let cargo_toml: Manifest = app.read_toml("Cargo.toml").context("Reading Cargo.toml")?;
 
@@ -246,7 +246,7 @@ impl RustProvider {
         Ok(None)
     }
 
-    fn get_rust_toolchain_file(app: &App) -> Option<String> {
+    pub(crate) fn get_rust_toolchain_file(app: &App) -> Option<String> {
         if app.includes_file("rust-toolchain") {
             Some("rust-toolchain".to_string())
         } else if app.includes_file("rust-toolchain.toml") {
@@ -257,7 +257,7 @@ impl RustProvider {
     }
 
     // Get the rust package version by parsing the `rust-version` field in `Cargo.toml`
-    fn get_rust_pkg(app: &App, env: &Environment) -> Result<Pkg> {
+    pub(crate) fn get_rust_pkg(app: &App, env: &Environment) -> Result<Pkg> {
         if let Some(version) = env.get_config_variable("RUST_VERSION") {
             return Ok(Pkg::new(&format!("rust-bin.stable.\"{version}\".default")));
         }
@@ -289,7 +289,7 @@ impl RustProvider {
         Ok(pkg)
     }
 
-    fn should_use_musl(app: &App, env: &Environment) -> Result<bool> {
+    pub(crate) fn should_use_musl(app: &App, env: &Environment) -> Result<bool> {
         if env.is_config_variable_truthy("NO_MUSL") {
             return Ok(false);
         }
@@ -306,7 +306,7 @@ impl RustProvider {
         Ok(true)
     }
 
-    fn uses_openssl(app: &App) -> Result<bool> {
+    pub(crate) fn uses_openssl(app: &App) -> Result<bool> {
         // Check Cargo.toml
         if let Some(toml_file) = RustProvider::parse_cargo_toml(app)? {
             if toml_file.dependencies.contains_key("openssl")
@@ -325,7 +325,7 @@ impl RustProvider {
         Ok(false)
     }
 
-    fn resolve_cargo_workspace(app: &App, env: &Environment) -> Result<Option<String>> {
+    pub(crate) fn resolve_cargo_workspace(app: &App, env: &Environment) -> Result<Option<String>> {
         if let Some(name) = env.get_config_variable("CARGO_WORKSPACE") {
             return Ok(Some(name));
         }
@@ -341,7 +341,7 @@ impl RustProvider {
         Ok(None)
     }
 
-    fn find_binary_in_workspace(app: &App, workspace: &Workspace) -> Result<Option<String>> {
+    pub(crate) fn find_binary_in_workspace(app: &App, workspace: &Workspace) -> Result<Option<String>> {
         let find_binary = |member: &str| -> Result<Option<String>> {
             let mut manifest = app.read_toml::<Manifest>(&format!("{member}/Cargo.toml"))?;
 

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -313,10 +313,7 @@ impl RustProvider {
     fn should_make_wasm32_wasi(app: &App, _env: &Environment) -> bool {
         let re_target = Regex::new(r##"target\s*=\s*"wasm32-wasi""##).expect("BUG: Broken regex");
 
-        match app.find_match(&re_target, ".cargo/config.toml") {
-            Ok(true) => true,
-            _ => false,
-        }
+        matches!(app.find_match(&re_target, ".cargo/config.toml"), Ok(true))
     }
 
     fn should_use_musl(app: &App, env: &Environment) -> Result<bool> {

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -127,7 +127,7 @@ impl RustProvider {
         Ok(build)
     }
 
-    pub(crate) fn get_bins(app: &App) -> Result<Option<Vec<String>>> {
+    fn get_bins(app: &App) -> Result<Option<Vec<String>>> {
         let mut bins = vec![];
 
         // Support the main bin
@@ -187,7 +187,7 @@ impl RustProvider {
         }
     }
 
-    pub(crate) fn get_app_name(app: &App) -> Result<Option<String>> {
+    fn get_app_name(app: &App) -> Result<Option<String>> {
         if let Some(toml_file) = RustProvider::parse_cargo_toml(app)? {
             if let Some(package) = toml_file.package {
                 let name = package.name;
@@ -198,7 +198,7 @@ impl RustProvider {
         Ok(None)
     }
 
-    pub(crate) fn get_start_bin(app: &App, env: &Environment) -> Result<Option<String>> {
+    fn get_start_bin(app: &App, env: &Environment) -> Result<Option<String>> {
         if let Some(bins) = RustProvider::get_bins(app)? {
             let mut bin: Option<String> = None;
 
@@ -228,7 +228,7 @@ impl RustProvider {
         }
     }
 
-    pub(crate) fn get_target(app: &App, env: &Environment) -> Result<Option<String>> {
+    fn get_target(app: &App, env: &Environment) -> Result<Option<String>> {
         if RustProvider::should_use_musl(app, env)? {
             Ok(Some(format!("{ARCH}-unknown-linux-musl")))
         } else {
@@ -236,7 +236,7 @@ impl RustProvider {
         }
     }
 
-    pub(crate) fn parse_cargo_toml(app: &App) -> Result<Option<Manifest>> {
+    fn parse_cargo_toml(app: &App) -> Result<Option<Manifest>> {
         if app.includes_file("Cargo.toml") {
             let cargo_toml: Manifest = app.read_toml("Cargo.toml").context("Reading Cargo.toml")?;
 
@@ -246,7 +246,7 @@ impl RustProvider {
         Ok(None)
     }
 
-    pub(crate) fn get_rust_toolchain_file(app: &App) -> Option<String> {
+    fn get_rust_toolchain_file(app: &App) -> Option<String> {
         if app.includes_file("rust-toolchain") {
             Some("rust-toolchain".to_string())
         } else if app.includes_file("rust-toolchain.toml") {
@@ -257,7 +257,7 @@ impl RustProvider {
     }
 
     // Get the rust package version by parsing the `rust-version` field in `Cargo.toml`
-    pub(crate) fn get_rust_pkg(app: &App, env: &Environment) -> Result<Pkg> {
+    fn get_rust_pkg(app: &App, env: &Environment) -> Result<Pkg> {
         if let Some(version) = env.get_config_variable("RUST_VERSION") {
             return Ok(Pkg::new(&format!("rust-bin.stable.\"{version}\".default")));
         }
@@ -289,7 +289,7 @@ impl RustProvider {
         Ok(pkg)
     }
 
-    pub(crate) fn should_use_musl(app: &App, env: &Environment) -> Result<bool> {
+    fn should_use_musl(app: &App, env: &Environment) -> Result<bool> {
         if env.is_config_variable_truthy("NO_MUSL") {
             return Ok(false);
         }
@@ -306,7 +306,7 @@ impl RustProvider {
         Ok(true)
     }
 
-    pub(crate) fn uses_openssl(app: &App) -> Result<bool> {
+    fn uses_openssl(app: &App) -> Result<bool> {
         // Check Cargo.toml
         if let Some(toml_file) = RustProvider::parse_cargo_toml(app)? {
             if toml_file.dependencies.contains_key("openssl")
@@ -325,7 +325,7 @@ impl RustProvider {
         Ok(false)
     }
 
-    pub(crate) fn resolve_cargo_workspace(app: &App, env: &Environment) -> Result<Option<String>> {
+    fn resolve_cargo_workspace(app: &App, env: &Environment) -> Result<Option<String>> {
         if let Some(name) = env.get_config_variable("CARGO_WORKSPACE") {
             return Ok(Some(name));
         }
@@ -341,7 +341,7 @@ impl RustProvider {
         Ok(None)
     }
 
-    pub(crate) fn find_binary_in_workspace(app: &App, workspace: &Workspace) -> Result<Option<String>> {
+    fn find_binary_in_workspace(app: &App, workspace: &Workspace) -> Result<Option<String>> {
         let find_binary = |member: &str| -> Result<Option<String>> {
             let mut manifest = app.read_toml::<Manifest>(&format!("{member}/Cargo.toml"))?;
 

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -644,6 +644,13 @@ async fn test_django_mysql() {
 }
 
 #[tokio::test]
+async fn test_lunatic_basic() {
+    let name = simple_build("./examples/lunatic-basic").await;
+    let output = run_image(&name, None).await;
+    assert!(output.contains("PING-PONG"));
+}
+
+#[tokio::test]
 async fn test_python_poetry() {
     let name = simple_build("./examples/python-poetry").await;
     let output = run_image(&name, None).await;

--- a/tests/snapshots/generate_plan_tests__lunatic_basic.snap
+++ b/tests/snapshots/generate_plan_tests__lunatic_basic.snap
@@ -1,0 +1,45 @@
+---
+source: tests/generate_plan_tests.rs
+expression: plan
+---
+{
+  "providers": [],
+  "buildImage": "[build_image]",
+  "variables": {
+    "NIXPACKS_METADATA": "lunatic"
+  },
+  "phases": {
+    "build": {
+      "name": "build",
+      "dependsOn": [
+        "setup"
+      ],
+      "cmds": [
+        "mkdir -p bin",
+        "cargo build --release --target wasm32-wasi",
+        "cp target/wasm32-wasi/release/lunatic-basic.wasm bin"
+      ],
+      "cacheDirectories": [
+        "/root/.cargo/git",
+        "/root/.cargo/registry",
+        "target"
+      ]
+    },
+    "setup": {
+      "name": "setup",
+      "nixPkgs": [
+        "binutils",
+        "gcc",
+        "(rust-bin.stable.latest.default.override { targets = [\"wasm32-wasi\"]; })",
+        "lunatic"
+      ],
+      "nixOverlays": [
+        "https://github.com/oxalica/rust-overlay/archive/master.tar.gz"
+      ],
+      "nixpkgsArchive": "[archive]"
+    }
+  },
+  "start": {
+    "cmd": "lunatic ./bin/lunatic-basic.wasm"
+  }
+}


### PR DESCRIPTION
This PR adds [lunatic](https://github.com/lunatic-solutions/lunatic) provider

I propose to either or / all of these:
- [X] Change the private fn from RustProvider as `pub(crate)` for DRY at lunatic that wraps them over and extends
- [X] Add provider that wraps on top of Rust since lunatic-rust is the 1st class server side wasm citizen
- [X] Detect from .cargo/config.toml whether the runner is set as "lunatic"
- [X] Detect whether the target is wasm32-wasi

Questions
- [X] Lunatic needs [lunatic-runtime](https://crates.io/crates/lunatic) binary and I was wondering how could I cache this somewhere best suited to nixpacks - **can use it's nixpkg - it was recently bumped to 0.13**

In the future
- Should this use alpine instead of big ubuntu ? musl shouldn't be an issue
- Extend with AssemblyScript-lunatic and re-organise `providers/lunatic.rs` with `lunatic/rust.rs` and `lunatic/as.rs`
- Add test workspace snapshot e.g. https://github.com/yaws-rs/yaws

Lunatic is fun - a bloggy blog I wrote:
- https://missmissm.medium.com/play-ping-pong-with-lunatic-udp-ef557a22a604
- https://github.com/lunatic-solutions/submillisecond/ - Web framework w/ [submillisecond-liveview](https://github.com/lunatic-solutions/submillisecond-live-view)
- https://github.com/yaws-rs - a web server I'm using it in