### PR TITLE
Fix fill_auto_in_vec function doc test

### DIFF
--- a/src/nixpacks/plan/mod.rs
+++ b/src/nixpacks/plan/mod.rs
@@ -18,7 +18,7 @@ pub mod merge;
 pub mod phase;
 pub mod pretty_print;
 mod topological_sort;
-mod utils;
+pub mod utils;
 
 /// Types that impl this trait can generate build plans.
 pub trait PlanGenerator {

--- a/src/nixpacks/plan/utils.rs
+++ b/src/nixpacks/plan/utils.rs
@@ -9,11 +9,13 @@ pub fn remove_autos_from_vec(original: Vec<String>) -> Vec<String> {
 /// Fills in the `"..."`'s or `"@auto"`'s in `replacer` with the values from the `original`
 ///
 /// ```
+/// use nixpacks::nixpacks::plan::utils::fill_auto_in_vec;
+///
 /// let arr = fill_auto_in_vec(
-///   Some(vec!["a", "b", "c"]),
-///   Some(vec!["x", "...", "z"])
+///   Some(vec!["a".into(), "b".into(), "c".into()]),
+///   Some(vec!["x".into(), "...".into(), "z".into()])
 /// );
-/// assert_eq!(Some(vec!["x", "...", "a", "b", "c", "z"]), arr);
+/// assert_eq!(Some(vec!["x".into(), "...".into(), "a".into(), "b".into(), "c".into(), "z".into()]), arr);
 /// ```
 pub fn fill_auto_in_vec(
     original: Option<Vec<String>>,


### PR DESCRIPTION
This PR fixes the documentation test (`doctest`) for the `fill_auto_in_vec` function, which was previously failing when running the command:

```bash
cargo test --doc
```

#### **Changes Made:**
- Updated the doctest to use the `.into()` method for converting `&str` to `String`, ensuring type consistency without cluttering the test code.
- Made the `utils` module public to ensure that the doctest can access the `fill_auto_in_vec` function correctly.

#### **Consideration:**
If these changes seem excessive or if maintaining the doctest is redundant (given that the function is already thoroughly tested in the `test` module within the same file), you might consider removing the doctest altogether to avoid duplicating efforts.
