### PR TITLE
test: ensure apt *and* python c extensions work properly

### DIFF
--- a/examples/python-numpy/main.py
+++ b/examples/python-numpy/main.py
@@ -1,5 +1,7 @@
+import sys
 import numpy as np
 import pandas as pd
+import subprocess
 
 print(np)
 print(pd)
@@ -8,3 +10,10 @@ arr = np.random.rand(2, 3)
 print(arr)
 
 print("Hello from Python numpy and pandas")
+
+# with the wrong LD_LIBRARY_PATH, this will fail with a GLIBC version mismatch
+result = subprocess.run(["apt", "--version"], capture_output=True, text=True)
+print(result.stdout)
+
+# fail if subprocess fails!
+sys.exit(result.returncode)

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -142,8 +142,15 @@ impl PythonProvider {
         let mut setup = Phase::setup(Some(pkgs));
 
         // Many Python packages need some C headers to be available
-        // stdenv.cc.cc.lib -> https://discourse.nixos.org/t/nixos-with-poetry-installed-pandas-libstdc-so-6-cannot-open-shared-object-file/8442/3
-        setup.add_pkgs_libs(vec!["zlib".to_string(), "stdenv.cc.cc.lib".to_string()]);
+        //
+        //   - https://discourse.nixos.org/t/nixos-with-poetry-installed-pandas-libstdc-so-6-cannot-open-shared-object-file/8442/3
+        //   - https://github.com/mcdonc/.nixconfig/blob/e7885ad18b7980f221e59a21c91b8eb02795b541/videos/pydev/script.rst
+        //
+        // Some packages (like stdenv.cc.cc.lib) may conflict with other system commands and cause libc version conflicts
+        // since LD_LIBRARY_PATH is mutated by `add_pkgs_libs`
+        //
+
+        setup.add_pkgs_libs(vec!["zlib".to_string()]);
         setup.add_nix_pkgs(&[Pkg::new("gcc")]);
 
         Ok(Some(setup))

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -97,6 +97,8 @@ async fn run_image(name: &str, cfg: Option<Config>) -> String {
         }
     };
 
+    assert!(_status_code == Some(0), "Failed to run image successfully");
+
     let reader = BufReader::new(child.stdout.unwrap());
     reader
         .lines()
@@ -771,6 +773,7 @@ async fn test_python_numpy() {
     let name = simple_build("./examples/python-numpy").await;
     let output = run_image(&name, None).await;
     assert!(output.contains("Hello from Python numpy and pandas"));
+    assert!(output.contains("apt is a commandline package manager"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
I ran into a tricky problem:

- I have a py project
- The project has to execute a system command, notably `apt` in this case
- stdenv.cc.cc.lib is required for numpy to work, but it breaks `apt` (and, more importantly, I'm assuming many other system commands) with the following error:

```
0.110 nix-env: /nix/store/02mqs1by2vab9yzw0qc4j7463w78p3ps-glibc-2.37-8/lib/libc.so.6: version `GLIBC_2.38' not found (required by nix-env)
```

This error can be fixed by reverting the mutated `LD_LIBRARY_PATH` from:

```
LD_LIBRARY_PATH=/nix/store/cq3kvw7kwz2n9c13fg6qaaj23mkm116l-gcc-12.3.0-lib/lib:/nix/store/wzm0753byf1app0xrsa97hjnfk9m1zs0-zlib-1.3/lib:/usr/lib
```

to:

```
LD_LIBRARY_PATH=/usr/lib
```

Did some research:

- https://github.com/mcdonc/.nixconfig/blob/e7885ad18b7980f221e59a21c91b8eb02795b541/videos/pydev/script.rst
- https://github.com/nix-community/poetry2nix
- https://discourse.nixos.org/t/nixos-with-poetry-installed-pandas-libstdc-so-6-cannot-open-shared-object-file/8442/8

I'm new to nix. It seems like creating a bespoke shell env with `LD` modified is the way to go, but that wouldn't actually solve this issue since
`LD_LIBRARY_PATH` would be inherited by the py process and therefore passed to the shell (unless the modified `LD` only applies to package installation, but I'm confident that would work either.

In any case, I'm curious what folks think here. I added a failing test to work off of, but unsure of the best solution.

## Docker container success assertion

In investigating this, I found that the docker container execution is not asserted to be successful. This feels like a good change
to make for all containers to avoid swallowing otherwise important errors.
