### PR TITLE
Add removal of `DOCKER_HOST` env when `docker_host` is `None`

### DIFF
--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -179,8 +179,9 @@ impl DockerImageBuilder {
             docker_build_cmd.arg("--cache-from").arg(value);
         }
 
-        if let Some(value) = &self.options.docker_host {
-            env::set_var("DOCKER_HOST", value);
+        match &self.options.docker_host {
+            Some(value) => env::set_var("DOCKER_HOST", value),
+            None => env::remove_var("DOCKER_HOST"),
         }
 
         if let Some(value) = &self.options.docker_tls_verify {


### PR DESCRIPTION
This PR enhances the handling of the `DOCKER_HOST` environment variable in the codebase.

#### Changes:
- Replaced the existing `if let` structure with a `match` statement.
- Added logic to remove the `DOCKER_HOST` environment variable when the `docker_host` option is `None`.

#### Impact:
Without this change, running tests locally would fail because the `DOCKER_HOST` variable wouldn't be removed when `docker_host` was `None`.
