### PR TITLE
fix: cairo as lib and not package

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -152,12 +152,12 @@ impl PythonProvider {
             pkgs.append(&mut vec![Pkg::new("pipenv")]);
         }
 
-        if PythonProvider::uses_dep(app, "cairo")? {
-            pkgs.append(&mut vec![Pkg::new("cairo")]);
-        }
-
         let mut setup = Phase::setup(Some(pkgs));
         setup.set_nix_archive(nix_archive);
+
+        if PythonProvider::uses_dep(app, "cairo")? {
+            setup.add_pkgs_libs(vec!["cairo".to_string()]);
+        }
 
         // Many Python packages need some C headers to be available
         // stdenv.cc.cc.lib -> https://discourse.nixos.org/t/nixos-with-poetry-installed-pandas-libstdc-so-6-cannot-open-shared-object-file/8442/3


### PR DESCRIPTION
This is a follow-on from #1178. This needs to be specified as a lib otherwise it won't be picked up by python.

The strange thing I'm running into here is Cairo does not show up in the build information dump:

```
╔══════════════════════════════ Nixpacks v1.29.0 ══════════════════════════════╗
║ setup      │ python312, gcc                                                  ║
║──────────────────────────────────────────────────────────────────────────────║
║ install    │ python -m venv --copies /opt/venv && . /opt/venv/bin/activate   ║
║            │ && pip install poetry==$NIXPACKS_POETRY_VERSION && poetry       ║
║            │ install --no-dev --no-interaction --no-ansi                     ║
║──────────────────────────────────────────────────────────────────────────────║
║ start      │ python main.py                                                  ║
╚══════════════════════════════════════════════════════════════════════════════╝
```

the failing lint seems to be unrelated.