### PR TITLE
prepend PATH with NIXPACKS_PATH

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -16,6 +16,7 @@ RUN set -o pipefail && curl -L https://nixos.org/nix/install | bash \
     && /nix/var/nix/profiles/default/bin/nix-channel --remove nixpkgs \
     && /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-old \
     && printf 'if [ -d $HOME/.nix-profile/etc/profile.d ]; then\n for i in $HOME/.nix-profile/etc/profile.d/*.sh; do\n if [ -r $i ]; then\n . $i\n fi\n done\n fi\n' >> /root/.profile
+    && printf 'PATH=$NIXPACKS_PATH:$PATH' >> /root/.profile
 
 ENV \
   ENV=/etc/profile \

--- a/base/ubuntu/Dockerfile
+++ b/base/ubuntu/Dockerfile
@@ -16,6 +16,7 @@ RUN set -o pipefail && curl -L https://nixos.org/nix/install | bash \
     && /nix/var/nix/profiles/default/bin/nix-channel --remove nixpkgs \
     && /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-old \
     && printf 'if [ -d $HOME/.nix-profile/etc/profile.d ]; then\n for i in $HOME/.nix-profile/etc/profile.d/*.sh; do\n if [ -r $i ]; then\n . $i\n fi\n done\n fi\n' >> /root/.profile
+    && printf 'PATH=$NIXPACKS_PATH:$PATH' >> /root/.profile
 
 ENV \
   ENV=/etc/profile \


### PR DESCRIPTION
Part of a fix for https://github.com/railwayapp/nixpacks/issues/872

The Nixpacks base image appends the `~/.profile` with the necessary commands to load Nix. This makes things installed via Nix available globally by setting the path to `PATH=<nix_stuff>:$PATH`. In some cases we want to prepend to the PATH. This was previously done by appending to `.profile` with something like `PATH=<new_path>:$PATH`. That was removed in https://github.com/railwayapp/nixpacks/pull/842 as a caching optimization. However, that made it impossible to prepend to the PATH variable in the Dockerfile as doing `ENV PATH=<something>:$PATH` would always get the `nix_stuff` prepended.

This PR introduces a new variable, `NIXPACKS_PATH` that will always prepend the Nix stuff. In a follow up PR I will update the writing of the PATH variable to instead set the `NIXPACKS_PATH` variable, which will fully fix 872.