### PR TITLE
 Update Bun version via newer NixPkgs archive commit hash

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -23,7 +23,7 @@ mod turborepo;
 
 pub const NODE_OVERLAY: &str = "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz";
 
-const NODE_NIXPKGS_ARCHIVE: &str = "bf744fe90419885eefced41b3e5ae442d732712d";
+const NODE_NIXPKGS_ARCHIVE: &str = "d1c6a5decfd9ad4c84354612d418b2856a57be1d";
 
 const DEFAULT_NODE_VERSION: u32 = 18;
 const AVAILABLE_NODE_VERSIONS: &[u32] = &[14, 16, 18, 20, 21];


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR changes one line in /src/providers/node/mod.rs which uses a newer NixPkgs commit hash which uses Bun 1.1.7. Nixpacks currently uses a much older commit hash which uses Bun 1.0 which lacks a LOT of features that 1.1.7 has that are needed for the apps I develop.

I was not able to run tests because I kept getting weird docker errors from Cargo- but Bun works fine:

![image](https://github.com/railwayapp/nixpacks/assets/61296321/1eff462e-6d09-4da9-9444-7f6ad4eca11f)

Thanks to anyone that sees this.

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
