### PR TITLE
Trim environment variable names when adding to Dockerfile

### DIFF
--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -466,6 +466,8 @@ impl DockerfileGenerator for Phase {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
 
     #[test]
@@ -490,6 +492,11 @@ mod tests {
     fn test_plan_generation() {
         let mut plan = BuildPlan::default();
 
+        plan.add_variables(BTreeMap::from([(
+            "VAR1 ".to_string(),
+            "value1".to_string(),
+        )]));
+
         let mut test1 = Phase::new("test1");
         test1.add_cmd("echo test1");
         test1.add_apt_pkgs(vec!["wget".to_owned()]);
@@ -512,5 +519,6 @@ mod tests {
         assert!(dockerfile.contains("echo test2"));
         assert!(dockerfile.contains("apt-get update"));
         assert!(dockerfile.contains("wget"));
+        assert!(dockerfile.contains("ENV VAR1=$VAR1"));
     }
 }

--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -154,7 +154,7 @@ impl DockerfileGenerator for BuildPlan {
                 // Make the variables available at runtime
                 variables
                     .iter()
-                    .map(|var| format!("{}=${}", var.0, var.0))
+                    .map(|var| format!("{}=${}", var.0.trim(), var.0.trim()))
                     .collect::<Vec<_>>()
                     .join(" ")
             )


### PR DESCRIPTION
This PR fixes [this](https://help.railway.app/questions/railway-should-trim-the-names-of-envi-d1fd6f10) issue caused by the fact that environment variables names are not trimmed.
