### PR TITLE
feat(php): ignore multiple php extensions

### DIFF
--- a/src/providers/php/mod.rs
+++ b/src/providers/php/mod.rs
@@ -226,9 +226,11 @@ impl PhpProvider {
         let composer_json: ComposerJson = app.read_json("composer.json")?;
         let version = PhpProvider::get_php_version(app)?;
         let mut extensions = Vec::new();
+        // ext-json is included by default in PHP >= 8.0 (and not available in Nix)
+        // ext-zend-opcache is included by default in PHP >= 5.5
+        let ignored_extensions = vec!["ext-json", "ext-zend-opcache"];
         for extension in composer_json.require.keys() {
-            // ext-json is included by default in PHP >= 8.0 (and not available in Nix) so skip over it
-            if extension.starts_with("ext-") && (version == "7.4" || extension != "ext-json") {
+            if extension.starts_with("ext-") && (version == "7.4" || !ignored_extensions.contains(extension)) {
                 extensions.push(
                     extension
                         .strip_prefix("ext-")

--- a/src/providers/php/mod.rs
+++ b/src/providers/php/mod.rs
@@ -228,9 +228,11 @@ impl PhpProvider {
         let mut extensions = Vec::new();
         // ext-json is included by default in PHP >= 8.0 (and not available in Nix)
         // ext-zend-opcache is included by default in PHP >= 5.5
-        let ignored_extensions = vec!["ext-json", "ext-zend-opcache"];
+        let ignored_extensions = [String::from("ext-json"), String::from("ext-zend-opcache")];
         for extension in composer_json.require.keys() {
-            if extension.starts_with("ext-") && (version == "7.4" || !ignored_extensions.contains(extension)) {
+            if extension.starts_with("ext-")
+                && (version == "7.4" || !ignored_extensions.contains(extension))
+            {
                 extensions.push(
                     extension
                         .strip_prefix("ext-")


### PR DESCRIPTION
Hi team!

I tried running a PHP Laravel application with nixpacks. In our `composer.json` we have `"ext-zend-opcache": "*"`, which causes the following error in nixpacks:

```
#8 77.02        error: attribute 'zend-opcache' missing
#8 77.02        at /app/.nixpacks/nixpkgs-dbc4f15b899ac77a8d408d8e0f89fa9c0c5f2b78.nix:6:91:
#8 77.02             5|   let
#8 77.02             6|     APPEND_LIBRARY_PATH = "${lib.makeLibraryPath [ libmysqlclient phpExtensions.simplexml phpExtensions.zend-opcache phpExtensions.zip ] }";
#8 77.02              |                                                                                           ^
#8 77.02             7|     myLibraries = writeText "libraries" ''
```

Since the `zend-opcache` extension is [included in PHP since 5.5](https://www.php.net/releases/5_5_0.php), I figured this might be why this exception occurs, and also why it's not included in nix? I could at least not find anything about it in your docs.

Anyways, Rust is new to me, so if the code is incorrect or not up to your standards, don't hesitate to let me know!