### PR TITLE
Rails: detect usage of sprockets/propshaft in lockfile, not just gemfile

### DIFF
--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -296,7 +296,6 @@ impl RubyProvider {
 
     fn uses_asset_pipeline(&self, app: &App) -> Result<bool> {
         if app.includes_file("Gemfile") {
-            let gemfile = app.read_file("Gemfile").unwrap_or_default();
             return Ok(self.uses_gem_dep(app, "sprockets") || self.uses_gem_dep(app, "propshaft"));
         }
         Ok(false)

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -297,7 +297,7 @@ impl RubyProvider {
     fn uses_asset_pipeline(&self, app: &App) -> Result<bool> {
         if app.includes_file("Gemfile") {
             let gemfile = app.read_file("Gemfile").unwrap_or_default();
-            return Ok(gemfile.contains("sprockets") || gemfile.contains("propshaft"));
+            return Ok(self.uses_gem_dep(app, "sprockets") || self.uses_gem_dep(app, "propshaft"));
         }
         Ok(false)
     }


### PR DESCRIPTION
In [Rails 6.1](https://rubygems.org/gems/rails/versions/6.1.7.3) and below, sprockets is an implicit dependency and may not be listed in the `Gemfile` (only in the `Gemfile.lock` lockfile).

This means that Railway fails to run `rake assets:precompile` when it otherwise should.

This change also allows for apps which include _other_ implicit dependencies on sprockets or propshaft, which would fix cases where someone pulls in asset pipeline assets via a [Rails engine](https://guides.rubyonrails.org/engines.html), which is common in Admin gems (e.g. `activeadmin`).