### PR TITLE
fix: add correct libs if canvas and puppeteer are setup

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -133,7 +133,9 @@ impl Provider for NodeProvider {
                 "libxshmfence1".to_string(),
                 "libglu1".to_string(),
             ]);
-        } else if NodeProvider::uses_node_dependency(app, "canvas") {
+        }
+
+        if NodeProvider::uses_node_dependency(app, "canvas") {
             setup.add_pkgs_libs(vec!["libuuid".to_string(), "libGL".to_string()]);
         }
 


### PR DESCRIPTION
I'm not familiar with canvas, but I don't see any reason why these two libs would be mutually exclusive.
