### PR TITLE
support Docker `--output` argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,11 @@ enum Commands {
         #[arg(long)]
         docker_tls_verify: Option<String>,
 
+        /// Specify output destination for Docker build.
+        /// https://docs.docker.com/reference/cli/docker/buildx/build/#output
+        #[arg(long)]
+        docker_output: Option<String>,
+
         /// Enable writing cache metadata into the output image
         #[arg(long)]
         inline_cache: bool,
@@ -259,6 +264,7 @@ async fn main() -> Result<()> {
             cache_from,
             docker_host,
             docker_tls_verify,
+            docker_output,
             add_host,
             inline_cache,
             no_error_without_start,
@@ -290,6 +296,7 @@ async fn main() -> Result<()> {
                 cache_from,
                 docker_host,
                 docker_tls_verify,
+                docker_output,
                 no_error_without_start,
                 incremental_cache_image,
                 cpu_quota,

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -195,6 +195,10 @@ impl DockerImageBuilder {
             }
         }
 
+        if let Some(value) = &self.options.docker_output {
+            docker_build_cmd.arg("--output").arg(value);
+        }
+
         if self.options.inline_cache {
             docker_build_cmd
                 .arg("--build-arg")

--- a/src/nixpacks/builder/docker/mod.rs
+++ b/src/nixpacks/builder/docker/mod.rs
@@ -23,6 +23,7 @@ pub struct DockerBuilderOptions {
     pub verbose: bool,
     pub docker_host: Option<String>,
     pub docker_tls_verify: Option<String>,
+    pub docker_output: Option<String>,
     pub add_host: Vec<String>,
 }
 


### PR DESCRIPTION
This PR adds a `--output` argument that proxies to Docker.

https://docs.docker.com/reference/cli/docker/buildx/build/#output
