### PR TITLE
pin corepack to 0.24.1

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -146,7 +146,7 @@ impl Provider for NodeProvider {
         // Install
         let corepack = NodeProvider::uses_corepack(app, env)?;
         let mut install = Phase::install(if corepack {
-            Some("npm install -g corepack && corepack enable".to_string())
+            Some("npm install -g corepack@0.24.1 && corepack enable".to_string())
         } else {
             NodeProvider::get_install_command(app)
         });

--- a/tests/snapshots/generate_plan_tests__node_yarn_berry.snap
+++ b/tests/snapshots/generate_plan_tests__node_yarn_berry.snap
@@ -30,7 +30,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "npm install -g corepack && corepack enable",
+        "npm install -g corepack@0.24.1 && corepack enable",
         "yarn install --check-cache"
       ],
       "cacheDirectories": [


### PR DESCRIPTION
Corepack has some bugs in the latest version that was released a few hours ago. We are pinning to the previous version until that is fixed

- https://github.com/nodejs/corepack/issues/379
- https://github.com/nodejs/corepack/releases/tag/v0.25.0