### PR TITLE
Add support for Go 1.23

### DIFF
--- a/docs/pages/docs/providers/go.md
+++ b/docs/pages/docs/providers/go.md
@@ -19,6 +19,7 @@ The following Go versions are available:
 - `1.20`
 - `1.21`
 - `1.22` (default)
+- `1.23`
 
 The version is parsed from the `go.mod` file.
 

--- a/examples/go-v123/go.mod
+++ b/examples/go-v123/go.mod
@@ -1,0 +1,3 @@
+module hello-world
+
+go 1.23

--- a/examples/go-v123/main.go
+++ b/examples/go-v123/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello from Go!")
+}

--- a/src/providers/go.rs
+++ b/src/providers/go.rs
@@ -35,7 +35,11 @@ const AVAILABLE_GO_VERSIONS: &[(&str, &str, &str)] = &[
         "1f13eabcd6f5b00fe9de9575ac52c66a0e887ce6",
     ),
     ("1.22", "go", "e89cf1c932006531f454de7d652163a9a5c86668"),
-    ("1.23", "go_1_23", "05bbf675397d5366259409139039af8077d695ce"),
+    (
+        "1.23",
+        "go_1_23",
+        "05bbf675397d5366259409139039af8077d695ce",
+    ),
 ];
 const DEFAULT_GO_PKG_NAME: &str = "go";
 const DEFAULT_ARCHIVE: &str = "e89cf1c932006531f454de7d652163a9a5c86668";

--- a/src/providers/go.rs
+++ b/src/providers/go.rs
@@ -35,6 +35,7 @@ const AVAILABLE_GO_VERSIONS: &[(&str, &str, &str)] = &[
         "1f13eabcd6f5b00fe9de9575ac52c66a0e887ce6",
     ),
     ("1.22", "go", "e89cf1c932006531f454de7d652163a9a5c86668"),
+    ("1.23", "go_1_23", "05bbf675397d5366259409139039af8077d695ce"),
 ];
 const DEFAULT_GO_PKG_NAME: &str = "go";
 const DEFAULT_ARCHIVE: &str = "e89cf1c932006531f454de7d652163a9a5c86668";

--- a/tests/snapshots/generate_plan_tests__go_v123.snap
+++ b/tests/snapshots/generate_plan_tests__go_v123.snap
@@ -1,0 +1,52 @@
+---
+source: tests/generate_plan_tests.rs
+expression: plan
+snapshot_kind: text
+---
+{
+  "providers": [],
+  "buildImage": "[build_image]",
+  "variables": {
+    "CGO_ENABLED": "0",
+    "NIXPACKS_METADATA": "go"
+  },
+  "phases": {
+    "build": {
+      "name": "build",
+      "dependsOn": [
+        "install",
+        "setup"
+      ],
+      "cmds": [
+        "go build -o out"
+      ],
+      "cacheDirectories": [
+        "/root/.cache/go-build"
+      ]
+    },
+    "install": {
+      "name": "install",
+      "dependsOn": [
+        "setup"
+      ],
+      "cmds": [
+        "go mod download"
+      ],
+      "cacheDirectories": [
+        "/root/.cache/go-build"
+      ]
+    },
+    "setup": {
+      "name": "setup",
+      "nixPkgs": [
+        "go_1_23"
+      ],
+      "nixOverlays": [],
+      "nixpkgsArchive": "[archive]"
+    }
+  },
+  "start": {
+    "cmd": "./out",
+    "runImage": "ubuntu:jammy"
+  }
+}


### PR DESCRIPTION
Closes PRO-3297.

This PR adds support for Go 1.23 and an example using the same.

Note: I have not updated the default Go version on Nixpacks as this revision points to `1.23rc1`.