### PR TITLE
Fix apt-get glibc error

### DIFF
--- a/examples/apt-ffmpeg/nixpacks.toml
+++ b/examples/apt-ffmpeg/nixpacks.toml
@@ -1,0 +1,14 @@
+[phases.setup]
+aptPkgs = [
+  "...",
+  "ffmpeg",
+  "imagemagick",
+  "ghostscript",
+  "gsfonts",
+  "fonts-droid-fallback",
+  "fonts-noto-mono",
+  "fonts-urw-base35",
+]
+
+[start]
+cmd = "ffmpeg 2>&1"

--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -135,7 +135,7 @@ impl DockerfileGenerator for BuildPlan {
             String::new()
         } else {
             format!(
-                "RUN apt-get update && apt-get install -y --no-install-recommends {}",
+                "RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends {}",
                 apt_pkgs.join(" ")
             )
         };

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -1171,6 +1171,5 @@ async fn test_nested_directory() {
 async fn test_ffmpeg() {
     let name = simple_build("./examples/apt-ffmpeg").await;
     let output = run_image(&name, None).await;
-    println!("OUTPUT: {}", output);
     assert!(output.contains("ffmpeg version"));
 }

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -1166,3 +1166,11 @@ async fn test_nested_directory() {
     let name = simple_build("./examples/nested").await;
     assert!(run_image(&name, None).await.contains("Nested directories!"));
 }
+
+#[tokio::test]
+async fn test_ffmpeg() {
+    let name = simple_build("./examples/apt-ffmpeg").await;
+    let output = run_image(&name, None).await;
+    println!("OUTPUT: {}", output);
+    assert!(output.contains("ffmpeg version"));
+}

--- a/tests/snapshots/generate_plan_tests__apt_ffmpeg.snap
+++ b/tests/snapshots/generate_plan_tests__apt_ffmpeg.snap
@@ -1,0 +1,25 @@
+---
+source: tests/generate_plan_tests.rs
+expression: plan
+---
+{
+  "providers": [],
+  "buildImage": "[build_image]",
+  "phases": {
+    "setup": {
+      "name": "setup",
+      "aptPkgs": [
+        "ffmpeg",
+        "imagemagick",
+        "ghostscript",
+        "gsfonts",
+        "fonts-droid-fallback",
+        "fonts-noto-mono",
+        "fonts-urw-base35"
+      ]
+    }
+  },
+  "start": {
+    "cmd": "ffmpeg 2>&1"
+  }
+}


### PR DESCRIPTION
This PR fixes the "Missing Glibc 2.36" error when running anything with `apt-get`. The problem is that The `LIBRARY_PATH` header was set to `~/.nix-profile` which includes packages built with glibc 2.36+. `apt-get` is built with glibc 2.35 since that is the default in Ubuntu. The problem is easily fixed by installing apt packages with `sudo` so that a different `LIBRARY_PATH` is used.

I've added an example that installs ffmpeg and a bunch of other stuff so we can catch this in the future.

Fixes https://github.com/railwayapp/nixpacks/issues/977
