### PR TITLE
Support Bun 1.1.20

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -23,7 +23,7 @@ mod turborepo;
 
 pub const NODE_OVERLAY: &str = "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz";
 
-const NODE_NIXPKGS_ARCHIVE: &str = "bdd2f439c62aa0b8aa97f5c784a965c23f968fe6";
+const NODE_NIXPKGS_ARCHIVE: &str = "e05605ec414618eab4a7a6aea8b38f6fbbcc8f08";
 
 // We need to use a specific commit hash for Node versions <16 since it is EOL in the latest Nix packages
 const NODE_LT_16_ARCHIVE: &str = "bf744fe90419885eefced41b3e5ae442d732712d";


### PR DESCRIPTION
Update Nix archive used for Node so we can support Bun 1.1.20

https://github.com/NixOS/nixpkgs/commit/e05605ec414618eab4a7a6aea8b38f6fbbcc8f08