### PR TITLE
feat: dump build command when --out is specified

### DIFF
--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -37,6 +37,11 @@ fn get_output_dir(app_src: &str, options: &DockerBuilderOptions) -> Result<Outpu
     }
 }
 
+fn command_to_string(command: &Command) -> String {
+    let args = command.get_args().map(|arg| arg.to_string_lossy()).collect::<Vec<_>>();
+    format!("{} {}", command.get_program().to_string_lossy(), args.join(" "))
+}
+
 use async_trait::async_trait;
 
 #[async_trait]
@@ -78,9 +83,16 @@ impl ImageBuilder for DockerImageBuilder {
         plan.write_supporting_files(&self.options, env, &output)
             .context("Writing supporting files")?;
 
+        let mut docker_build_cmd = self.get_docker_build_cmd(plan, name.as_str(), &output)?;
+
+        if !self.options.out_dir.is_none() {
+            let command_path = output.get_absolute_path("build.sh");
+            File::create(command_path.clone()).context("Creating command.sh file")?;
+            fs::write(command_path, command_to_string(&docker_build_cmd)).context("Write command")?;
+        }
+
         // Only build if the --out flag was not specified
         if self.options.out_dir.is_none() {
-            let mut docker_build_cmd = self.get_docker_build_cmd(plan, name.as_str(), &output)?;
 
             // Execute docker build
             let build_result = docker_build_cmd.spawn()?.wait().context("Building image")?;

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -38,8 +38,15 @@ fn get_output_dir(app_src: &str, options: &DockerBuilderOptions) -> Result<Outpu
 }
 
 fn command_to_string(command: &Command) -> String {
-    let args = command.get_args().map(|arg| arg.to_string_lossy()).collect::<Vec<_>>();
-    format!("{} {}", command.get_program().to_string_lossy(), args.join(" "))
+    let args = command
+        .get_args()
+        .map(|arg| arg.to_string_lossy())
+        .collect::<Vec<_>>();
+    format!(
+        "{} {}",
+        command.get_program().to_string_lossy(),
+        args.join(" ")
+    )
 }
 
 use async_trait::async_trait;
@@ -88,12 +95,12 @@ impl ImageBuilder for DockerImageBuilder {
         if !self.options.out_dir.is_none() {
             let command_path = output.get_absolute_path("build.sh");
             File::create(command_path.clone()).context("Creating command.sh file")?;
-            fs::write(command_path, command_to_string(&docker_build_cmd)).context("Write command")?;
+            fs::write(command_path, command_to_string(&docker_build_cmd))
+                .context("Write command")?;
         }
 
         // Only build if the --out flag was not specified
         if self.options.out_dir.is_none() {
-
             // Execute docker build
             let build_result = docker_build_cmd.spawn()?.wait().context("Building image")?;
             if !build_result.success() {

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -92,7 +92,7 @@ impl ImageBuilder for DockerImageBuilder {
 
         let mut docker_build_cmd = self.get_docker_build_cmd(plan, name.as_str(), &output)?;
 
-        if !self.options.out_dir.is_none() {
+        if self.options.out_dir.is_some() {
             let command_path = output.get_absolute_path("build.sh");
             File::create(command_path.clone()).context("Creating command.sh file")?;
             fs::write(command_path, command_to_string(&docker_build_cmd))


### PR DESCRIPTION
Follow-up from https://github.com/railwayapp/nixpacks/pull/1066

> Is the use case mainly for debugging what Nixpacks is doing? I wonder if we could instead of a verbose mode where the docker command is output in the logs. Would that solve the problem?

Yes. Primarily for debugging.

Without this, it's hard to actually recreate what nixpacks is doing when building a dockerfile to 
iterate on the Dockerfile config locally.

Outputting the build command would be fine, but it seems better to me to persist the necessary commands to build the
entire docker container exactly like nixpacks does when --dump is used.
