### PR TITLE
docs: update nixos link to official wiki

### DIFF
--- a/docs/pages/docs/configuration/file.md
+++ b/docs/pages/docs/configuration/file.md
@@ -137,7 +137,7 @@ Nix packages to be made available through the `LD_LIBRARY_PATH` environment vari
 
 ### Nix overlays
 
-[Nix overlays](https://nixos.wiki/wiki/Overlays) to use as alternate package sources.
+[Nix overlays](https://wiki.nixos.org/wiki/Overlays) to use as alternate package sources.
 
 ```toml
 [phase.name]


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org/

ref: https://github.com/NixOS/foundation/issues/113

<!-- PR Checklist  -->

- [x] Docs are updated if needed 
