### PR TITLE
refactor(providers): specify `NIXPACKS_PYTHON_PACKAGE_MANAGER`

### DIFF
--- a/docs/pages/docs/providers/python.md
+++ b/docs/pages/docs/providers/python.md
@@ -38,41 +38,59 @@ You also specify the exact poetry, pdm, and uv versions:
 - The `NIXPACKS_PDM_VERSION` environment variable
 - The `NIXPACKS_UV_VERSION` environment variable or `uv` in a `.tool-versions` file
 
+You can specify a particular package manager, to override the lockfile-based choice, by setting the
+`NIXPACKS_PYTHON_PACKAGE_MANAGER` environment variable to one of the following:
+
+- `auto` to choose based on the available lockfiles (default)
+- `requirements` to install using `pip` from `requirements.txt`
+- `setuptools` to install using `pip` with `build` and `setuptools`
+- `poetry` to install using `poetry` from `poetry.lock`
+- `pdm` to install using `pdm` from `pdm.lock`
+- `uv` to install using `uv` from `uv.lock`
+- `pipenv` to install with `pipenv` from `Pipfile` (if a `Pipfile.lock` is present it will be used)
+- `skip` to not install a package
+
 ## Install
 
 If `requirements.txt`
 
-```
+```shell
 pip install -r requirements.txt
 ```
 
 If `pyproject.toml`
 
-```
+```shell
 pip install --upgrade build setuptools && pip install .
 ```
 
 If `pyproject.toml` (w/ `poetry.lock`)
 
-```
+```shell
 poetry install --no-dev --no-interactive --no-ansi
 ```
 
 If `pyproject.toml` (w/ `pdm.lock`)
 
-```
+```shell
 pdm install --prod
 ```
 
 If `Pipfile` (w/ `Pipfile.lock`)
 
-```
+```shell
 PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy
+```
+
+If `Pipfile` (without `Pipfile.lock`)
+
+```shell
+PIPENV_VENV_IN_PROJECT=1 pipenv install --skip-lock
 ```
 
 if `uv.lock`:
 
-```
+```shell
 uv sync --no-dev --frozen
 ```
 
@@ -80,19 +98,19 @@ uv sync --no-dev --frozen
 
 if Django Application
 
-```
+```shell
 python manage.py migrate && gunicorn {app_name}.wsgi
 ```
 
 if `pyproject.toml`
 
-```
+```shell
 python -m {module}
 ```
 
 Otherwise
 
-```
+```shell
 python main.py
 ```
 

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -69,9 +69,7 @@ impl PackageManager {
                 "pipenv" => Self::Specified(PackageManagerType::Pipenv),
                 "skip" => Self::Skip,
                 _ => {
-                    eprintln!(
-                        "Warning: Unknown package manager '{s}'. Using auto-detection.",
-                    );
+                    eprintln!("Warning: Unknown package manager '{s}'. Using auto-detection.",);
                     Self::Auto
                 }
             })

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -59,7 +59,7 @@ enum PackageManager {
 impl PackageManager {
     fn from_env(env: &Environment) -> Self {
         env.get_config_variable("PYTHON_PACKAGE_MANAGER")
-            .map(|s| match s.to_lowercase().as_str() {
+            .map_or(Self::Auto, |s| match s.to_lowercase().as_str() {
                 "auto" => Self::Auto,
                 "requirements" => Self::Specified(PackageManagerType::PipReqs),
                 "setuptools" => Self::Specified(PackageManagerType::PipSetuptools),
@@ -70,16 +70,14 @@ impl PackageManager {
                 "skip" => Self::Skip,
                 _ => {
                     eprintln!(
-                        "Warning: Unknown package manager '{}'. Using auto-detection.",
-                        s
+                        "Warning: Unknown package manager '{s}'. Using auto-detection.",
                     );
                     Self::Auto
                 }
             })
-            .unwrap_or(Self::Auto)
     }
 
-    fn resolve(&self, app: &App) -> Action {
+    fn resolve(self, app: &App) -> Action {
         match self {
             // Auto-detect package manager if not explicitly specified
             Self::Auto => {
@@ -101,7 +99,7 @@ impl PackageManager {
                     Action::NoInstallation // Default fallback
                 }
             }
-            Self::Specified(manager) => Action::InstallWith(*manager),
+            Self::Specified(manager) => Action::InstallWith(manager),
             Self::Skip => Action::NoInstallation,
         }
     }

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -58,7 +58,7 @@ enum PackageManager {
 
 impl PackageManager {
     fn from_env(env: &Environment) -> Self {
-        env.get_config_variable("NIXPACKS_PYTHON_PACKAGE_MANAGER")
+        env.get_config_variable("PYTHON_PACKAGE_MANAGER")
             .map(|s| match s.to_lowercase().as_str() {
                 "auto" => Self::Auto,
                 "requirements" => Self::Specified(PackageManagerType::PipReqs),

--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -275,7 +275,8 @@ impl PythonProvider {
         // Create the installation phase based on the determined package manager
         match effective_manager {
             PackageManager::PipReqs => {
-                let install_cmd = format!("{create_env} && {activate_env} && pip install -r requirements.txt");
+                let install_cmd =
+                    format!("{create_env} && {activate_env} && pip install -r requirements.txt");
                 let mut install_phase = Phase::install(Some(install_cmd));
 
                 install_phase.add_path(format!("{VENV_LOCATION}/bin"));
@@ -359,9 +360,7 @@ impl PythonProvider {
                 Ok(Some(install_phase))
             }
 
-            PackageManager::Skip => {
-                Ok(Some(Phase::install(None)))
-            }
+            PackageManager::Skip => Ok(Some(Phase::install(None))),
         }
     }
 
@@ -779,6 +778,81 @@ mod test {
             &Environment::new(BTreeMap::new())
         )
         .unwrap());
+        Ok(())
+    }
+
+    #[test]
+    fn test_package_manager_from_env() -> Result<()> {
+        assert_eq!(
+            PackageManager::from_env(&Environment::default()),
+            PackageManager::Auto
+        );
+
+        assert_eq!(
+            PackageManager::from_env(&Environment::new(BTreeMap::from([(
+                "NIXPACKS_PYTHON_PACKAGE_MANAGER".to_string(),
+                "poetry".to_string()
+            )]))),
+            PackageManager::Poetry
+        );
+
+        assert_eq!(
+            PackageManager::from_env(&Environment::new(BTreeMap::from([(
+                "NIXPACKS_PYTHON_PACKAGE_MANAGER".to_string(),
+                "requirements".to_string()
+            )]))),
+            PackageManager::PipReqs
+        );
+
+        assert_eq!(
+            PackageManager::from_env(&Environment::new(BTreeMap::from([(
+                "NIXPACKS_PYTHON_PACKAGE_MANAGER".to_string(),
+                "setuptools".to_string()
+            )]))),
+            PackageManager::PipSetuptools
+        );
+
+        assert_eq!(
+            PackageManager::from_env(&Environment::new(BTreeMap::from([(
+                "NIXPACKS_PYTHON_PACKAGE_MANAGER".to_string(),
+                "pdm".to_string()
+            )]))),
+            PackageManager::Pdm
+        );
+
+        assert_eq!(
+            PackageManager::from_env(&Environment::new(BTreeMap::from([(
+                "NIXPACKS_PYTHON_PACKAGE_MANAGER".to_string(),
+                "uv".to_string()
+            )]))),
+            PackageManager::Uv
+        );
+
+        assert_eq!(
+            PackageManager::from_env(&Environment::new(BTreeMap::from([(
+                "NIXPACKS_PYTHON_PACKAGE_MANAGER".to_string(),
+                "pipenv".to_string()
+            )]))),
+            PackageManager::Pipenv
+        );
+
+        assert_eq!(
+            PackageManager::from_env(&Environment::new(BTreeMap::from([(
+                "NIXPACKS_PYTHON_PACKAGE_MANAGER".to_string(),
+                "skip".to_string()
+            )]))),
+            PackageManager::Skip
+        );
+
+        // Test unknown package manager falls back to Auto
+        assert_eq!(
+            PackageManager::from_env(&Environment::new(BTreeMap::from([(
+                "NIXPACKS_PYTHON_PACKAGE_MANAGER".to_string(),
+                "unknown".to_string()
+            )]))),
+            PackageManager::Auto
+        );
+
         Ok(())
     }
 }


### PR DESCRIPTION
This PR refactors the Python rewrite package manager choice logic using an enum to make the decision tree explicitly clear, and thus also to allow a particular branch to be specified in config

- Motivated by a wish (#1301) to allow for the case where a Python project may have multiple valid lock files, and to override the default preference, e.g. to reverse the default of `Poetry.lock` > `uv.lock`

## Tasks

- refactors the Python providers module taking care to preserve the exact pre-existing behaviour (so no existing projects will choose a different package manager to install from)
- [x] Tests are added/updated
  - Unit tests to correctly resolve config variable for `NIXPACKS_PYTHON_PACKAGE_MANAGER` as "poetry", "uv", etc.
- [x] Docs are updated