### PR TITLE
feat: add asdf support to python + poetry

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -321,6 +321,9 @@ impl PythonProvider {
         } else if app.includes_file("Pipfile") {
             let file_content = &app.read_file("Pipfile")?;
             custom_version = PythonProvider::parse_pipfile_python_version(file_content)?;
+        } else if app.includes_file(".tool-versions") {
+            let file_content = &app.read_file(".tool-versions")?;
+            custom_version = PythonProvider::parse_asdf_python_version(file_content)?;
         }
 
         // If it's still none, return default


### PR DESCRIPTION
This PR is not complete! I wanted to get your thoughts on it before putting anymore work into it.

The idea here is to support asdf/.tool-versions for specifying python + poetry versions. This could then
be extended to support node, go, etc in the future but my initial use case is scoped to python.

Interest in this feature being added? If so I can finish implementation + add tests.
