### PR TITLE
ref(deno): Add support for deno.jsonc and index.{tsx,jsx}

### DIFF
--- a/docs/pages/docs/providers/deno.md
+++ b/docs/pages/docs/providers/deno.md
@@ -4,7 +4,7 @@ title: Deno
 
 # {% $markdoc.frontmatter.title %}
 
-Deno is detected if there is a `deno.json` file found or if any `.(j|t)s` file is found that imports something from [deno.land](https://deno.land).
+Deno is detected if there is a `deno.{json,jsonc}` file found or if any `.{ts,tsx,js,jsx}` file is found that imports something from [deno.land](https://deno.land).
 
 Apps built with [Deno Fresh](https://fresh.deno.dev/) should work out of the box.
 
@@ -14,18 +14,18 @@ _None_
 
 ## Build
 
-The deno provider will compile all the project with `deno compile`.
+The deno provider will compile all the projects with `deno compile`.
 
 ## Start
 
-If a `start` task is found in `deno.json` then
+If a `start` task is found in `deno.{json,jsonc}` then:
 
 ```
 deno task start
 ```
 
-Otherwise
+Otherwise, the first file matching `index.{ts,tsx,js,jsx}` pattern, eg.:
 
 ```
-deno run --allow-all index.j|ts
+deno run --allow-all index.ts
 ```

--- a/tests/snapshots/generate_plan_tests__deno_fresh.snap
+++ b/tests/snapshots/generate_plan_tests__deno_fresh.snap
@@ -9,6 +9,16 @@ expression: plan
     "NIXPACKS_METADATA": "deno"
   },
   "phases": {
+    "build": {
+      "name": "build",
+      "dependsOn": [
+        "install",
+        "setup"
+      ],
+      "cmds": [
+        "deno cache routes/index.tsx"
+      ]
+    },
     "setup": {
       "name": "setup",
       "nixPkgs": [


### PR DESCRIPTION
This PR adds support for `deno.jsonc` to be used as the entry point for `deno task`, as it was already used for detecting whether a project is Deno in the first place.  And it does the same for running the default `index` file, by adding `jsx` and `tsx` to the list of checked extensions.

PR Checklist
- [x] Tests are added/updated if needed
- [x] Docs are updated if needed
