### PR TITLE
Add support for Java 20/21 in Java & Scala Providers

### DIFF
--- a/docs/pages/docs/providers/java.md
+++ b/docs/pages/docs/providers/java.md
@@ -12,6 +12,8 @@ Java is detected if a `pom.[xml|atom|clj|groovy|rb|scala|yaml|yml]` or `gradlew`
 
 The following major JDK versions are available
 
+- `21`
+- `20`
 - `19`
 - `17` (Default)
 - `11`

--- a/docs/pages/docs/providers/scala.md
+++ b/docs/pages/docs/providers/scala.md
@@ -13,6 +13,8 @@ at Java. Scala is detected by `build.sbt` in project root.
 
 The following major JDK versions are available
 
+- `21`
+- `20`
 - `19`
 - `17` (Default)
 - `11`

--- a/src/providers/java.rs
+++ b/src/providers/java.rs
@@ -169,6 +169,8 @@ impl JavaProvider {
 
     fn get_jdk_pkg(&self, jdk_version: u32) -> Result<Pkg> {
         let pkg = match jdk_version {
+            21 => Pkg::new("jdk21"),
+            20 => Pkg::new("jdk20"),
             19 => Pkg::new("jdk"),
             17 => Pkg::new("jdk17"),
             11 => Pkg::new("jdk11"),
@@ -349,6 +351,42 @@ mod tests {
                 java.get_jdk_version(
                     &App::new("examples/java-gradle-hello-world").unwrap(),
                     &Environment::from_envs(vec!["NIXPACKS_JDK_VERSION=8"]).unwrap(),
+                )
+                .unwrap()
+            )
+            .unwrap()
+        );
+
+        assert_eq!(
+            Pkg::new("jdk21"),
+            java.get_jdk_pkg(
+                java.get_jdk_version(
+                    &App::new("examples/java-gradle-hello-world").unwrap(),
+                    &Environment::from_envs(vec!["NIXPACKS_JDK_VERSION=21"]).unwrap(),
+                )
+                .unwrap()
+            )
+            .unwrap()
+        );
+
+        assert_eq!(
+            Pkg::new("jdk20"),
+            java.get_jdk_pkg(
+                java.get_jdk_version(
+                    &App::new("examples/java-gradle-hello-world").unwrap(),
+                    &Environment::from_envs(vec!["NIXPACKS_JDK_VERSION=20"]).unwrap(),
+                )
+                .unwrap()
+            )
+            .unwrap()
+        );
+
+        assert_eq!(
+            Pkg::new("jdk"),
+            java.get_jdk_pkg(
+                java.get_jdk_version(
+                    &App::new("examples/java-gradle-hello-world").unwrap(),
+                    &Environment::from_envs(vec!["NIXPACKS_JDK_VERSION=19"]).unwrap(),
                 )
                 .unwrap()
             )

--- a/src/providers/java.rs
+++ b/src/providers/java.rs
@@ -15,7 +15,7 @@ pub struct JavaProvider {}
 
 const DEFAULT_JDK_VERSION: u32 = 17;
 const DEFAULT_GRADLE_VERSION: u32 = 7;
-const GRADLE_NIXPKGS_ARCHIVE: &str = "2f9286912cb215969ece465147badf6d07aa43fe";
+const JAVA_NIXPKGS_ARCHIVE: &str = "59dc10b5a6f2a592af36375c68fda41246794b86";
 
 impl Provider for JavaProvider {
     fn name(&self) -> &str {
@@ -38,7 +38,7 @@ impl Provider for JavaProvider {
         let (setup, build) = if self.is_using_gradle(app) {
             let pkgs = self.get_jdk_and_gradle_pkgs(app, env)?;
             let mut setup = Phase::setup(Some(pkgs));
-            setup.set_nix_archive(GRADLE_NIXPKGS_ARCHIVE.to_string());
+            setup.set_nix_archive(JAVA_NIXPKGS_ARCHIVE.to_string());
 
             let mut build = Phase::build(None);
             let gradle_exe = self.get_gradle_exe(app);
@@ -57,7 +57,8 @@ impl Provider for JavaProvider {
             let jdk_version = self.get_jdk_version(app, env)?;
             let jdk_pkg = self.get_jdk_pkg(jdk_version)?;
 
-            let setup = Phase::setup(Some(vec![jdk_pkg, Pkg::new("maven")]));
+            let mut setup = Phase::setup(Some(vec![jdk_pkg, Pkg::new("maven")]));
+            setup.set_nix_archive(JAVA_NIXPKGS_ARCHIVE.to_string());
 
             let mvn_exe = self.get_maven_exe(app);
             let mut build = Phase::build(Some(format!("{mvn_exe} -DoutputFile=target/mvn-dependency-list.log -B -DskipTests clean dependency:list install"

--- a/src/providers/scala.rs
+++ b/src/providers/scala.rs
@@ -134,31 +134,24 @@ mod tests {
         // defaults to Java 17
         assert_eq!(
             "jdk17",
-             scala.get_jdk_pkg_name(
-                 scala.get_jdk_version(
-                     &Environment::from_envs(vec![]).unwrap(),
-                )
-             )
+            scala
+                .get_jdk_pkg_name(scala.get_jdk_version(&Environment::from_envs(vec![]).unwrap(),))
         );
 
         // Supports Java 20
         assert_eq!(
             "jdk20",
-             scala.get_jdk_pkg_name(
-                 scala.get_jdk_version(
-                     &Environment::from_envs(vec!["NIXPACKS_JDK_VERSION=20"]).unwrap(),
-                )
-             )
+            scala.get_jdk_pkg_name(scala.get_jdk_version(
+                &Environment::from_envs(vec!["NIXPACKS_JDK_VERSION=20"]).unwrap(),
+            ))
         );
 
         // Supports Java 21
         assert_eq!(
             "jdk21",
-             scala.get_jdk_pkg_name(
-                 scala.get_jdk_version(
-                     &Environment::from_envs(vec!["NIXPACKS_JDK_VERSION=21"]).unwrap(),
-                )
-             )
+            scala.get_jdk_pkg_name(scala.get_jdk_version(
+                &Environment::from_envs(vec!["NIXPACKS_JDK_VERSION=21"]).unwrap(),
+            ))
         );
     }
 

--- a/src/providers/scala.rs
+++ b/src/providers/scala.rs
@@ -78,6 +78,8 @@ impl ScalaProvider {
 
     fn get_jdk_pkg_name(&self, jdk_version: u32) -> &str {
         match jdk_version {
+            21 => "jdk21",
+            20 => "jdk20",
             19 => "jdk",
             11 => "jdk11",
             8 => "jdk8",
@@ -89,12 +91,14 @@ impl ScalaProvider {
 
     fn get_jdk_run_image(&self, jdk_version: u32) -> &str {
         match jdk_version {
+            21 => "eclipse-temurim:21.0.1_12-jre-jammy",
+            20 => "eclipse-temurim:20.0.2_9-jre-jammy",
             19 => "eclipse-temurin:19.0.2_7-jre-jammy",
-            11 => "eclipse-temurin:11.0.18_10-jre-jammy",
-            8 => "eclipse-temurin:8u362-b09-jre-jammy",
+            11 => "eclipse-temurin:11.0.21_9-jre-jammy",
+            8 => "eclipse-temurin:8u392-b08-jre-jammy",
 
             // Using 17 as default because its the latest LTS
-            _ => "eclipse-temurin:17.0.5_8-jre-jammy",
+            _ => "eclipse-temurin:17.0.9_9-jre-jammy",
         }
     }
 
@@ -122,6 +126,41 @@ impl ScalaProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_get_jdk_pkg_name() {
+        let scala = ScalaProvider {};
+
+        // defaults to Java 17
+        assert_eq!(
+            "jdk17",
+             scala.get_jdk_pkg_name(
+                 scala.get_jdk_version(
+                     &Environment::from_envs(vec![]).unwrap(),
+                )
+             )
+        );
+
+        // Supports Java 20
+        assert_eq!(
+            "jdk20",
+             scala.get_jdk_pkg_name(
+                 scala.get_jdk_version(
+                     &Environment::from_envs(vec!["NIXPACKS_JDK_VERSION=20"]).unwrap(),
+                )
+             )
+        );
+
+        // Supports Java 21
+        assert_eq!(
+            "jdk21",
+             scala.get_jdk_pkg_name(
+                 scala.get_jdk_version(
+                     &Environment::from_envs(vec!["NIXPACKS_JDK_VERSION=21"]).unwrap(),
+                )
+             )
+        );
+    }
 
     #[test]
     fn test_sbt_package() {

--- a/tests/snapshots/generate_plan_tests__scala_sbt.snap
+++ b/tests/snapshots/generate_plan_tests__scala_sbt.snap
@@ -35,7 +35,7 @@ expression: plan
   },
   "start": {
     "cmd": "./target/universal/stage/bin/main",
-    "runImage": "eclipse-temurin:17.0.5_8-jre-jammy",
+    "runImage": "eclipse-temurin:17.0.9_9-jre-jammy",
     "onlyIncludeFiles": [
       "./target/universal"
     ]


### PR DESCRIPTION
## What?

This PR adds Java 20 and 21 support in Java and Scala providers.

Specifically for Scala, it also updates the Eclipse Temurin images to the latest
versions.

- [x] Tests are added/updated if needed
- [x] Docs are updated if needed
