### PR TITLE
Fix custom rust toolchain test

### DIFF
--- a/examples/rust-custom-toolchain/rust-toolchain.toml
+++ b/examples/rust-custom-toolchain/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-02-17"
+channel = "nightly-2024-08-12"
 profile = "minimal"

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -1074,7 +1074,7 @@ async fn test_rust_toolchain_file() {
         .await
         .unwrap();
     let output = run_image(&name, None).await;
-    assert!(output.contains("cargo 1.60.0-nightly"));
+    assert!(output.contains("cargo 1.82.0-nightly"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR
- Updates the `rust-toolchain.toml` file to use a more recent version of Rust that exists in Nix.
