### PR TITLE
Fix: correct node version parse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,26 +427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,7 +1055,6 @@ dependencies = [
  "clap",
  "colored",
  "console",
- "const_format",
  "dotenv-parser",
  "futures",
  "futures-util",
@@ -1840,12 +1819,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +424,26 @@ dependencies = [
  "libc",
  "terminal_size",
  "winapi",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -981,10 +1007,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "miette"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07749fb52853e739208049fb513287c6f448de9103dfa78b05ae01f2fc5809bb"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a07ad93a80d1b92bb44cb42d7c49b49c9aab1778befefad49cceb5e4c5bf460"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1020,6 +1075,7 @@ dependencies = [
  "clap",
  "colored",
  "console",
+ "const_format",
  "dotenv-parser",
  "futures",
  "futures-util",
@@ -1027,6 +1083,7 @@ dependencies = [
  "ignore",
  "indoc",
  "insta",
+ "node-semver",
  "path-slash",
  "portpicker",
  "rand 0.8.5",
@@ -1045,6 +1102,29 @@ dependencies = [
  "uuid",
  "wait-timeout",
  "walkdir",
+]
+
+[[package]]
+name = "node-semver"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f390c1756333538f2aed01cf280a56bc683e199b9804a504df6e7320d40116"
+dependencies = [
+ "bytecount",
+ "miette",
+ "nom",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1754,6 +1834,18 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ tokio = { version = "1.23.0", features = ["full"] }
 async-trait = "0.1.59"
 semver = "1.0.14"
 node-semver = "2.1.0"
-const_format = "0.2.30"
 
 [dev-dependencies]
 dotenv-parser = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ portpicker = "0.1.1"
 tokio = { version = "1.23.0", features = ["full"] }
 async-trait = "0.1.59"
 semver = "1.0.14"
+node-semver = "2.1.0"
+const_format = "0.2.30"
 
 [dev-dependencies]
 dotenv-parser = "0.1.3"

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -570,15 +570,19 @@ fn version_number_to_pkg(version: u32) -> String {
     }
 }
 
-fn pkg_to_version_number(pkg: &str) -> u32 {
+fn pkg_to_version_number(pkg: &str) -> Option<u32> {
     let re = Regex::new(r"nodejs-(?P<version>\d+)_x").unwrap();
-    let captures = re.captures(pkg).unwrap();
-    let version_number: u32 = captures["version"].parse().unwrap();
-    version_number
+    match re.captures(pkg) {
+        None => None,
+        Some(captures) => {
+            let version_number: u32 = captures["version"].parse().unwrap();
+            Some(version_number)
+        }
+    }
 }
 
 fn parse_node_version_into_pkg(node_version: &str) -> String {
-    let default_node_version = pkg_to_version_number(DEFAULT_NODE_PKG_NAME);
+    let default_node_version = pkg_to_version_number(DEFAULT_NODE_PKG_NAME).unwrap();
     let range: Range = node_version.parse().unwrap_or_else(|_| {
         println!("Warning: node version {node_version} is not valid, using default node version {DEFAULT_NODE_PKG_NAME}");
         Range::parse(default_node_version.to_string()).unwrap()
@@ -604,6 +608,16 @@ mod test {
 
     fn engines_node(version: &str) -> HashMap<String, String> {
         HashMap::from([("node".to_string(), version.to_string())])
+    }
+
+    #[test]
+    fn test_pkg_to_version_number_invalid() {
+        assert_eq!(None, pkg_to_version_number("1"));
+    }
+
+    #[test]
+    fn test_pkg_to_version_number() {
+        assert_eq!(Some(16), pkg_to_version_number("nodejs-16_x"));
     }
 
     #[test]

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -576,11 +576,13 @@ fn parse_node_version_into_pkg(node_version: &str) -> String {
         println!("Warning: node version {node_version} is not valid, using default node version {DEFAULT_NODE_PKG_NAME}");
         Range::parse(DEFAULT_NODE_VERSION.to_string()).unwrap()
     });
-    for version_number in AVAILABLE_NODE_VERSIONS {
+    let mut available_node_versions = AVAILABLE_NODE_VERSIONS.to_vec();
+    available_node_versions.sort_by(|a, b| b.cmp(a));
+    for version_number in available_node_versions {
         let version_range_string = format!("{version_number}.x.x");
         let version_range: Range = version_range_string.parse().unwrap();
         if version_range.allows_any(&range) {
-            return version_number_to_pkg(*version_number);
+            return version_number_to_pkg(version_number);
         }
     }
     DEFAULT_NODE_PKG_NAME.to_string()

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -807,13 +807,31 @@ mod test {
             NodeProvider::get_nix_node_pkg(
                 &PackageJson {
                     name: Some(String::default()),
-                    engines: Some(engines_node("1.2.3 || >14.10.3")),
+                    engines: Some(engines_node("1.2.3 || 14.10.3")),
                     ..Default::default()
                 },
                 &App::new("examples/node")?,
                 &Environment::default()
             )?,
             Pkg::new("nodejs-14_x")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_engine_multi_satisfied_range() -> Result<()> {
+        assert_eq!(
+            NodeProvider::get_nix_node_pkg(
+                &PackageJson {
+                    name: Some(String::default()),
+                    engines: Some(engines_node("14.10.3 || 18.10.0")),
+                    ..Default::default()
+                },
+                &App::new("examples/node")?,
+                &Environment::default()
+            )?,
+            Pkg::new("nodejs-18_x")
         );
 
         Ok(())

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -584,6 +584,7 @@ fn parse_node_version_into_pkg(node_version: &str) -> String {
         Range::parse(default_node_version.to_string()).unwrap()
     });
     let mut available_node_versions = AVAILABLE_NODE_VERSIONS.to_vec();
+    // use newest node version first
     available_node_versions.sort_by(|a, b| b.cmp(a));
     for version_number in available_node_versions {
         let version_range_string = format!("{version_number}.x.x");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR:
fix #858 

#858 describe our current implementation cant parse `^14.10.3` correctly, it will return the default node version, but it should return `14`.

In real world `node-semver` is more complicated. You can check how npm handle this https://github.com/npm/node-semver

Fortunately, we have a great crate can do same thing https://github.com/felipesere/node-semver-rs

## How I think the original implementation?
**inputs (one of):** 
1. package.json -> engines -> node (node semver)
2. .nvmrc (may prefixed `v`)
3. NODE_VERSION (node semver)

**outputs:**
node version that statisfied the inputs version (one of):
1. 14
2. 16
3. 18


<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
