### PR TITLE
Allowing "tasks" instead of only allowing "pipeline" in turbo.json

### DIFF
--- a/src/providers/node/turborepo.rs
+++ b/src/providers/node/turborepo.rs
@@ -13,7 +13,10 @@ use super::{NodeProvider, PackageJson};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TurboJson {
+    #[serde(default)]
     pub pipeline: HashMap<String, Value>,
+    #[serde(default)]
+    pub tasks: HashMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -39,7 +42,7 @@ impl Turborepo {
     }
 
     fn get_pipeline_cmd(cfg: &TurboJson, name: &str) -> Option<String> {
-        if cfg.pipeline.contains_key(name) {
+        if cfg.pipeline.contains_key(name) || cfg.tasks.contains_key(name) {
             Some(format!("npx turbo run {name}"))
         } else {
             None

--- a/tests/snapshots/generate_plan_tests__node_pnpm_monorepo.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_monorepo.snap
@@ -1,0 +1,57 @@
+---
+source: tests/generate_plan_tests.rs
+expression: plan
+---
+{
+  "providers": [],
+  "buildImage": "[build_image]",
+  "variables": {
+    "CI": "true",
+    "NIXPACKS_METADATA": "node",
+    "NODE_ENV": "production",
+    "NPM_CONFIG_PRODUCTION": "false"
+  },
+  "phases": {
+    "build": {
+      "name": "build",
+      "dependsOn": [
+        "install"
+      ],
+      "cmds": [
+        "pnpm run build"
+      ],
+      "cacheDirectories": [
+        "apps/docs/.next/cache",
+        "apps/web/.next/cache",
+        "node_modules/.cache"
+      ]
+    },
+    "install": {
+      "name": "install",
+      "dependsOn": [
+        "setup"
+      ],
+      "cmds": [
+        "npm install -g corepack@0.24.1 && corepack enable",
+        "pnpm i --frozen-lockfile"
+      ],
+      "cacheDirectories": [
+        "/root/.local/share/pnpm/store/v3"
+      ],
+      "paths": [
+        "/app/node_modules/.bin"
+      ]
+    },
+    "setup": {
+      "name": "setup",
+      "nixPkgs": [
+        "nodejs_22",
+        "pnpm-9_x"
+      ],
+      "nixOverlays": [
+        "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
+      ],
+      "nixpkgsArchive": "[archive]"
+    }
+  }
+}


### PR DESCRIPTION
### Issue Description

**Nixpacks does not support `turbo` versions >= 1.7**. Specifically, `turborepo.rs` attempts to read `turbo.json` and looks for the `"pipeline"` key, but `turbo` versions 1.7 and above use the `"tasks"` key instead. This mismatch results in Nixpacks failing silently and throwing an error like "start command not found," without clearly indicating the underlying issue.

Additionally, the documentation does not explicitly state that only `turbo` versions < 1.7 are supported.

---

### Possible Solutions

1. **Downgrade `turbo` to v1.6**: This is a temporary workaround, but it’s not ideal for users who rely on newer `turbo` features.
2. **Add support for the `"tasks"` key in this repository**: This would involve updating the code to handle `turbo` versions >= 1.7. However, it’s unclear whether this change only requires supporting the new JSON key or if additional implementation is needed to fully support newer `turbo` versions.

---

### Proposed Fix

This PR implements **Solution 2** by adding support for the `"tasks"` key in `turborepo.rs`. This ensures compatibility with `turbo` versions >= 1.7 while maintaining backward compatibility with older versions. The changes include:

- Updating the JSON parsing logic to check for both `"pipeline"` and `"tasks"` keys.
- Ensuring the build process correctly identifies and uses the appropriate commands from `turbo.json`.
