### PR TITLE
Prepend PATH during phase execution

### DIFF
--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -389,7 +389,7 @@ impl DockerfileGenerator for Phase {
         // Ensure paths are available in the environment
         let build_path = if let Some(paths) = &phase.paths {
             let joined_paths = paths.join(":");
-            format!("ENV PATH {joined_paths}:$PATH")
+            format!("ENV NIXPACKS_PATH {joined_paths}:$NIXPACKS_PATH")
         } else {
             String::new()
         };


### PR DESCRIPTION
Fixes https://github.com/railwayapp/nixpacks/issues/872

Follow up to https://github.com/railwayapp/nixpacks/pull/900

This PR sets the `NIXPACKS_PATH` variable for any PATH changes that occur during the build. This will get prepended to the `PATH` variable when the commands are run.
