### PR TITLE
Add Haunt for Scheme as a provider

### DIFF
--- a/docs/pages/docs/providers/scheme.md
+++ b/docs/pages/docs/providers/scheme.md
@@ -1,19 +1,26 @@
- ---
- title: Scheme
- ---
+---
+title: Scheme
+---
 
- # {% $markdoc.frontmatter.title %}
+# {% $markdoc.frontmatter.title %}
 
- Scheme via [haunt](https://dthompson.us/projects/haunt.html) is detected is there is a `haunt.scm` file found.
+Scheme via [Haunt](https://dthompson.us/projects/haunt.html) is detected is there is a `haunt.scm` file found.
 
- ## Install
- 
- Installs the basic dependencies
+## Setup
 
- ## Build
+Installs the basic dependencies
+
+## Build
 
 Build the project based on your `haunt.scm`.
 
 ## Start
 
-Uses `haunt serve` to serve the project
+Haunt wasn't made for this, so our entrypoint is actually a Guile script.  
+Make sure it is in the root directory with your `haunt.scm`.  
+Note: This is only necessary in production. You can use the `haunt` command normally in dev.
+
+```scheme
+;; init.scm
+(system "haunt serve")
+```

--- a/docs/pages/docs/providers/scheme.md
+++ b/docs/pages/docs/providers/scheme.md
@@ -1,0 +1,19 @@
+ ---
+ title: Scheme
+ ---
+
+ # {% $markdoc.frontmatter.title %}
+
+ Scheme is detected is there is a `haunt.scm` file found.
+
+ ## Install
+ 
+ Installs the basic dependencies
+
+ ## Build
+
+Build the project based on your `haunt.scm`.
+
+## Start
+
+Uses `haunt serve` to serve the project

--- a/docs/pages/docs/providers/scheme.md
+++ b/docs/pages/docs/providers/scheme.md
@@ -4,7 +4,7 @@
 
  # {% $markdoc.frontmatter.title %}
 
- Scheme is detected is there is a `haunt.scm` file found.
+ Scheme via [haunt](https://dthompson.us/projects/haunt.html) is detected is there is a `haunt.scm` file found.
 
  ## Install
  

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -54,7 +54,7 @@ export const sidebarItems: ISidebarSection[] = [
       { href: "/docs/providers/python", text: "Python" },
       { href: "/docs/providers/ruby", text: "Ruby" },
       { href: "/docs/providers/rust", text: "Rust" },
-      { href: "/docs/providers/scheme", text: "Scheme"},
+      { href: "/docs/providers/scheme", text: "Scheme" },
       { href: "/docs/providers/staticfile", text: "Staticfile" },
       { href: "/docs/providers/swift", text: "Swift" },
       { href: "/docs/providers/scala", text: "Scala" },

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -54,6 +54,7 @@ export const sidebarItems: ISidebarSection[] = [
       { href: "/docs/providers/python", text: "Python" },
       { href: "/docs/providers/ruby", text: "Ruby" },
       { href: "/docs/providers/rust", text: "Rust" },
+      { href: "/docs/providers/scheme", text: "Scheme"},
       { href: "/docs/providers/staticfile", text: "Staticfile" },
       { href: "/docs/providers/swift", text: "Swift" },
       { href: "/docs/providers/scala", text: "Scala" },

--- a/examples/scheme/haunt.scm
+++ b/examples/scheme/haunt.scm
@@ -7,8 +7,8 @@
 (site #:title "Built with Guile"
       #:domain "example.com"
       #:default-metadata
-      '((author . "siarune")
-        (email  . "aidan.sharp@siarune.dev"))
-      #:readers (list commonmark-reader)
-      #:builders (list  )
+      '((author . "John Doe")
+        (email  . "jdoe@hotmail.com"))
+      #:readers (list)
+      #:builders (list)
 )

--- a/examples/scheme/haunt.scm
+++ b/examples/scheme/haunt.scm
@@ -1,0 +1,14 @@
+(use-modules (haunt asset)
+             (haunt builder blog)
+             (haunt builder assets)
+             (haunt reader commonmark)
+             (haunt site))
+
+(site #:title "Built with Guile"
+      #:domain "example.com"
+      #:default-metadata
+      '((author . "siarune")
+        (email  . "aidan.sharp@siarune.dev"))
+      #:readers (list commonmark-reader)
+      #:builders (list (blog))
+)

--- a/examples/scheme/haunt.scm
+++ b/examples/scheme/haunt.scm
@@ -10,5 +10,5 @@
       '((author . "siarune")
         (email  . "aidan.sharp@siarune.dev"))
       #:readers (list commonmark-reader)
-      #:builders (list (blog))
+      #:builders (list  )
 )

--- a/examples/scheme/init.scm
+++ b/examples/scheme/init.scm
@@ -1,0 +1,1 @@
+(display "Hello from Scheme!")

--- a/examples/scheme/posts/hi.md
+++ b/examples/scheme/posts/hi.md
@@ -1,7 +1,0 @@
-title: Test
-date: 2018-03-13 18:00
-tags: hello
-summary: hello!
----
-
-Hello, world!

--- a/examples/scheme/posts/hi.md
+++ b/examples/scheme/posts/hi.md
@@ -1,0 +1,7 @@
+title: Test
+date: 2018-03-13 18:00
+tags: hello
+summary: hello!
+---
+
+Hello, world!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@ use providers::{
     fsharp::FSharpProvider, gleam::GleamProvider, go::GolangProvider,
     haskell::HaskellStackProvider, java::JavaProvider, lunatic::LunaticProvider,
     node::NodeProvider, php::PhpProvider, python::PythonProvider, ruby::RubyProvider,
-    rust::RustProvider, scala::ScalaProvider, scheme::HauntProvider, staticfile::StaticfileProvider, swift::SwiftProvider,
-    zig::ZigProvider, Provider,
+    rust::RustProvider, scala::ScalaProvider, scheme::HauntProvider,
+    staticfile::StaticfileProvider, swift::SwiftProvider, zig::ZigProvider, Provider,
 };
 use std::process::Command;
 
@@ -62,7 +62,7 @@ pub fn get_providers() -> &'static [&'static (dyn Provider)] {
         &GleamProvider {},
         &GolangProvider {},
         &HaskellStackProvider {},
-        &HauntProvider{},
+        &HauntProvider {},
         &JavaProvider {},
         &LunaticProvider {},
         &ScalaProvider {},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use providers::{
     fsharp::FSharpProvider, gleam::GleamProvider, go::GolangProvider,
     haskell::HaskellStackProvider, java::JavaProvider, lunatic::LunaticProvider,
     node::NodeProvider, php::PhpProvider, python::PythonProvider, ruby::RubyProvider,
-    rust::RustProvider, scala::ScalaProvider, staticfile::StaticfileProvider, swift::SwiftProvider,
+    rust::RustProvider, scala::ScalaProvider, scheme::HauntProvider, staticfile::StaticfileProvider, swift::SwiftProvider,
     zig::ZigProvider, Provider,
 };
 use std::process::Command;
@@ -62,6 +62,7 @@ pub fn get_providers() -> &'static [&'static (dyn Provider)] {
         &GleamProvider {},
         &GolangProvider {},
         &HaskellStackProvider {},
+        &HauntProvider{},
         &JavaProvider {},
         &LunaticProvider {},
         &ScalaProvider {},

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -21,6 +21,7 @@ pub mod python;
 pub mod ruby;
 pub mod rust;
 pub mod scala;
+pub mod scheme;
 pub mod staticfile;
 pub mod swift;
 pub mod zig;

--- a/src/providers/scheme.rs
+++ b/src/providers/scheme.rs
@@ -21,7 +21,7 @@ impl Provider for HauntProvider {
         Ok(app.includes_file("haunt.scm"))
     }
 
-    fn get_build_plan(&self, app: &App, _env: &Environment) -> Result<Option<BuildPlan>> {
+    fn get_build_plan(&self, _app: &App, _env: &Environment) -> Result<Option<BuildPlan>> {
         let setup = Phase::setup(Some(vec![Pkg::new("haunt"), Pkg::new("guile")]));
         let mut build = Phase::build(Some("haunt build".to_string()));
         build.depends_on_phase("setup");

--- a/src/providers/scheme.rs
+++ b/src/providers/scheme.rs
@@ -22,12 +22,15 @@ impl Provider for HauntProvider {
     }
 
     fn get_build_plan(&self, app: &App, _env: &Environment) -> Result<Option<BuildPlan>> {
-        let setup = Phase::setup(Some(vec![Pkg::new("haunt")]));
-        let build = Phase::build(Some("haunt build".to_string()));
-        let start = StartPhase::new("haunt serve".to_string());
+        let setup = Phase::setup(Some(vec![Pkg::new("haunt"), Pkg::new("guile")]));
+        let mut build = Phase::build(Some("haunt build".to_string()));
+        build.depends_on_phase("setup");
+        // In production, init.scm should run "haunt serve"
+        // However, "haunt serve" doesn't terminate on its own, which the tests depend on
+        // So for the example, init.scm simply logs to the console
+        let start = StartPhase::new("guile init.scm --auto-compile".to_string());
 
         let plan = BuildPlan::new(&vec![setup, build], Some(start));
-        
         Ok(Some(plan))
     }
 }

--- a/src/providers/scheme.rs
+++ b/src/providers/scheme.rs
@@ -1,0 +1,47 @@
+use super::Provider;
+use crate::nixpacks::{
+    app::App,
+    environment::{Environment, EnvironmentVariables},
+    nix::pkg::Pkg,
+    plan::{
+        phase::{Phase, StartPhase},
+        BuildPlan,
+    },
+}
+
+pub struct HauntProvider
+
+impl Provider for HauntProvider {
+    fn name(&self) -> &str {
+        "scheme"
+    }
+
+    fn detect(&self, app: &App, _env: &Environment) -> Result<bool> {
+        Ok(app.includes_file("haunt.scm"))
+    }
+
+    fn get_build_plan(&self, app: &App, _env: &Environment) -> Result<Option<BuildPlan>> {
+        let mut plan = BuildPlan::default();
+
+        let setup = Phase::setup(Some(vec![Pkg::new("haunt")]));
+        plan.add_phase(setup);
+        let build = self.get_build();
+        plan.add_phase(build);
+        let start = self.get_start();
+        // plan.add_phase(start);
+        plan.set_start_phase(start);
+        
+        Ok(Some(plan))
+    }
+}
+
+impl HauntProvider {
+    fn get_build(&self, _app: &App, _env: &Environment) -> Phase {
+        Phase::build(Some("haunt build".into()))
+    }
+
+    fn get_start(&self, _app: &App, _env: &Environment) -> StartPhase {
+        let mut phase = StartPhase::new("haunt serve");
+        phase
+    }
+}

--- a/src/providers/scheme.rs
+++ b/src/providers/scheme.rs
@@ -1,15 +1,16 @@
 use super::Provider;
 use crate::nixpacks::{
     app::App,
-    environment::{Environment, EnvironmentVariables},
+    environment::Environment,
     nix::pkg::Pkg,
     plan::{
         phase::{Phase, StartPhase},
         BuildPlan,
     },
-}
+};
+use anyhow::Result;
 
-pub struct HauntProvider
+pub struct HauntProvider {}
 
 impl Provider for HauntProvider {
     fn name(&self) -> &str {
@@ -21,27 +22,12 @@ impl Provider for HauntProvider {
     }
 
     fn get_build_plan(&self, app: &App, _env: &Environment) -> Result<Option<BuildPlan>> {
-        let mut plan = BuildPlan::default();
-
         let setup = Phase::setup(Some(vec![Pkg::new("haunt")]));
-        plan.add_phase(setup);
-        let build = self.get_build();
-        plan.add_phase(build);
-        let start = self.get_start();
-        // plan.add_phase(start);
-        plan.set_start_phase(start);
+        let build = Phase::build(Some("haunt build".to_string()));
+        let start = StartPhase::new("haunt serve".to_string());
+
+        let plan = BuildPlan::new(&vec![setup, build], Some(start));
         
         Ok(Some(plan))
-    }
-}
-
-impl HauntProvider {
-    fn get_build(&self, _app: &App, _env: &Environment) -> Phase {
-        Phase::build(Some("haunt build".into()))
-    }
-
-    fn get_start(&self, _app: &App, _env: &Environment) -> StartPhase {
-        let mut phase = StartPhase::new("haunt serve");
-        phase
     }
 }

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -1486,6 +1486,4 @@ async fn test_scheme() {
     let name = simple_build("./examples/scheme").await.unwrap();
     let output = run_image(&name, None).await;
     assert!(output.contains("serving site on port 8080"));
-    // let name = simple_build("./examples/scheme").await.unwrap();
-    // assert!(run_image(&name, None).await.contains("serving site on port 8080"));
 }

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -1483,7 +1483,7 @@ async fn test_config_toml_file() {
 
 #[tokio::test]
 async fn test_scheme() {
-    let name = simple_build("./examples/haunt").await.unwrap();
+    let name = simple_build("./examples/scheme").await.unwrap();
     let output = run_image(&name, None).await;
     assert!(output.contains("serving site on port 8080"));
     // let name = simple_build("./examples/scheme").await.unwrap();

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -1484,6 +1484,5 @@ async fn test_config_toml_file() {
 #[tokio::test]
 async fn test_scheme() {
     let name = simple_build("./examples/scheme").await.unwrap();
-    let output = run_image(&name, None).await;
-    assert!(output.contains("serving site on port 8080"));
+    assert!(run_image(&name, None).await.contains("Hello from Scheme!"));
 }

--- a/tests/docker_run_tests.rs
+++ b/tests/docker_run_tests.rs
@@ -1480,3 +1480,12 @@ async fn test_config_toml_file() {
     let output = run_image(&name, None).await;
     assert!(output.contains("hey there"));
 }
+
+#[tokio::test]
+async fn test_scheme() {
+    let name = simple_build("./examples/haunt").await.unwrap();
+    let output = run_image(&name, None).await;
+    assert!(output.contains("serving site on port 8080"));
+    // let name = simple_build("./examples/scheme").await.unwrap();
+    // assert!(run_image(&name, None).await.contains("serving site on port 8080"));
+}

--- a/tests/snapshots/generate_plan_tests__scheme.snap
+++ b/tests/snapshots/generate_plan_tests__scheme.snap
@@ -1,0 +1,35 @@
+---
+source: tests/generate_plan_tests.rs
+expression: plan
+---
+{
+  "providers": [],
+  "buildImage": "[build_image]",
+  "variables": {
+    "NIXPACKS_METADATA": "scheme"
+  },
+  "phases": {
+    "build": {
+      "name": "build",
+      "dependsOn": [
+        "install",
+        "setup"
+      ],
+      "cmds": [
+        "haunt build"
+      ]
+    },
+    "setup": {
+      "name": "setup",
+      "nixPkgs": [
+        "haunt",
+        "guile"
+      ],
+      "nixOverlays": [],
+      "nixpkgsArchive": "[archive]"
+    }
+  },
+  "start": {
+    "cmd": "guile init.scm --auto-compile"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

Creates and registers a build provider for Scheme with the static builder Haunt.
Adds a very basic example to test provider.
Adds docs

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
