### PR TITLE
fix: automatically add gcc-unwrapped when installing sharp

### DIFF
--- a/docs/pages/docs/guides/configuring-builds.md
+++ b/docs/pages/docs/guides/configuring-builds.md
@@ -30,6 +30,7 @@ You can easily install additional Nix or Apt packages so that they are available
 ```toml
 [phases.setup]
 nixPkgs = ["...", "ffmpeg"] # Install the ffmpeg package from Nix
+nixLibs = ["...", "gcc-unwrapped"] # Install the gcc-unwrapped package from Nix and add it to the LD_LIBRARY_PATH
 aptPkgs = ["...", "wget"]   # Install the wget package with apt-get
 ```
 

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -118,6 +118,10 @@ impl Provider for NodeProvider {
             setup.add_nix_pkgs(&[Pkg::new("openssl")]);
         }
 
+        if NodeProvider::uses_node_dependency(app, "sharp") {
+            setup.add_pkgs_libs(vec!["gcc-unwrapped".to_string()]);
+        }
+
         if NodeProvider::uses_node_dependency(app, "puppeteer") {
             // https://gist.github.com/winuxue/cfef08e2f5fe9dfc16a1d67a4ad38a01
             setup.add_apt_pkgs(vec![


### PR DESCRIPTION
This PR adds the necessary lib to eliminate this error when using the sharp npm package:

```
error: Could not load the "sharp" module using the linux-arm64 runtime
undefined: libstdc++.so.6: cannot open shared object file: No such file or directory
Possible solutions:
```

