### PR TITLE
chore: update nixpacks and add go 1.19/1.20 support

### DIFF
--- a/docs/pages/docs/providers/go.md
+++ b/docs/pages/docs/providers/go.md
@@ -16,6 +16,8 @@ The following Go version are available
 
 - `1.17` (Default)
 - `1.18`
+- `1.19`
+- `1.20`
 
 The version is parsed from the `go.mod` file.
 

--- a/examples/go-custom-version/go.mod
+++ b/examples/go-custom-version/go.mod
@@ -1,3 +1,3 @@
 module versiontest
 
-go 1.18
+go 1.20

--- a/src/nixpacks/nix/mod.rs
+++ b/src/nixpacks/nix/mod.rs
@@ -6,9 +6,9 @@ use crate::nixpacks::plan::phase::{Phase, Phases};
 pub mod pkg;
 
 // This line is automatically updated.
-// Last Modified: 2023-01-02 17:04:24 UTC+0000
-// https://github.com/NixOS/nixpkgs/commit/293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847
-pub const NIXPKGS_ARCHIVE: &str = "293a28df6d7ff3dec1e61e37cc4ee6e6c0fb0847";
+// Last Modified: 2023-06-17 19:28:17 UTC+0000
+// https://github.com/NixOS/nixpkgs/commit/835cf967865765fc31a5d15425c2a503068655fd
+pub const NIXPKGS_ARCHIVE: &str = "835cf967865765fc31a5d15425c2a503068655fd";
 
 // Version of the Nix archive that uses OpenSSL 1.1
 pub const NIXPACKS_ARCHIVE_LEGACY_OPENSSL: &str = "a0b7e70db7a55088d3de0cc370a59f9fbcc906c3";

--- a/src/providers/go.rs
+++ b/src/providers/go.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 pub struct GolangProvider {}
 
 const BINARY_NAME: &str = "out";
-const AVAILABLE_GO_VERSIONS: &[(&str, &str)] = &[("1.17", "go"), ("1.18", "go_1_18")];
+const AVAILABLE_GO_VERSIONS: &[(&str, &str)] = &[("1.17", "go"), ("1.18", "go_1_18"), ("1.19", "go_1_19"), ("1.20", "go_1_20")];
 const DEFAULT_GO_PKG_NAME: &str = "go";
 
 const GO_BUILD_CACHE_DIR: &str = "/root/.cache/go-build";


### PR DESCRIPTION
This PR updates the nixpacks commit hash and updates the Go provider with 1.19 and 1.20.

I followed https://github.com/railwayapp/nixpacks/pull/747 to update the commit hash. It seems like the bot is broken and hasn't updated in 6 months. 

I updated the custom version in the custom go version example and confirmed that it built correctly.
