### PR TITLE
Remove redundant line from test_phase_generation

### DIFF
--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -474,7 +474,6 @@ mod tests {
     fn test_phase_generation() {
         let mut phase = Phase::new("test");
         phase.add_cmd("echo test");
-        phase.add_apt_pkgs(vec!["wget".to_owned()]);
 
         let dockerfile = phase
             .generate_dockerfile(


### PR DESCRIPTION
This PR removes a redundant line from `test_phase_generation` function which is not necessary.

PR Checklist
 - [x] Tests are added/updated if needed

