### PR TITLE
Revert "docs: clarify environment variable setting for Node provider (#1251)"

### DIFF
--- a/docs/pages/docs/providers/node.md
+++ b/docs/pages/docs/providers/node.md
@@ -8,7 +8,7 @@ The Node provider supports NPM, Yarn, Yarn 2, PNPM and Bun.
 
 ## Environment Variables
 
-The Node provider sets the following environment variables when the container is running (not during build):
+The Node provider sets the following environment variables:
 
 - `CI=true`
 - `NODE_ENV=production`


### PR DESCRIPTION
This reverts commit 7653b2f1a8b7c4532adb51d1c8f7f20cbd26386c.

The "clarification" is misinformed. Env vars are set before the build phases in the Dockerfile:
https://github.com/railwayapp/nixpacks/blob/2e3090bbbd85dd9f1c2b96c8d932311d0e7efea8/src/nixpacks/builder/docker/dockerfile_generation.rs#L222-L235
As is correctly stated in the CLI reference:
https://github.com/railwayapp/nixpacks/blob/2f5bbf818cf28db2b47697d6cdea8782f0f1b6ea/docs/pages/docs/cli.md?plain=1#L33