### PR TITLE
Resolve build warning for LegacyKeyValueFormat

### DIFF
--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -388,7 +388,7 @@ impl DockerfileGenerator for Phase {
         // Ensure paths are available in the environment
         let build_path = if let Some(paths) = &phase.paths {
             let joined_paths = paths.join(":");
-            format!("ENV NIXPACKS_PATH {joined_paths}:$NIXPACKS_PATH")
+            format!("ENV NIXPACKS_PATH={joined_paths}:$NIXPACKS_PATH")
         } else {
             String::new()
         };
@@ -474,6 +474,7 @@ mod tests {
     fn test_phase_generation() {
         let mut phase = Phase::new("test");
         phase.add_cmd("echo test");
+        phase.add_path("/test".to_string());
 
         let dockerfile = phase
             .generate_dockerfile(
@@ -485,6 +486,7 @@ mod tests {
             .unwrap();
 
         assert!(dockerfile.contains("echo test"));
+        assert!(dockerfile.contains("ENV NIXPACKS_PATH=/test:$NIXPACKS_PATH"));
     }
 
     #[test]


### PR DESCRIPTION
This PR resolves the warning related to `LegacyKeyValueFormat` that appears when running the build command. For example, the following command would trigger the warning:

```bash
cargo run -- build examples/node --name node
```

PR Checklist 
- [x] Tests are added/updated if needed
