### PR TITLE
Fix deb release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,15 +138,15 @@ jobs:
         files: nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.target }}*
 
     - name: Install cargo-deb
-      if: matrix.target == 'x86_64-unknown-linux-musl'
+      if: matrix.target == 'x86_64-unknown-linux-gnu'
       run: cargo install cargo-deb
 
     - name: Generate .deb package file
-      if: matrix.target == 'x86_64-unknown-linux-musl'
-      run: cargo deb --target x86_64-unknown-linux-musl --output nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-amd64.deb
+      if: matrix.target == 'x86_64-unknown-linux-gnu'
+      run: cargo deb --target ${{ matrix.target }} --output nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-amd64.deb
 
     - name: Upload .deb package file
-      if: matrix.target == 'x86_64-unknown-linux-musl'
+      if: matrix.target == 'x86_64-unknown-linux-gnu'
       uses: svenstaro/upload-release-action@v2
       with:
         tag: ${{ needs.create-release.outputs.nixpacks_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
         formula-name: nixpacks
         formula-path: nixpacks.rb
         homebrew-tap: railwayapp/homebrew-tap
-        download-url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}/download/nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-x86_64-apple-darwin.tar.gz
+        download-url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.create-release.outputs.nixpacks_version }}/download/nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-x86_64-apple-darwin.tar.gz
       env:
         COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 
@@ -189,4 +189,4 @@ jobs:
           avatar_url: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
           title: Published version ${{ needs.create-release.outputs.nixpacks_version }} of Nixpacks
           description: |
-            [View Changelog](https://github.com/railwayapp/nixpacks/releases/tag/${{ needs.create-release.outputs.nixpacks_version }})
+            [View Changelog](${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.create-release.outputs.nixpacks_version }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
         formula-name: nixpacks
         formula-path: nixpacks.rb
         homebrew-tap: railwayapp/homebrew-tap
-        download-url: https://github.com/railwayapp/nixpacks/releases/latest/download/nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-x86_64-apple-darwin.tar.gz
+        download-url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}/download/nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-x86_64-apple-darwin.tar.gz
       env:
         COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   create-release:
     name: Create Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     outputs:
       nixpacks_version: ${{ env.NIXPACKS_VERSION }}
@@ -49,6 +51,8 @@ jobs:
 
   build-release:
     name: Build Release Assets
+    permissions:
+      contents: write
     needs: ['create-release']
     runs-on: ${{ matrix.os }}
     continue-on-error: true


### PR DESCRIPTION
This PR fixes the .deb creation pipeline, as Debian and Ubuntu prefer non-musl compilations.

There is also minor tweaking for hard coded values to accomodate this and working on forks.

You may check out:
 - my action outputs: https://github.com/PeterHeja/nixpacks/actions
 - my test v0.1.101 release on my fork: https://github.com/PeterHeja/nixpacks/releases

PR Checklist
 - [x] Tests are added/updated if needed - not needed
 - [x] Docs are updated if needed  - not needed, but .deb install will work as advertised in docs

Caveat:
 - discord notification still broken on fork (maybe gate it via `if: github.event.pull_request.head.repo.fork`?)
 - homebrew-tap update still broken on fork (maybe gate this as well?)