### PR TITLE
fix phoenix/elixir recipe

### DIFF
--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -148,7 +148,7 @@ impl DockerfileGenerator for BuildPlan {
                 // Pull the variables in from docker `--build-arg`
                 variables
                     .iter()
-                    .map(|var| var.0.to_string())
+                    .map(|var| format!("{}=\"{}\"", var.0.trim(), var.1.trim()))
                     .collect::<Vec<_>>()
                     .join(" "),
                 // Make the variables available at runtime

--- a/src/nixpacks/builder/docker/dockerfile_generation.rs
+++ b/src/nixpacks/builder/docker/dockerfile_generation.rs
@@ -361,12 +361,19 @@ impl DockerfileGenerator for StartPhase {
                 start_cmd=start_cmd,}
             }
             None => {
+                // Copy over app files if provided, otherwise copy all files
+                let copy_cmds = match &self.only_include_files {
+                    Some(files) => utils::get_copy_commands(&files.clone(), APP_DIR).join("\n"),
+                    None => "COPY . /app".to_string(),
+                };
+
                 formatdoc! {"
                   # start
-                  COPY . /app
+                  {copy_cmds}
                   {user_str}
                   {start_cmd}
                 ",
+                copy_cmds=copy_cmds,
                 start_cmd=start_cmd,
                 user_str=user_str}
             }

--- a/src/providers/elixir.rs
+++ b/src/providers/elixir.rs
@@ -45,7 +45,7 @@ impl Provider for ElixirProvider {
             build_phase.add_cmd("mix assets.deploy".to_string());
         }
 
-        if mix_exs_content.contains("postgrex") && mix_exs_content.contains("ecto") {
+        if mix_exs_content.contains("ecto_sql") && mix_exs_content.contains("ecto") {
             build_phase.add_cmd("mix ecto.setup");
         }
 

--- a/src/providers/elixir.rs
+++ b/src/providers/elixir.rs
@@ -32,15 +32,14 @@ impl Provider for ElixirProvider {
         plan.add_phase(setup);
 
         // Install Phase
-        let mut install_phase =
-            Phase::install(Some("MIX_ENV=prod mix local.hex --force".to_string()));
+        let mut install_phase = Phase::install(Some("mix local.hex --force".to_string()));
         install_phase.only_include_files = Some(vec![
             "config/config.exs".to_string(),
-            "config/prod.exs".to_string(),
+            "config/${MIX_ENV}.exs".to_string(),
             "mix.exs".to_string(),
             "mix.lock".to_string(),
         ]);
-        install_phase.add_cmd("MIX_ENV=prod mix local.rebar --force");
+        install_phase.add_cmd("mix local.rebar --force");
         install_phase.add_cmd("mix deps.get --only prod");
         plan.add_phase(install_phase);
 

--- a/src/providers/gleam/mod.rs
+++ b/src/providers/gleam/mod.rs
@@ -96,8 +96,6 @@ impl GleamProvider {
     }
 
     fn get_start(&self, _app: &App, _env: &Environment) -> StartPhase {
-        let mut phase = StartPhase::new("./build/erlang-shipment/entrypoint.sh run");
-        phase.only_include_files = Some(vec!["build/erlang-shipment".into()]);
-        phase
+        StartPhase::new("./build/erlang-shipment/entrypoint.sh run")
     }
 }

--- a/tests/snapshots/generate_plan_tests__basic_gleam.snap
+++ b/tests/snapshots/generate_plan_tests__basic_gleam.snap
@@ -49,9 +49,6 @@ expression: plan
     }
   },
   "start": {
-    "cmd": "./build/erlang-shipment/entrypoint.sh run",
-    "onlyIncludeFiles": [
-      "build/erlang-shipment"
-    ]
+    "cmd": "./build/erlang-shipment/entrypoint.sh run"
   }
 }

--- a/tests/snapshots/generate_plan_tests__elixir_ecto.snap
+++ b/tests/snapshots/generate_plan_tests__elixir_ecto.snap
@@ -8,6 +8,8 @@ snapshot_kind: text
   "buildImage": "[build_image]",
   "variables": {
     "ELIXIR_ERL_OPTIONS": "+fnu",
+    "LANG": "en_US.UTF-8",
+    "LANGUAGE": "en_US:en",
     "MIX_ENV": "prod",
     "NIXPACKS_METADATA": "elixir"
   },
@@ -18,8 +20,14 @@ snapshot_kind: text
         "install"
       ],
       "cmds": [
-        "mix compile",
-        "mix ecto.setup"
+        "mix compile"
+      ],
+      "onlyIncludeFiles": [
+        "config/runtime.exs",
+        "assets",
+        "priv",
+        "config",
+        "lib"
       ]
     },
     "install": {
@@ -28,9 +36,15 @@ snapshot_kind: text
         "setup"
       ],
       "cmds": [
-        "mix local.hex --force",
-        "mix local.rebar --force",
+        "MIX_ENV=prod mix local.hex --force",
+        "MIX_ENV=prod mix local.rebar --force",
         "mix deps.get --only prod"
+      ],
+      "onlyIncludeFiles": [
+        "config/config.exs",
+        "config/prod.exs",
+        "mix.exs",
+        "mix.lock"
       ]
     },
     "setup": {
@@ -47,6 +61,7 @@ snapshot_kind: text
     }
   },
   "start": {
-    "cmd": "mix phx.server"
+    "cmd": "mix ecto.setup && mix phx.server",
+    "onlyIncludeFiles": []
   }
 }

--- a/tests/snapshots/generate_plan_tests__elixir_ecto.snap
+++ b/tests/snapshots/generate_plan_tests__elixir_ecto.snap
@@ -36,13 +36,13 @@ snapshot_kind: text
         "setup"
       ],
       "cmds": [
-        "MIX_ENV=prod mix local.hex --force",
-        "MIX_ENV=prod mix local.rebar --force",
+        "mix local.hex --force",
+        "mix local.rebar --force",
         "mix deps.get --only prod"
       ],
       "onlyIncludeFiles": [
         "config/config.exs",
-        "config/prod.exs",
+        "config/${MIX_ENV}.exs",
         "mix.exs",
         "mix.lock"
       ]

--- a/tests/snapshots/generate_plan_tests__elixir_phx_no_ecto.snap
+++ b/tests/snapshots/generate_plan_tests__elixir_phx_no_ecto.snap
@@ -7,6 +7,8 @@ expression: plan
   "buildImage": "[build_image]",
   "variables": {
     "ELIXIR_ERL_OPTIONS": "+fnu",
+    "LANG": "en_US.UTF-8",
+    "LANGUAGE": "en_US:en",
     "MIX_ENV": "prod",
     "NIXPACKS_METADATA": "elixir"
   },
@@ -17,8 +19,14 @@ expression: plan
         "install"
       ],
       "cmds": [
-        "mix compile",
-        "mix assets.deploy"
+        "mix compile"
+      ],
+      "onlyIncludeFiles": [
+        "config/runtime.exs",
+        "assets",
+        "priv",
+        "config",
+        "lib"
       ]
     },
     "install": {
@@ -27,9 +35,15 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "mix local.hex --force",
-        "mix local.rebar --force",
+        "MIX_ENV=prod mix local.hex --force",
+        "MIX_ENV=prod mix local.rebar --force",
         "mix deps.get --only prod"
+      ],
+      "onlyIncludeFiles": [
+        "config/config.exs",
+        "config/prod.exs",
+        "mix.exs",
+        "mix.lock"
       ]
     },
     "setup": {
@@ -46,6 +60,7 @@ expression: plan
     }
   },
   "start": {
-    "cmd": "mix phx.server"
+    "cmd": "mix phx.server",
+    "onlyIncludeFiles": []
   }
 }

--- a/tests/snapshots/generate_plan_tests__elixir_phx_no_ecto.snap
+++ b/tests/snapshots/generate_plan_tests__elixir_phx_no_ecto.snap
@@ -19,7 +19,8 @@ expression: plan
         "install"
       ],
       "cmds": [
-        "mix compile"
+        "mix compile",
+        "mix assets.deploy"
       ],
       "onlyIncludeFiles": [
         "config/runtime.exs",
@@ -35,13 +36,13 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "MIX_ENV=prod mix local.hex --force",
-        "MIX_ENV=prod mix local.rebar --force",
+        "mix local.hex --force",
+        "mix local.rebar --force",
         "mix deps.get --only prod"
       ],
       "onlyIncludeFiles": [
         "config/config.exs",
-        "config/prod.exs",
+        "config/${MIX_ENV}.exs",
         "mix.exs",
         "mix.lock"
       ]


### PR DESCRIPTION
# Summary

- :one: Lock file problem when deploying a Phoenix Elixir app
- :two: Improvements for the Phoenix/Elixir deploying recipe
- :three: Fixes issue with copied files for the start phase
-  :three: Fixes issue with default values for ARGS in the docker file

:wave: **the FINAL dockerfile output is in the reference section** ⬇️ 

## :one: Lock file problem

When deploying a Phoenix Elixir app to Railway there is a conflict with the lock file that cause the error: ` lock outdated: the lock is outdated compared to the options in your mix.exs`[1]. This is because the we're copying too many files during multiple phases. The solution is to update the elixir dockerfile builder to only copy specific files. 

https://elixirforum.com/t/docker-build-started-failing-unchecked-dependencies-for-environment-prod/28844/6

The [Railway template for phoenix](https://github.com/railwayapp-templates/phoenix) got around this problem by removing the lock file, which is not behaviour we want. 

## :two: General updates to the Elixir build

- run `mix ecto.setup` if ecto_sql is detected rather than postgrex
   - postgrex is a postgres specific adapter, but there are other adapters (for mysql, etc). detecting `ecto_sql` is more generic
- only copy the necessary folders and assets
- build hex, rebar, and other deps using `MIX_ENV=prod`

### Future considerations

The way we run elixir is with `mix phx.server` but actually creating a `mix release` is the better approach (it creates a binary that can be run). [More details here about why release are better](https://hexdocs.pm/mix/Mix.Tasks.Release.html#module-why-releases). In the future, we should move away from `mix phx.server` and use releases instead, but it's beyond the scope of this PR. [Here's an example of an Elixir dockerfile that uses releases](https://github.com/superfly/flyctl/blob/2e7e50db83543036a920499d6dba43b93fb4f085/scanner/templates/phoenix/Dockerfile#L96).

## :three: Other fixes

- Issue: setting `only_include_files` in the start phase was ignored. Instead `COPY . /app` was always added to the generated dockerfile
   - ✅  if `only_include_files` is set in the start phase, use it
- Issue: default environment values aren't set in the Dockerfile
  - ✅ set default values for docker ARGs. Example output: `ARG ELIXIR_ERL_OPTIONS="+fnu" LANG="en_US.UTF-8" LANGUAGE="en_US:en" MIX_ENV="prod" NIXPACKS_METADATA="elixir"`  

## References

### [1] Lock file problem

```
[+] Building 113.3s (15/18)                                                 docker:orbstack
 => [internal] load build definition from Dockerfile                                   0.0s
 => => transferring dockerfile: 858B                                                   0.0s
 => [internal] load metadata for ghcr.io/railwayapp/nixpacks:ubuntu-1733184274         0.9s
 => [internal] load .dockerignore                                                      0.0s
 => => transferring context: 2B                                                        0.0s
 => [ 1/14] FROM ghcr.io/railwayapp/nixpacks:ubuntu-1733184274@sha256:91b1c0ad82b8a7a  0.0s
 => [internal] load build context                                                      0.6s
 => => transferring context: 82.02MB                                                   0.5s
 => CACHED [ 2/14] WORKDIR /app/                                                       0.0s
 => CACHED [ 3/14] COPY .nixpacks/nixpkgs-c5702bd28cbde41a191a9c2a00501f18941efbd0.ni  0.0s
 => [ 4/14] RUN nix-env -if .nixpacks/nixpkgs-c5702bd28cbde41a191a9c2a00501f18941ef  102.7s
 => [ 5/14] COPY . /app/.                                                              0.9s
 => [ 6/14] RUN  mix local.hex --force                                                 2.0s
 => [ 7/14] RUN  echo test                                                             0.2s
 => [ 8/14] RUN  mix local.rebar --force                                               1.7s
 => [ 9/14] RUN  mix deps.get --only prod                                              2.5s
 => [10/14] COPY . /app/.                                                              1.1s
 => ERROR [11/14] RUN  mix compile                                                     0.4s
------
 > [11/14] RUN  mix compile:
0.382 Unchecked dependencies for environment prod:
0.382 * heroicons (https://github.com/tailwindlabs/heroicons.git - v2.1.1)
0.382   lock outdated: the lock is outdated compared to the options in your mix.exs. To fetch locked version run "mix deps.get"
0.384 ** (Mix) Can't continue due to errors on dependencies
------
Dockerfile:26
--------------------
  24 |     # build phase
  25 |     COPY . /app/.
  26 | >>> RUN  mix compile
  27 |     RUN  mix assets.deploy
  28 |     RUN  mix ecto.setup
--------------------
ERROR: failed to solve: process "/bin/bash -ol pipefail -c mix compile" did not complete successfully: exit code: 1

View build details: docker-desktop://dashboard/build/orbstack/orbstack/uxra2k6hpddi2mzjzo7r97fjr
Error: Docker build failed
```

### [2] Final Dockerfile

output of `nixpacks build --dockerfile .` on a phoenix elixir project that uses a database:

```
FROM ghcr.io/railwayapp/nixpacks:ubuntu-1733184274

ENTRYPOINT ["/bin/bash", "-l", "-c"]
WORKDIR /app/


COPY .nixpacks/nixpkgs-c5702bd28cbde41a191a9c2a00501f18941efbd0.nix .nixpacks/nixpkgs-c5702bd28cbde41a191a9c2a00501f18941efbd0.nix
RUN nix-env -if .nixpacks/nixpkgs-c5702bd28cbde41a191a9c2a00501f18941efbd0.nix && nix-collect-garbage -d


ARG ELIXIR_ERL_OPTIONS="+fnu" LANG="en_US.UTF-8" LANGUAGE="en_US:en" MIX_ENV="prod" NIXPACKS_METADATA="elixir"
ENV ELIXIR_ERL_OPTIONS=$ELIXIR_ERL_OPTIONS LANG=$LANG LANGUAGE=$LANGUAGE MIX_ENV=$MIX_ENV NIXPACKS_METADATA=$NIXPACKS_METADATA

# setup phase
# noop

# install phase
COPY config/config.exs /app/config/config.exs
COPY config/${MIX_ENV}.exs /app/config/${MIX_ENV}.exs
COPY mix.exs /app/mix.exs
COPY mix.lock /app/mix.lock
RUN  mix local.hex --force
RUN  mix local.rebar --force
RUN  mix deps.get --only prod

# build phase
COPY config/runtime.exs /app/config/runtime.exs
COPY assets /app/assets
COPY priv /app/priv
COPY config /app/config
COPY lib /app/lib
RUN  mix compile
RUN  mix assets.deploy





# start


CMD ["mix ecto.setup && mix phx.server"]
```
