### PR TITLE
Fix doc build warning

### DIFF
--- a/docs/components/SideNav.tsx
+++ b/docs/components/SideNav.tsx
@@ -17,14 +17,12 @@ export const SideNav: React.FC<{ className?: string }> = ({ className }) => {
       </div>
       {/* using css fallback properties for cross-browser compatibility  */}
       {/* read more: https://modernweb.com/using-css-fallback-properties-for-better-cross-browser-compatibility/ */}
-      <style jsx>
-        {" "}
-        {`
-          .sidebar-container {
-            height: calc(100vh - var(--top-nav-height) - 4px);
-            height: calc(100dvh - var(--top-nav-height) - 4px);
-          }
-        `}
+      <style jsx> {`
+        .sidebar-container {
+          height: calc(100vh - var(--top-nav-height) - 4px);
+          height: calc(100dvh - var(--top-nav-height) - 4px);
+        }
+      `}
       </style>
     </nav>
   );

--- a/docs/components/SideNav.tsx
+++ b/docs/components/SideNav.tsx
@@ -17,12 +17,13 @@ export const SideNav: React.FC<{ className?: string }> = ({ className }) => {
       </div>
       {/* using css fallback properties for cross-browser compatibility  */}
       {/* read more: https://modernweb.com/using-css-fallback-properties-for-better-cross-browser-compatibility/ */}
-      <style jsx> {`
-        .sidebar-container {
-          height: calc(100vh - var(--top-nav-height) - 4px);
-          height: calc(100dvh - var(--top-nav-height) - 4px);
-        }
-      `}
+      <style jsx>
+        {`
+          .sidebar-container {
+            height: calc(100vh - var(--top-nav-height) - 4px);
+            height: calc(100dvh - var(--top-nav-height) - 4px);
+          }
+        `}
       </style>
     </nav>
   );

--- a/docs/components/TableOfContents.tsx
+++ b/docs/components/TableOfContents.tsx
@@ -143,14 +143,12 @@ export const TableOfContents: React.FC<{
       </div>
       {/* using css fallback properties for cross-browser compatibility  */}
       {/* read more: https://modernweb.com/using-css-fallback-properties-for-better-cross-browser-compatibility/ */}
-      <style jsx>
-        {" "}
-        {`
-          .table-container {
-            height: calc(100vh - var(--top-nav-height) - 4px);
-            height: calc(100dvh - var(--top-nav-height) - 4px);
-          }
-        `}
+      <style jsx> {`
+        .table-container {
+          height: calc(100vh - var(--top-nav-height) - 4px);
+          height: calc(100dvh - var(--top-nav-height) - 4px);
+        }
+      `}
       </style>
     </nav>
   );

--- a/docs/components/TableOfContents.tsx
+++ b/docs/components/TableOfContents.tsx
@@ -143,12 +143,13 @@ export const TableOfContents: React.FC<{
       </div>
       {/* using css fallback properties for cross-browser compatibility  */}
       {/* read more: https://modernweb.com/using-css-fallback-properties-for-better-cross-browser-compatibility/ */}
-      <style jsx> {`
-        .table-container {
-          height: calc(100vh - var(--top-nav-height) - 4px);
-          height: calc(100dvh - var(--top-nav-height) - 4px);
-        }
-      `}
+      <style jsx>
+        {`
+          .table-container {
+            height: calc(100vh - var(--top-nav-height) - 4px);
+            height: calc(100dvh - var(--top-nav-height) - 4px);
+          }
+        `}
       </style>
     </nav>
   );

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@headlessui/react": "^1.6.5",
     "@markdoc/markdoc": "^0.1.3",
-    "@markdoc/next.js": "^0.1.5",
+    "@markdoc/next.js": "^0.1.7",
     "lodash.debounce": "^4.0.8",
     "next": "^12.2.0",
     "prismjs": "^1.28.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -56,10 +56,10 @@
   resolved "https://registry.yarnpkg.com/@markdoc/markdoc/-/markdoc-0.1.3.tgz#6bcbfa536f7ad72534b7390365a5481d9f698076"
   integrity sha512-4n2cobUSeOob+237wZhpNiOEHCSfOydlQnKHTFdRY6ug/DupXGaxkkkszJYQxRftiMs8jmb10XvVO1svEYD43Q==
 
-"@markdoc/next.js@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@markdoc/next.js/-/next.js-0.1.5.tgz#360b00db57fefd0cd77e019f2081319deb9f86af"
-  integrity sha512-K+vVgXl9IC7/2qUYzI3IVi1n0pC/RIbQrOvlVj9rlOwMGcBAQimeyl4lEHU1JtdKv3/7iw5I5GVfQPE4M8WzrA==
+"@markdoc/next.js@^0.1.7":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@markdoc/next.js/-/next.js-0.1.10.tgz#9de7c271b214bf6ad6b371c520d836cebd4c3c52"
+  integrity sha512-ncxQcxDtimRT1h5Xw4VXqLY9OSrOav6hHEkfV6Vq4pKUM3QOsb/RnNo8E1rNIj9hRDH/SvQEQzggTCsQYmAr0g==
   dependencies:
     js-yaml "^4.1.0"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR fix doc building warnings:

<img width="1410" alt="Screenshot 2023-05-13 at 19 25 41" src="https://github.com/railwayapp/nixpacks/assets/11530682/e1a54418-f6d1-44e2-8740-341d700c2e57">

I am prettry sure this is a upstream issue https://github.com/markdoc/next.js/pull/15.

- [x] **I need make sure it wont break our doc webpage because I fix it by bump the `@markdoc/next` version**



<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
