### PR TITLE
Use mix ecto.setup instead of mix ecto.migrate and seed command

### DIFF
--- a/src/providers/elixir.rs
+++ b/src/providers/elixir.rs
@@ -52,8 +52,7 @@ impl Provider for ElixirProvider {
         }
 
         if mix_exs_content.contains("postgrex") && mix_exs_content.contains("ecto") {
-            build_phase.add_cmd("mix ecto.migrate");
-            build_phase.add_cmd("mix run priv/repo/seeds.exs");
+            build_phase.add_cmd("mix ecto.setup");
         }
         plan.add_phase(build_phase);
 

--- a/tests/snapshots/generate_plan_tests__elixir_ecto.snap
+++ b/tests/snapshots/generate_plan_tests__elixir_ecto.snap
@@ -17,8 +17,7 @@ expression: plan
       ],
       "cmds": [
         "mix compile",
-        "mix ecto.migrate",
-        "mix run priv/repo/seeds.exs"
+        "mix ecto.setup"
       ]
     },
     "install": {


### PR DESCRIPTION
## Why

`mix ecto.setup` is an alias that will execute the following commands:

```elixir
"ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
```

This will ensure that the database that needs to be created exists!
