### PR TITLE
Document Python detection via Pipfile

### DIFF
--- a/docs/pages/docs/providers/python.md
+++ b/docs/pages/docs/providers/python.md
@@ -4,7 +4,12 @@ title: Python
 
 # {% $markdoc.frontmatter.title %}
 
-Python is detected if a `main.py` OR `requirements.txt` OR `pyproject.toml` file is found.
+Python is detected if any of the following files are found
+
+- `main.py`
+- `requirements.txt`
+- `pyproject.toml`
+- `Pipfile`
 
 ## Setup
 


### PR DESCRIPTION
This PR updates the docs to mention that Python is detected when a `Pipfile` is found. Pipfile behavior is already documented for setup but is absent from the introduction.