### PR TITLE
Make Gradle 8 the default version

### DIFF
--- a/docs/pages/docs/providers/java.md
+++ b/docs/pages/docs/providers/java.md
@@ -25,8 +25,8 @@ The version can be overridden by setting the `NIXPACKS_JDK_VERSION` environment 
 
 The following major Gradle versions are available
 
-- `8`
-- `7` (Default)
+- `8` (Default)
+- `7`
 - `6`
 - `5`
 - `4`

--- a/src/providers/crystal.rs
+++ b/src/providers/crystal.rs
@@ -40,7 +40,8 @@ impl Provider for CrystalProvider {
         let target_names = config.targets.keys().cloned().collect::<Vec<_>>();
         let start = StartPhase::new(format!(
             "./bin/{}",
-            target_names.first()
+            target_names
+                .first()
                 .ok_or_else(|| anyhow::anyhow!("Unable to get executable name"))?
         ));
 

--- a/src/providers/crystal.rs
+++ b/src/providers/crystal.rs
@@ -40,8 +40,7 @@ impl Provider for CrystalProvider {
         let target_names = config.targets.keys().cloned().collect::<Vec<_>>();
         let start = StartPhase::new(format!(
             "./bin/{}",
-            target_names
-                .get(0)
+            target_names.first()
                 .ok_or_else(|| anyhow::anyhow!("Unable to get executable name"))?
         ));
 

--- a/src/providers/haskell.rs
+++ b/src/providers/haskell.rs
@@ -61,7 +61,8 @@ impl Provider for HaskellStackProvider {
         let package: HaskellStackPackageYaml = app.read_yaml("package.yaml")?;
         let exe_names: Vec<String> = package.executables.keys().cloned().collect();
 
-        let name = exe_names.first()
+        let name = exe_names
+            .first()
             .ok_or_else(|| anyhow::anyhow!("Failed to get executable name"))?;
 
         let start = StartPhase::new(format!("/root/.local/bin/{name}"));

--- a/src/providers/haskell.rs
+++ b/src/providers/haskell.rs
@@ -61,8 +61,7 @@ impl Provider for HaskellStackProvider {
         let package: HaskellStackPackageYaml = app.read_yaml("package.yaml")?;
         let exe_names: Vec<String> = package.executables.keys().cloned().collect();
 
-        let name = exe_names
-            .get(0)
+        let name = exe_names.first()
             .ok_or_else(|| anyhow::anyhow!("Failed to get executable name"))?;
 
         let start = StartPhase::new(format!("/root/.local/bin/{name}"));

--- a/src/providers/java.rs
+++ b/src/providers/java.rs
@@ -14,7 +14,7 @@ use regex::Regex;
 pub struct JavaProvider {}
 
 const DEFAULT_JDK_VERSION: u32 = 17;
-const DEFAULT_GRADLE_VERSION: u32 = 7;
+const DEFAULT_GRADLE_VERSION: u32 = 8;
 const JAVA_NIXPKGS_ARCHIVE: &str = "59dc10b5a6f2a592af36375c68fda41246794b86";
 
 impl Provider for JavaProvider {

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -386,11 +386,11 @@ impl PythonProvider {
         let module_name = chain!(project.project.clone() =>
             (
                 |proj| proj.packages,
-                |pkgs| pkgs.get(0).cloned()
+                |pkgs| pkgs.first().cloned()
             );
             (
                 |proj| proj.py_modules,
-                |mods| mods.get(0).cloned()
+                |mods| mods.first().cloned()
             );
             (
                 |_| project_name.clone()


### PR DESCRIPTION
## What?

This PR makes Gradle 8 the default version. The first release for Gradle 8 was made on Feb 13, 2023, so it should be safe to make it default (coming from version 7).

- [x] Tests are added/updated if needed
- [x] Docs are updated if needed
