### PR TITLE
Select latest lts node version

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -634,9 +634,14 @@ fn parse_node_version_into_pkg(node_version: &str) -> String {
         eprintln!("Warning: node version {node_version} is not valid, using default node version {default_node_pkg_name}");
         Range::parse(DEFAULT_NODE_VERSION.to_string()).unwrap()
     });
-    let mut available_node_versions = AVAILABLE_NODE_VERSIONS.to_vec();
+    let mut available_lts_node_versions = AVAILABLE_NODE_VERSIONS
+        .to_vec()
+        .iter()
+        .filter(|v| v % 2 == 0)
+        .collect::<Vec<_>>();
+
     // use newest node version first
-    available_node_versions.sort_by(|a, b| b.cmp(a));
+    available_lts_node_versions.sort_by(|a, b| b.cmp(a));
     for version_number in available_node_versions {
         let version_range_string = format!("{version_number}.x.x");
         let version_range: Range = version_range_string.parse().unwrap();

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -635,18 +635,17 @@ fn parse_node_version_into_pkg(node_version: &str) -> String {
         Range::parse(DEFAULT_NODE_VERSION.to_string()).unwrap()
     });
     let mut available_lts_node_versions = AVAILABLE_NODE_VERSIONS
-        .to_vec()
         .iter()
-        .filter(|v| v % 2 == 0)
+        .filter(|v| *v % 2 == 0)
         .collect::<Vec<_>>();
 
     // use newest node version first
     available_lts_node_versions.sort_by(|a, b| b.cmp(a));
-    for version_number in available_node_versions {
+    for version_number in available_lts_node_versions {
         let version_range_string = format!("{version_number}.x.x");
         let version_range: Range = version_range_string.parse().unwrap();
         if version_range.allows_any(&range) {
-            return version_number_to_pkg(version_number);
+            return version_number_to_pkg(*version_number);
         }
     }
     default_node_pkg_name
@@ -721,6 +720,24 @@ mod test {
                 &Environment::default()
             )?,
             Pkg::new(version_number_to_pkg(DEFAULT_NODE_VERSION).as_str())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_latest_lts_version() -> Result<()> {
+        assert_eq!(
+            NodeProvider::get_nix_node_pkg(
+                &PackageJson {
+                    name: Some(String::default()),
+                    engines: Some(engines_node(">=18")),
+                    ..Default::default()
+                },
+                &App::new("examples/node")?,
+                &Environment::default()
+            )?,
+            Pkg::new(version_number_to_pkg(22).as_str())
         );
 
         Ok(())

--- a/tests/snapshots/generate_plan_tests__node_pnpm_corepack.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_corepack.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_plan_tests.rs
 expression: plan
-snapshot_kind: text
 ---
 {
   "providers": [],
@@ -44,7 +43,7 @@ snapshot_kind: text
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_23",
+        "nodejs_22",
         "pnpm-9_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_turborepo.snap
+++ b/tests/snapshots/generate_plan_tests__node_turborepo.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_plan_tests.rs
 expression: plan
-snapshot_kind: text
 ---
 {
   "providers": [],
@@ -45,7 +44,7 @@ snapshot_kind: text
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_23",
+        "nodejs_22",
         "npm-8_x"
       ],
       "nixOverlays": [


### PR DESCRIPTION
When selecting a node version when we find a range in the `package.json` file, we should only select LTS versions (even version numbers).
