### PR TITLE
Use list-like flags for flags that take a list of options

### DIFF
--- a/docs/pages/docs/cli.md
+++ b/docs/pages/docs/cli.md
@@ -24,25 +24,25 @@ nixpacks build --help
 
 ### Options
 
-|                             |                                                                             |
-| :-------------------------- | :-------------------------------------------------------------------------- |
-| `--install-cmd <cmd>`, `-i` | Specify the install command                                                 |
-| `--build-cmd <cmd>`, `-b`   | Specify the build command                                                   |
-| `--start-cmd <cmd>`, `-s`   | Specify the start command                                                   |
-| `--name <name>`             | Name for the built image                                                    |
-| `--env <envs...>`           | Provide environment variables to your build.                                |
-| `--pkgs <pkgs...>`, `-p`    | Provide additional Nix packages to install in the environment               |
-| `--apt <pkgs...>`           | Provide additional apt packages to install in the environment               |
-| `--libs <libs...>`          | Provide additional Nix libraries to install in the environment              |
-| `--tag <tag...>`, `-t`      | Additional tags to add to the output image                                  |
-| `--label <labels...>`, `-l` | Additional labels to add to the output image                                |
-| `--cache-key <key>`         | Unique identifier to use for the build cache                                |
-| `--no-cache`                | Disable caching for the build                                               |
-| `--cache-from`              | Image to consider as cache sources                                          |
-| `--inline-cache`            | Enable writing cache metadata into the output image                         |
-| `--out <dir>`, `-o`         | Save output directory instead of building it with Docker                    |
-| `--platform <platforms...>` | Choosing the target platform for the target environment                     |
-| `--config <file>`           | Location of the Nixpacks configuration file relative to the root of the app |
+|                                                |                                                                             |
+| :--------------------------------------------- | :-------------------------------------------------------------------------- |
+| `--install-cmd <cmd>`, `-i`                    | Specify the install command                                                 |
+| `--build-cmd <cmd>`, `-b`                      | Specify the build command                                                   |
+| `--start-cmd <cmd>`, `-s`                      | Specify the start command                                                   |
+| `--name <name>`                                | Name for the built image                                                    |
+| `--env <env> [--env <env>...]`                 | Provide environment variables to your build.                                |
+| `--pkgs <pkg> [--pkgs <pkg>...]`, `-p`         | Provide additional Nix packages to install in the environment               |
+| `--apt <pkgs> [--apt <pkgs>...]`               | Provide additional apt packages to install in the environment               |
+| `--libs <lib> [--libs <lib>...]`               | Provide additional Nix libraries to install in the environment              |
+| `--tag <tag> [--tag <tag>...]`, `-t`           | Additional tags to add to the output image                                  |
+| `--label <labels> [--label <labels>...]`, `-l` | Additional labels to add to the output image                                |
+| `--cache-key <key>`                            | Unique identifier to use for the build cache                                |
+| `--no-cache`                                   | Disable caching for the build                                               |
+| `--cache-from`                                 | Image to consider as cache sources                                          |
+| `--inline-cache`                               | Enable writing cache metadata into the output image                         |
+| `--out <dir>`, `-o`                            | Save output directory instead of building it with Docker                    |
+| `--platform <platforms...>`                    | Choosing the target platform for the target environment                     |
+| `--config <file>`                              | Location of the Nixpacks configuration file relative to the root of the app |
 
 #### Environment Variables
 

--- a/docs/pages/docs/cli.md
+++ b/docs/pages/docs/cli.md
@@ -24,25 +24,25 @@ nixpacks build --help
 
 ### Options
 
-|                                                |                                                                             |
-| :--------------------------------------------- | :-------------------------------------------------------------------------- |
-| `--install-cmd <cmd>`, `-i`                    | Specify the install command                                                 |
-| `--build-cmd <cmd>`, `-b`                      | Specify the build command                                                   |
-| `--start-cmd <cmd>`, `-s`                      | Specify the start command                                                   |
-| `--name <name>`                                | Name for the built image                                                    |
-| `--env <env> [--env <env>...]`                 | Provide environment variables to your build.                                |
-| `--pkgs <pkg> [--pkgs <pkg>...]`, `-p`         | Provide additional Nix packages to install in the environment               |
-| `--apt <pkgs> [--apt <pkgs>...]`               | Provide additional apt packages to install in the environment               |
-| `--libs <lib> [--libs <lib>...]`               | Provide additional Nix libraries to install in the environment              |
-| `--tag <tag> [--tag <tag>...]`, `-t`           | Additional tags to add to the output image                                  |
-| `--label <labels> [--label <labels>...]`, `-l` | Additional labels to add to the output image                                |
-| `--cache-key <key>`                            | Unique identifier to use for the build cache                                |
-| `--no-cache`                                   | Disable caching for the build                                               |
-| `--cache-from`                                 | Image to consider as cache sources                                          |
-| `--inline-cache`                               | Enable writing cache metadata into the output image                         |
-| `--out <dir>`, `-o`                            | Save output directory instead of building it with Docker                    |
-| `--platform <platforms...>`                    | Choosing the target platform for the target environment                     |
-| `--config <file>`                              | Location of the Nixpacks configuration file relative to the root of the app |
+|                                                    |                                                                             |
+| :------------------------------------------------- | :-------------------------------------------------------------------------- |
+| `--install-cmd <cmd>`, `-i`                        | Specify the install command                                                 |
+| `--build-cmd <cmd>`, `-b`                          | Specify the build command                                                   |
+| `--start-cmd <cmd>`, `-s`                          | Specify the start command                                                   |
+| `--name <name>`                                    | Name for the built image                                                    |
+| `--env <env> [--env <env>...]`                     | Provide environment variables to your build.                                |
+| `--pkgs <pkg> [--pkgs <pkg>...]`, `-p`             | Provide additional Nix packages to install in the environment               |
+| `--apt <pkg> [--apt <pkg>...]`                     | Provide additional apt packages to install in the environment               |
+| `--libs <lib> [--libs <lib>...]`                   | Provide additional Nix libraries to install in the environment              |
+| `--tag <tag> [--tag <tag>...]`, `-t`               | Additional tags to add to the output image                                  |
+| `--label <label> [--label <label>...]`, `-l`       | Additional labels to add to the output image                                |
+| `--cache-key <key>`                                | Unique identifier to use for the build cache                                |
+| `--no-cache`                                       | Disable caching for the build                                               |
+| `--cache-from`                                     | Image to consider as cache sources                                          |
+| `--inline-cache`                                   | Enable writing cache metadata into the output image                         |
+| `--out <dir>`, `-o`                                | Save output directory instead of building it with Docker                    |
+| `--platform <platform> [--platform <platform>...]` | Choosing the target platform for the target environment                     |
+| `--config <file>`                                  | Location of the Nixpacks configuration file relative to the root of the app |
 
 #### Environment Variables
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ enum Commands {
 
         /// Additional labels to add to the output image
         #[arg(short, long)]
-        label: Vec<String>,
+        label: Option<Vec<String>>,
 
         /// Set target platform for your output image
         #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ enum Commands {
 
         /// Set target platform for your output image
         #[arg(long)]
-        platform: Vec<String>,
+        platform: Option<Vec<String>>,
 
         /// Unique identifier to key cache by. Defaults to the current directory
         #[arg(long)]
@@ -259,7 +259,7 @@ async fn main() -> Result<()> {
                 quiet: false,
                 cache_key,
                 no_cache,
-                platform,
+                platform: platform.unwrap_or_default(),
                 print_dockerfile: dockerfile,
                 current_dir,
                 inline_cache,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,11 +57,11 @@ struct Args {
 
     /// Provide additional apt packages to install in the environment
     #[arg(long, short, global = true)]
-    apt: Vec<String>,
+    apt: Option<Vec<String>>,
 
     /// Provide additional nix libraries to install in the environment
     #[arg(long, global = true)]
-    libs: Vec<String>,
+    libs: Option<Vec<String>>,
 
     /// Provide environment variables to your build
     #[arg(long, short, global = true)]
@@ -166,11 +166,13 @@ async fn main() -> Result<()> {
         .collect::<Vec<_>>();
 
     // CLI build plan
-    let mut cli_plan = BuildPlan::default();
-    if !args.pkgs.is_empty() || !args.libs.is_empty() || !args.apt.is_empty() {
+    let mut cli_plan: BuildPlan = BuildPlan::default();
+    let apt = args.apt.unwrap_or_default();
+    let libs: Vec<String> = args.libs.unwrap_or_default();
+    if !args.pkgs.is_empty() || !libs.is_empty() || !apt.is_empty() {
         let mut setup = Phase::setup(Some(vec![pkgs, vec![Pkg::new("...")]].concat()));
-        setup.apt_pkgs = Some(vec![args.apt, vec!["...".to_string()]].concat());
-        setup.nix_libs = Some(vec![args.libs, vec!["...".to_string()]].concat());
+        setup.apt_pkgs = Some(vec![apt, vec!["...".to_string()]].concat());
+        setup.nix_libs = Some(vec![libs, vec!["...".to_string()]].concat());
         cli_plan.add_phase(setup);
     }
     if let Some(install_cmds) = args.install_cmd {

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ enum Commands {
 
         /// Additional tags to add to the output image
         #[arg(short, long)]
-        tag: Vec<String>,
+        tag: Option<Vec<String>>,
 
         /// Additional labels to add to the output image
         #[arg(short, long)]
@@ -252,7 +252,7 @@ async fn main() -> Result<()> {
 
             let build_options = &DockerBuilderOptions {
                 name,
-                tags: tag,
+                tags: tag.unwrap_or_default(),
                 labels: label,
                 out_dir: out,
                 quiet: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ struct Args {
 
     /// Provide additional nix packages to install in the environment
     #[arg(long, short, global = true)]
-    pkgs: Vec<String>,
+    pkgs: Option<Vec<String>>,
 
     /// Provide additional apt packages to install in the environment
     #[arg(long, short, global = true)]
@@ -160,6 +160,7 @@ async fn main() -> Result<()> {
 
     let pkgs = args
         .pkgs
+        .unwrap_or_default()
         .iter()
         .map(|p| p.deref())
         .map(Pkg::new)
@@ -169,7 +170,7 @@ async fn main() -> Result<()> {
     let mut cli_plan: BuildPlan = BuildPlan::default();
     let apt = args.apt.unwrap_or_default();
     let libs: Vec<String> = args.libs.unwrap_or_default();
-    if !args.pkgs.is_empty() || !libs.is_empty() || !apt.is_empty() {
+    if !pkgs.is_empty() || !libs.is_empty() || !apt.is_empty() {
         let mut setup = Phase::setup(Some(vec![pkgs, vec![Pkg::new("...")]].concat()));
         setup.apt_pkgs = Some(vec![apt, vec!["...".to_string()]].concat());
         setup.nix_libs = Some(vec![libs, vec!["...".to_string()]].concat());

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ struct Args {
 
     /// Provide environment variables to your build
     #[arg(long, short, global = true)]
-    env: Vec<String>,
+    env: Option<Vec<String>>,
 
     /// Path to config file
     #[arg(long, short, global = true)]
@@ -200,7 +200,8 @@ async fn main() -> Result<()> {
         cli_plan
     };
 
-    let env: Vec<&str> = args.env.iter().map(|e| e.deref()).collect();
+    let env: Vec<String> = args.env.unwrap_or_default();
+    let env: Vec<&str> = env.iter().map(|e| e.deref()).collect();
     let options = GeneratePlanOptions {
         plan: Some(cli_plan),
         config_file: args.config,
@@ -241,7 +242,7 @@ async fn main() -> Result<()> {
             no_error_without_start,
             verbose,
         } => {
-            let verbose = verbose || args.env.contains(&"NIXPACKS_VERBOSE=1".to_string());
+            let verbose = verbose || env.contains(&"NIXPACKS_VERBOSE=1");
 
             // Default to absolute `path` of the source that is being built as the cache-key if not disabled
             let cache_key = if !no_cache && cache_key.is_none() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ async fn main() -> Result<()> {
 
     // CLI build plan
     let mut cli_plan: BuildPlan = BuildPlan::default();
-    let apt = args.apt.unwrap_or_default();
+    let apt: Vec<String> = args.apt.unwrap_or_default();
     let libs: Vec<String> = args.libs.unwrap_or_default();
     if !pkgs.is_empty() || !libs.is_empty() || !apt.is_empty() {
         let mut setup = Phase::setup(Some(vec![pkgs, vec![Pkg::new("...")]].concat()));

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -172,8 +172,10 @@ impl DockerImageBuilder {
         for t in self.options.tags.clone() {
             docker_build_cmd.arg("-t").arg(t);
         }
-        for l in self.options.labels.clone() {
-            docker_build_cmd.arg("--label").arg(l);
+        if let Some(l) = self.options.labels.clone() {
+            for label in l {
+                docker_build_cmd.arg("--label").arg(label);
+            }
         }
         for l in self.options.platform.clone() {
             docker_build_cmd.arg("--platform").arg(l);

--- a/src/nixpacks/builder/docker/mod.rs
+++ b/src/nixpacks/builder/docker/mod.rs
@@ -8,7 +8,7 @@ pub struct DockerBuilderOptions {
     pub out_dir: Option<String>,
     pub print_dockerfile: bool,
     pub tags: Vec<String>,
-    pub labels: Vec<String>,
+    pub labels: Option<Vec<String>>,
     pub quiet: bool,
     pub cache_key: Option<String>,
     pub no_cache: bool,


### PR DESCRIPTION
This PR migrates the existing flags that use a list of values for a single flag (`--flag value1 value2`) to a more common format of list of flags (`--flag value1 --flag value2`). This allows folks to more seamlessly switch from other CLI tools like `docker` or `pack`. 

<!-- PR Checklist  -->
- [ ] Tests are added/updated if needed
- [x] Docs are updated if needed 
