### PR TITLE
Fix #1241: nixpack plan generates an invalid toml file ...

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -86,7 +86,6 @@ impl Provider for PythonProvider {
                 if let Some(poetry_version) =
                     PythonProvider::parse_tool_versions_poetry_version(file_content)?
                 {
-                    println!("Using poetry version from .tool-versions: {poetry_version}");
                     version = poetry_version;
                 }
             }
@@ -114,7 +113,6 @@ impl Provider for PythonProvider {
                 if let Some(uv_version) =
                     PythonProvider::parse_tool_versions_uv_version(file_content)?
                 {
-                    println!("Using uv version from .tool-versions: {uv_version}");
                     version = uv_version;
                 }
             }


### PR DESCRIPTION
See #1241 nixpack plan generates an invalid toml file for python projects containing a .tool-versions file.

I assume that outputting those lines before the toml or json file is not intended. If it is then please ignore this commit.

Another option might be to print these messages to stderr instead?