### PR TITLE
Add support for bun.lock

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -362,7 +362,7 @@ impl NodeProvider {
             pkg_manager = "pnpm";
         } else if app.includes_file("yarn.lock") {
             pkg_manager = "yarn";
-        } else if app.includes_file("bun.lockb") {
+        } else if app.includes_file("bun.lockb") || app.includes_file("bun.lock") {
             pkg_manager = "bun";
         }
         pkg_manager.to_string()
@@ -397,7 +397,7 @@ impl NodeProvider {
             }
         } else if app.includes_file("package-lock.json") {
             install_cmd = "npm ci".to_string();
-        } else if app.includes_file("bun.lockb") {
+        } else if app.includes_file("bun.lockb") || app.includes_file("bun.lock") {
             install_cmd = "bun i --no-save".to_string();
         }
 


### PR DESCRIPTION
This PR adds support for Bun's new text lockfile `bun.lock`.

Bun v1.39 added a new text based lockfile format, without this change, apps using this new format will be detected as using npm instead of bun.

PR: https://github.com/oven-sh/bun/issues/11863
More info: https://bun.sh/blog/bun-lock-text-lockfile
