### PR TITLE
add `runtime.txt` in the list of places to set the python version

### DIFF
--- a/docs/pages/docs/providers/python.md
+++ b/docs/pages/docs/providers/python.md
@@ -21,6 +21,7 @@ The version can be overridden by
 
 - Setting the `NIXPACKS_PYTHON_VERSION` environment variable
 - Setting the version in a `.python-version` file
+- Setting the version in a `runtime.txt` file
 
 ## Install
 


### PR DESCRIPTION
the python provider will use a `runtime.txt` file but the docs did not make it known
