### PR TITLE
Allow multiple docker output options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ result
 .vscode/
 
 .vstags
+
+.idea/

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,10 +154,10 @@ enum Commands {
         #[arg(long)]
         docker_tls_verify: Option<String>,
 
-        /// Specify output destination for Docker build.
+        /// Specify output destinations for Docker build.
         /// https://docs.docker.com/reference/cli/docker/buildx/build/#output
         #[arg(long)]
-        docker_output: Option<String>,
+        docker_output: Vec<String>,
 
         /// Specify the path to the Docker client certificates
         #[arg(long)]

--- a/src/nixpacks/builder/docker/docker_image_builder.rs
+++ b/src/nixpacks/builder/docker/docker_image_builder.rs
@@ -178,8 +178,10 @@ impl DockerImageBuilder {
             docker_build_cmd.arg("--cache-from").arg(value);
         }
 
-        if let Some(value) = &self.options.docker_output {
-            docker_build_cmd.arg("--output").arg(value);
+        if !self.options.docker_output.is_empty() {
+            for output in &self.options.docker_output {
+                docker_build_cmd.arg("--output").arg(output);
+            }
         }
 
         if let Some(value) = &self.options.docker_host {

--- a/src/nixpacks/builder/docker/mod.rs
+++ b/src/nixpacks/builder/docker/mod.rs
@@ -23,7 +23,7 @@ pub struct DockerBuilderOptions {
     pub verbose: bool,
     pub docker_host: Option<String>,
     pub docker_tls_verify: Option<String>,
-    pub docker_output: Option<String>,
+    pub docker_output: Vec<String>,
     pub add_host: Vec<String>,
     pub docker_cert_path: Option<String>,
 }


### PR DESCRIPTION
Change the --docker-output flag to accept multiple values so you can pass multiple --output flags to the underlying docker build command.

PR Checklist
- [X] Flag is not documented, so no need to update docs
