### PR TITLE
Fix: use dvh to fix iOS sidebar style issue

### DIFF
--- a/docs/components/SideNav.tsx
+++ b/docs/components/SideNav.tsx
@@ -15,6 +15,8 @@ export const SideNav: React.FC<{ className?: string }> = ({ className }) => {
       >
         <SidebarContent />
       </div>
+      {/* using css fallback properties for cross-browser compatibility  */}
+      {/* read more: https://modernweb.com/using-css-fallback-properties-for-better-cross-browser-compatibility/ */}
       <style jsx> {`
         .sidebar-container {
           height: calc(100vh - var(--top-nav-height) - 4px);

--- a/docs/components/SideNav.tsx
+++ b/docs/components/SideNav.tsx
@@ -8,14 +8,20 @@ export const SideNav: React.FC<{ className?: string }> = ({ className }) => {
   return (
     <nav className={`sidenav text-sm px-4 w-[240px] ${className ?? ""}`}>
       <div
-        className="sticky pt-8 pb-4 overflow-y-auto"
+        className="sticky pt-8 pb-4 overflow-y-auto sidebar-container"
         style={{
-          height: "calc(100vh - var(--top-nav-height) - 4px)",
           top: "calc(var(--top-nav-height) + 4px)",
         }}
       >
         <SidebarContent />
       </div>
+      <style jsx> {`
+        .sidebar-container {
+          height: calc(100vh - var(--top-nav-height) - 4px);
+          height: calc(100dvh - var(--top-nav-height) - 4px);
+        }
+      `}
+      </style>
     </nav>
   );
 };

--- a/docs/components/TableOfContents.tsx
+++ b/docs/components/TableOfContents.tsx
@@ -141,6 +141,8 @@ export const TableOfContents: React.FC<{
           <ArrowRight size={14} className="ml-2 text-current" />
         </a>
       </div>
+      {/* using css fallback properties for cross-browser compatibility  */}
+      {/* read more: https://modernweb.com/using-css-fallback-properties-for-better-cross-browser-compatibility/ */}
       <style jsx> {`
         .table-container {
           height: calc(100vh - var(--top-nav-height) - 4px);

--- a/docs/components/TableOfContents.tsx
+++ b/docs/components/TableOfContents.tsx
@@ -91,9 +91,8 @@ export const TableOfContents: React.FC<{
   return (
     <nav className={`toc w-56 px-4 ${className}`}>
       <div
-        className="sticky pt-20"
+        className="sticky pt-20 table-container"
         style={{
-          height: "calc(100vh - var(--top-nav-height) - 4px)",
           top: "calc(var(--top-nav-height) + 4px)",
         }}
       >
@@ -142,6 +141,13 @@ export const TableOfContents: React.FC<{
           <ArrowRight size={14} className="ml-2 text-current" />
         </a>
       </div>
+      <style jsx> {`
+        .table-container {
+          height: calc(100vh - var(--top-nav-height) - 4px);
+          height: calc(100dvh - var(--top-nav-height) - 4px);
+        }
+      `}
+      </style>
     </nav>
   );
 };

--- a/docs/components/TopNav.tsx
+++ b/docs/components/TopNav.tsx
@@ -77,13 +77,19 @@ export const TopNav: React.FC<{
         <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
         <div className="fixed inset-0 bg-bg">
-          <Dialog.Panel className="px-8 overflow-y-auto mt-[var(--top-nav-height)] py-4 max-h-[calc(100vh-var(--top-nav-height))]">
+          <Dialog.Panel className="px-8 overflow-y-auto mt-[var(--top-nav-height)] py-4 dialog-panel-container">
             <Dialog.Title className="hidden">Navigation</Dialog.Title>
 
             <SidebarContent className="w-full" />
           </Dialog.Panel>
         </div>
       </Dialog>
+      <style jsx global>{`
+        .dialog-panel-container {
+          max-height: calc(100vh - var(--top-nav-height));
+          max-height: calc(100dvh - var(--top-nav-height));
+        }
+      `}</style>
     </div>
   );
 };

--- a/docs/components/TopNav.tsx
+++ b/docs/components/TopNav.tsx
@@ -84,6 +84,9 @@ export const TopNav: React.FC<{
           </Dialog.Panel>
         </div>
       </Dialog>
+      {/* using css fallback properties for cross-browser compatibility  */}
+      {/* read more: https://modernweb.com/using-css-fallback-properties-for-better-cross-browser-compatibility/ */}
+      {/* using global style because scope style does not work on Dialog component */}
       <style jsx global>{`
         .dialog-panel-container {
           max-height: calc(100vh - var(--top-nav-height));

--- a/docs/typings/styled-jsx.d.ts
+++ b/docs/typings/styled-jsx.d.ts
@@ -1,7 +1,7 @@
 import "react";
 // Augmentation of React
 declare module "react" {
-  interface HTMLProps<T> {
+  interface StyleHTMLAttributes<T> extends React.HTMLAttributes<T> {
     jsx?: boolean;
     global?: boolean;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This pr:
1. fix: #882 . Using `dvh` to replace `vh` will fix this bug. 
2. fix wrong style jsx typing

In order to make sure it 100% compatible with old and new browser, I use `style jsx` here.

For more `dvh` information, can read this awesome article https://dev.to/frehner/css-vh-dvh-lvh-svh-and-vw-units-27k4

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
