### PR TITLE
Update Node and Bun versions

### DIFF
--- a/examples/node-custom-version/package.json
+++ b/examples/node-custom-version/package.json
@@ -6,6 +6,6 @@
     "start": "./start.sh"
   },
   "engines": {
-    "node": "20.x"
+    "node": "21.x"
   }
 }

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -23,8 +23,10 @@ mod turborepo;
 
 pub const NODE_OVERLAY: &str = "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz";
 
+const NODE_NIXPKGS_ARCHIVE: &str = "bf744fe90419885eefced41b3e5ae442d732712d";
+
 const DEFAULT_NODE_VERSION: u32 = 18;
-const AVAILABLE_NODE_VERSIONS: &[u32] = &[14, 16, 18, 20];
+const AVAILABLE_NODE_VERSIONS: &[u32] = &[14, 16, 18, 20, 21];
 
 const YARN_CACHE_DIR: &str = "/usr/local/share/.cache/yarn/v6";
 const PNPM_CACHE_DIR: &str = "/root/.local/share/pnpm/store/v3";
@@ -110,6 +112,7 @@ impl Provider for NodeProvider {
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<Option<BuildPlan>> {
         // Setup
         let mut setup = Phase::setup(Some(NodeProvider::get_nix_packages(app, env)?));
+        setup.set_nix_archive(NODE_NIXPKGS_ARCHIVE.into());
 
         if NodeProvider::uses_node_dependency(app, "prisma") {
             setup.add_nix_pkgs(&[Pkg::new("openssl")]);

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -437,7 +437,7 @@ async fn test_node_nx_express() {
 async fn test_node_custom_version() {
     let name = simple_build("./examples/node-custom-version").await;
     let output = run_image(&name, None).await;
-    assert!(output.contains("Node version: v20"));
+    assert!(output.contains("Node version: v21"));
 }
 
 #[tokio::test]

--- a/tests/snapshots/generate_plan_tests__node_custom_version.snap
+++ b/tests/snapshots/generate_plan_tests__node_custom_version.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_20",
+        "nodejs_21",
         "npm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_pnpm_custom_node_version.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_custom_node_version.snap
@@ -42,7 +42,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_20",
+        "nodejs_21",
         "pnpm-8_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_turborepo.snap
+++ b/tests/snapshots/generate_plan_tests__node_turborepo.snap
@@ -44,7 +44,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_20",
+        "nodejs_21",
         "npm-8_x"
       ],
       "nixOverlays": [


### PR DESCRIPTION
- Update the Nix archive used for Node and Bun
  + Updates latest Bun version to 1.0.11
  + Enabled using Node 20 and 21
  + Default version of Node is still 18
