### PR TITLE
Fix Node 14 usage

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -112,7 +112,18 @@ impl Provider for NodeProvider {
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<Option<BuildPlan>> {
         // Setup
         let mut setup = Phase::setup(Some(NodeProvider::get_nix_packages(app, env)?));
-        setup.set_nix_archive(NODE_NIXPKGS_ARCHIVE.into());
+
+        if setup
+            .clone()
+            .nix_pkgs
+            .unwrap_or_default()
+            .iter()
+            .find(|p| p.contains("14"))
+            .is_none()
+        {
+            // Only use the latest archive version of Node > 14
+            setup.set_nix_archive(NODE_NIXPKGS_ARCHIVE.into());
+        }
 
         if NodeProvider::uses_node_dependency(app, "prisma") {
             setup.add_nix_pkgs(&[Pkg::new("openssl")]);


### PR DESCRIPTION
Only use the latest Nix archive version for Node != 14
