### PR TITLE
This manifest requires workspace inheritance

### DIFF
--- a/examples/rust-cargo-workspaces/Cargo.toml
+++ b/examples/rust-cargo-workspaces/Cargo.toml
@@ -3,3 +3,7 @@ members = [
     "binary",
     "library"
 ]
+
+[workspace.dependencies]
+http = "0.2.9"
+

--- a/examples/rust-cargo-workspaces/binary/Cargo.toml
+++ b/examples/rust-cargo-workspaces/binary/Cargo.toml
@@ -5,5 +5,8 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[dependencies]
+http = { workspace = true }
+
 [dependencies.library]
 path = "../library"


### PR DESCRIPTION
This PR shows how to recreate "Error: This manifest requires workspace inheritance, but `inherit_workspace` hasn't been called yet"
