### PR TITLE
update homebrew installation command

### DIFF
--- a/docs/pages/docs/install.md
+++ b/docs/pages/docs/install.md
@@ -9,7 +9,7 @@ title: Installation
 Install Nixpacks with [Homebrew](https://brew.sh/) (macOS Only)
 
 ```sh
-brew install railwayapp/tap/nixpacks
+brew install nixpacks
 ```
 
 ## MacPorts


### PR DESCRIPTION
Installation ([on current docs](https://nixpacks.com/docs/getting-started#install)) of `railwayapp/tap/nixpacks` will cause this error on apple silicon:
```
nixpacks: Bad CPU type in executable
```

Updated the docs to the correct brew recipe.

View #923 #941 