### PR TITLE
fix: automatically add cairo lib dependency when pip package is detected

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -152,6 +152,10 @@ impl PythonProvider {
             pkgs.append(&mut vec![Pkg::new("pipenv")]);
         }
 
+        if PythonProvider::uses_dep(app, "cairo")? {
+            pkgs.append(&mut vec![Pkg::new("cairo")]);
+        }
+
         let mut setup = Phase::setup(Some(pkgs));
         setup.set_nix_archive(nix_archive);
 


### PR DESCRIPTION
This PR automatically adds the cairo lib when it's detected in the dependency list.

