### PR TITLE
actually use the docker-output flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,7 @@ enum Commands {
         /// https://docs.docker.com/reference/cli/docker/buildx/build/#output
         #[arg(long)]
         docker_output: Option<String>,
+
         /// Specify the path to the Docker client certificates
         #[arg(long)]
         docker_cert_path: Option<String>,

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -178,6 +178,10 @@ impl DockerImageBuilder {
             docker_build_cmd.arg("--cache-from").arg(value);
         }
 
+        if let Some(value) = &self.options.docker_output {
+            docker_build_cmd.arg("--output").arg(value);
+        }
+
         match &self.options.docker_host {
             Some(value) => docker_build_cmd.env("DOCKER_HOST", value),
             None => docker_build_cmd.env_remove("DOCKER_HOST"),


### PR DESCRIPTION
This PR fixes a regression where we were ignoring the `--docker-output` argument
