### PR TITLE
add openssl lib when using prisma

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -116,6 +116,7 @@ impl Provider for NodeProvider {
 
         if NodeProvider::uses_node_dependency(app, "prisma") {
             setup.add_nix_pkgs(&[Pkg::new("openssl")]);
+            setup.add_pkgs_libs(vec!["openssl".into()]);
         }
 
         if NodeProvider::uses_node_dependency(app, "puppeteer") {

--- a/tests/snapshots/generate_plan_tests__node_bun_prisma.snap
+++ b/tests/snapshots/generate_plan_tests__node_bun_prisma.snap
@@ -46,6 +46,9 @@ expression: plan
         "bun",
         "openssl"
       ],
+      "nixLibs": [
+        "openssl"
+      ],
       "nixOverlays": [
         "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
       ],

--- a/tests/snapshots/generate_plan_tests__node_legacy_prisma.snap
+++ b/tests/snapshots/generate_plan_tests__node_legacy_prisma.snap
@@ -47,6 +47,9 @@ expression: plan
         "yarn-1_x",
         "openssl"
       ],
+      "nixLibs": [
+        "openssl"
+      ],
       "nixOverlays": [
         "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
       ],

--- a/tests/snapshots/generate_plan_tests__node_prisma_postgres.snap
+++ b/tests/snapshots/generate_plan_tests__node_prisma_postgres.snap
@@ -46,6 +46,9 @@ expression: plan
         "npm-6_x",
         "openssl"
       ],
+      "nixLibs": [
+        "openssl"
+      ],
       "nixOverlays": [
         "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
       ],

--- a/tests/snapshots/generate_plan_tests__node_prisma_postgres_npm_v9.snap
+++ b/tests/snapshots/generate_plan_tests__node_prisma_postgres_npm_v9.snap
@@ -46,6 +46,9 @@ expression: plan
         "npm-9_x",
         "openssl"
       ],
+      "nixLibs": [
+        "openssl"
+      ],
       "nixOverlays": [
         "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
       ],

--- a/tests/snapshots/generate_plan_tests__node_yarn_prisma.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn_prisma.snap
@@ -46,6 +46,9 @@ expression: plan
         "yarn-1_x",
         "openssl"
       ],
+      "nixLibs": [
+        "openssl"
+      ],
       "nixOverlays": [
         "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
       ],


### PR DESCRIPTION
Fix prisma errors related to missing libssl library
