### PR TITLE
update the docker-host and docker-tls-verify flag description for the help command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,11 +141,11 @@ enum Commands {
         #[arg(long)]
         cache_from: Option<String>,
 
-        /// Image to consider as cache sources
+        /// Specify host for Docker client
         #[arg(long)]
         docker_host: Option<String>,
 
-        /// Image to consider as cache sources
+        /// Specify if Docker client should verify the TLS (Transport Layer Security) certificates
         #[arg(long)]
         docker_tls_verify: Option<String>,
 


### PR DESCRIPTION
A simple description update for the docker-host and docker-tls-verify flags. No tests are necessary because there are no business logic changes. The docs don't need to be updated because they contain the correct information.

