### PR TITLE
add back missing env vars to base images

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -31,4 +31,7 @@ ENV \
   NIXPKGS_ALLOW_BROKEN=1 \
   NIXPKGS_ALLOW_UNFREE=1 \
   NIXPKGS_ALLOW_INSECURE=1 \
-  LD_LIBRARY_PATH=/usr/lib
+  LD_LIBRARY_PATH=/usr/lib \
+  CPATH=~/.nix-profile/include:$CPATH \
+  LIBRARY_PATH=~/.nix-profile/lib:$LIBRARY_PATH \
+  QTDIR=~/.nix-profile:$QTDIR

--- a/base/ubuntu/Dockerfile
+++ b/base/ubuntu/Dockerfile
@@ -31,4 +31,7 @@ ENV \
   NIXPKGS_ALLOW_BROKEN=1 \
   NIXPKGS_ALLOW_UNFREE=1 \
   NIXPKGS_ALLOW_INSECURE=1 \
-  LD_LIBRARY_PATH=/usr/lib
+  LD_LIBRARY_PATH=/usr/lib \
+  CPATH=~/.nix-profile/include:$CPATH \
+  LIBRARY_PATH=~/.nix-profile/lib:$LIBRARY_PATH \
+  QTDIR=~/.nix-profile:$QTDIR


### PR DESCRIPTION
These were removed in this PR https://github.com/railwayapp/nixpacks/pull/1314/files
