### PR TITLE
docs: indicate that curl can be used on all platforms

### DIFF
--- a/docs/pages/docs/install.md
+++ b/docs/pages/docs/install.md
@@ -28,6 +28,8 @@ Download Nixpacks from GH releases and install automatically
 curl -sSL https://nixpacks.com/install.sh | bash
 ```
 
+This works across all supported platforms.
+
 ## PowerShell
 
 Download Nixpacks from GH release and install automatically (with powershell)


### PR DESCRIPTION
For some reason this wasn't obvious to me, I would guess others would feel the same.
