### PR TITLE
Feat/docker cert path

### DIFF
--- a/docs/pages/docs/cli.md
+++ b/docs/pages/docs/cli.md
@@ -40,7 +40,7 @@ nixpacks build --help
 | `--no-cache`                | Disable caching for the build                                                                                                                           |
 | `--docker-host`             | Specify host for Docker client                                                                                                                          |
 | `--docker-tls-verify`       | Specify if Docker client should verify the TLS (Transport Layer Security) certificates of the Docker daemon when communicating over a secure connection |
-| `--docker-cert-path`       | Specify the path of your cert to docker if your connection is under TLS |
+| `--docker-cert-path`        | Specify the path of your cert to docker if your connection is under TLS                                                                                 |
 | `--cache-from`              | Image to consider as cache sources                                                                                                                      |
 | `--inline-cache`            | Enable writing cache metadata into the output image                                                                                                     |
 | `--out <dir>`, `-o`         | Save output directory instead of building it with Docker                                                                                                |

--- a/docs/pages/docs/cli.md
+++ b/docs/pages/docs/cli.md
@@ -40,6 +40,7 @@ nixpacks build --help
 | `--no-cache`                | Disable caching for the build                                                                                                                           |
 | `--docker-host`             | Specify host for Docker client                                                                                                                          |
 | `--docker-tls-verify`       | Specify if Docker client should verify the TLS (Transport Layer Security) certificates of the Docker daemon when communicating over a secure connection |
+| `--docker-cert-path`       | Specify the path of your cert to docker if your connection is under TLS |
 | `--cache-from`              | Image to consider as cache sources                                                                                                                      |
 | `--inline-cache`            | Enable writing cache metadata into the output image                                                                                                     |
 | `--out <dir>`, `-o`         | Save output directory instead of building it with Docker                                                                                                |

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,12 +267,9 @@ async fn main() -> Result<()> {
             cache_from,
             docker_host,
             docker_tls_verify,
-<<<<<<< HEAD
             docker_output,
             add_host,
-=======
             docker_cert_path,
->>>>>>> 1136354 (feat: add a params to specify the docker cert path)
             inline_cache,
             no_error_without_start,
             cpu_quota,
@@ -303,11 +300,8 @@ async fn main() -> Result<()> {
                 cache_from,
                 docker_host,
                 docker_tls_verify,
-<<<<<<< HEAD
                 docker_output,
-=======
                 docker_cert_path,
->>>>>>> 1136354 (feat: add a params to specify the docker cert path)
                 no_error_without_start,
                 incremental_cache_image,
                 cpu_quota,

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,9 @@ enum Commands {
         /// https://docs.docker.com/reference/cli/docker/buildx/build/#output
         #[arg(long)]
         docker_output: Option<String>,
+        /// Specify the path to the Docker client certificates
+        #[arg(long)]
+        docker_cert_path: Option<String>,
 
         /// Enable writing cache metadata into the output image
         #[arg(long)]
@@ -264,8 +267,12 @@ async fn main() -> Result<()> {
             cache_from,
             docker_host,
             docker_tls_verify,
+<<<<<<< HEAD
             docker_output,
             add_host,
+=======
+            docker_cert_path,
+>>>>>>> 1136354 (feat: add a params to specify the docker cert path)
             inline_cache,
             no_error_without_start,
             cpu_quota,
@@ -296,7 +303,11 @@ async fn main() -> Result<()> {
                 cache_from,
                 docker_host,
                 docker_tls_verify,
+<<<<<<< HEAD
                 docker_output,
+=======
+                docker_cert_path,
+>>>>>>> 1136354 (feat: add a params to specify the docker cert path)
                 no_error_without_start,
                 incremental_cache_image,
                 cpu_quota,

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -191,8 +191,9 @@ impl DockerImageBuilder {
             }
         }
 
-        if let Some(value) = &self.options.docker_output {
-            docker_build_cmd.arg("--output").arg(value);
+        match &self.options.docker_cert_path {
+            Some(value) => env::set_var("DOCKER_CERT_PATH", value),
+            None => env::remove_var("DOCKER_CERT_PATH"),
         }
 
         if self.options.inline_cache {

--- a/src/nixpacks/builder/docker/mod.rs
+++ b/src/nixpacks/builder/docker/mod.rs
@@ -25,6 +25,7 @@ pub struct DockerBuilderOptions {
     pub docker_tls_verify: Option<String>,
     pub docker_output: Option<String>,
     pub add_host: Vec<String>,
+    pub docker_cert_path: Option<String>,
 }
 
 mod cache;


### PR DESCRIPTION
Hi @coffee-cup,

I'm recreating this pull request following the closure of the previous one. As discussed earlier, I'm proposing to add a parameter to specify the Docker cert path.

I understand your concern about not wanting to integrate too much Docker configuration into Nixpacks. However, since there is already a variable to specify a Docker host (docker-host), it seems logical to add another variable specifically for establishing a secure connection with this host. This would make it easier for users who want to secure their connection without manually configuring every aspect.

Please let me know your thoughts on this. I'm also open to suggestions on how to test this new feature.

Thank you for your understanding and time!