### PR TITLE
Add tracing logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -178,7 +178,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -236,7 +236,7 @@ checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -384,7 +384,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -495,7 +495,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -506,7 +506,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -519,7 +519,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -665,7 +665,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1042,9 +1042,21 @@ dependencies = [
  "textwrap",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "wait-timeout",
  "walkdir",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1068,6 +1080,12 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1140,7 +1158,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1190,7 +1208,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -1207,18 +1225,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -1402,7 +1420,7 @@ checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1447,7 +1465,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1472,6 +1490,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1525,6 +1552,17 @@ name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1593,7 +1631,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1675,7 +1713,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1710,7 +1748,19 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1720,6 +1770,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1780,6 +1856,12 @@ checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ portpicker = "0.1.1"
 tokio = { version = "1.23.0", features = ["full"] }
 async-trait = "0.1.59"
 semver = "1.0.14"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
 
 [dev-dependencies]
 dotenv-parser = "0.1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ use providers::{
     rust::RustProvider, scala::ScalaProvider, staticfile::StaticfileProvider, swift::SwiftProvider,
     zig::ZigProvider, Provider,
 };
+use tracing::info;
 
 mod chain;
 #[macro_use]
@@ -118,7 +119,7 @@ pub async fn create_docker_image(
 
     if let Ok(subdir) = app.source.strip_prefix(orig_path) {
         if subdir != std::path::Path::new("") {
-            println!("Using subdirectory \"{}\"", subdir.to_str().unwrap());
+            info!("Using subdirectory \"{}\"", subdir.to_str().unwrap());
         }
     }
 
@@ -127,19 +128,19 @@ pub async fn create_docker_image(
 
     let phase_count = plan.phases.clone().map_or(0, |phases| phases.len());
     if phase_count > 0 {
-        println!("{}", plan.get_build_string()?);
+        info!("Build plan has {} phases", phase_count);
 
         let start = plan.start_phase.clone().unwrap_or_default();
         if start.cmd.is_none() && !build_options.no_error_without_start {
             bail!("No start command could be found")
         }
     } else {
-        println!("\nNixpacks was unable to generate a build plan for this app.\nPlease check the documentation for supported languages: https://nixpacks.com");
-        println!("\nThe contents of the app directory are:\n");
+        info!("\nNixpacks was unable to generate a build plan for this app.\nPlease check the documentation for supported languages: https://nixpacks.com");
+        info!("\nThe contents of the app directory are:\n");
 
         for file in &app.paths {
             let path = app.strip_source_path(file.as_path())?;
-            println!(
+            info!(
                 "  {}{}",
                 path.display(),
                 if file.is_dir() { "/" } else { "" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use std::{
     ops::Deref,
     string::ToString,
 };
+use tracing::info;
 
 /// The build plan config file format to use.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -156,6 +157,8 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
     let args = Args::parse();
 
     let pkgs = args
@@ -213,12 +216,12 @@ async fn main() -> Result<()> {
                 PlanFormat::Toml => plan.to_toml()?,
             };
 
-            println!("{plan_s}");
+            info!("Generated build plan: {}", plan_s);
         }
-        // Detect which providers should be used to build a project and print them to stdout.
+        // Detect which providers should be used to build a project and print them.
         Commands::Detect { path } => {
             let providers = get_plan_providers(&path, env, &options)?;
-            println!("{}", providers.join(", "));
+            info!("Detected providers: {}", providers.join(", "));
         }
         // Generate a Dockerfile and builds a container, using any specified build options.
         Commands::Build {

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -16,6 +16,7 @@ use std::{
     process::Command,
 };
 use tempdir::TempDir;
+use tracing::info;
 use uuid::Uuid;
 
 /// Builds Docker images from options, logging to stdout if the build is successful.
@@ -67,7 +68,7 @@ impl ImageBuilder for DockerImageBuilder {
 
         // If printing the Dockerfile, don't write anything to disk
         if self.options.print_dockerfile {
-            println!("{dockerfile}");
+            info!("Dockerfile: {}", dockerfile);
             return Ok(());
         }
 
@@ -88,8 +89,8 @@ impl ImageBuilder for DockerImageBuilder {
             }
 
             self.logger.log_section("Successfully Built!");
-            println!("\nRun:");
-            println!("  docker run -it {name}");
+            info!("\nRun:");
+            info!("  docker run -it {name}");
 
             if self.options.incremental_cache_image.is_some() {
                 incremental_cache.create_image(
@@ -102,8 +103,8 @@ impl ImageBuilder for DockerImageBuilder {
                 remove_dir_all(output.root)?;
             }
         } else {
-            println!("\nSaved output to:");
-            println!("  {}", output.root.to_str().unwrap());
+            info!("\nSaved output to:");
+            info!("  {}", output.root.to_str().unwrap());
         }
 
         Ok(())

--- a/src/nixpacks/builder/docker/file_server.rs
+++ b/src/nixpacks/builder/docker/file_server.rs
@@ -11,6 +11,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::thread;
+use tracing::error;
 
 use super::incremental_cache::IncrementalCacheDirs;
 use uuid::Uuid;
@@ -48,7 +49,7 @@ impl FileServer {
         thread::spawn(move || {
             let server_future = FileServer::run_app(server_config);
             if let Err(e) = rt::System::new().block_on(server_future) {
-                println!("File server error: {e}");
+                error!("File server error: {e}");
             }
         });
 

--- a/src/nixpacks/builder/docker/incremental_cache.rs
+++ b/src/nixpacks/builder/docker/incremental_cache.rs
@@ -7,6 +7,7 @@ use std::{
 use super::{dockerfile_generation::OutputDir, file_server::FileServerConfig};
 use anyhow::{bail, Context, Result};
 use std::process::Stdio;
+use tracing::info;
 
 const INCREMENTAL_CACHE_DIR: &str = "incremental-cache";
 const INCREMENTAL_CACHE_UPLOADS_DIR: &str = "uploads";
@@ -96,7 +97,7 @@ impl IncrementalCache {
             }
         }
 
-        println!("Incremental cache image created: {}", &tag);
+        info!("Incremental cache image created: {}", &tag);
         Ok(())
     }
 

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use anyhow::{bail, Context, Ok, Result};
 use colored::Colorize;
+use tracing::warn;
 
 use super::{
     merge::Mergeable,
@@ -151,7 +152,7 @@ impl NixpacksBuildPlanGenerator<'_> {
         let provider_names = self.get_all_providers(app, env, manual_providers)?;
 
         if provider_names.len() > 1 {
-            println!(
+            warn!(
                 "{}",
                 "\n Using multiple providers is experimental\n".bright_yellow()
             );
@@ -237,7 +238,7 @@ impl NixpacksBuildPlanGenerator<'_> {
             };
 
         if plan.is_some() {
-            println!(
+            warn!(
                 "{}",
                 "\n Nixpacks file based configuration is experimental and may change\n"
                     .bright_yellow()

--- a/src/providers/node/turborepo.rs
+++ b/src/providers/node/turborepo.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, error::Error};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::{
     nixpacks::{app::App, environment::Environment},
@@ -95,7 +96,7 @@ impl Turborepo {
                     format!("{pkg_manager} --workspace {name} run start")
                 }));
             }
-            println!("Warning: Turborepo app `{name}` not found");
+            warn!("Turborepo app `{name}` not found");
         }
         if let Some(start_pipeline) = Turborepo::get_start_cmd(&turbo_cfg) {
             return Ok(Some(start_pipeline));

--- a/src/providers/php/mod.rs
+++ b/src/providers/php/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::nixpacks::{
     app::{App, StaticAssets},
@@ -191,13 +192,11 @@ impl PhpProvider {
             } else if v.contains("7.4") {
                 "7.4".to_string()
             } else {
-                println!(
-                    "Warning: PHP version {v} is not available, using PHP {DEFAULT_PHP_VERSION}"
-                );
+                warn!("PHP version {v} is not available, using PHP {DEFAULT_PHP_VERSION}");
                 DEFAULT_PHP_VERSION.to_string()
             }
         } else {
-            println!("Warning: No PHP version specified, using PHP {DEFAULT_PHP_VERSION}; see https://getcomposer.org/doc/04-schema.md#package-links for how to specify a PHP version.");
+            warn!("No PHP version specified, using PHP {DEFAULT_PHP_VERSION}; see https://getcomposer.org/doc/04-schema.md#package-links for how to specify a PHP version.");
             DEFAULT_PHP_VERSION.to_string()
         };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR tried to add a logging library for better user and developer experience. 
Only transformed all our `println!` with logging library.

Why [tracing](https://github.com/tokio-rs/tracing)? 
Rust compiler using it (https://github.com/rust-lang/rust/pull/74726). 
It gives us structured logging power, then we(also other service using nixpacks) can easily collecting and parse building logs. (expecially error logs)

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
