### PR TITLE
ci: remove deprecated use and narrow perms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -50,6 +52,8 @@ jobs:
 
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -92,6 +96,8 @@ jobs:
 
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -130,6 +136,8 @@ jobs:
 
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -169,6 +177,8 @@ jobs:
 
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install 1.60 rust toolchain
         uses: actions-rs/toolchain@v1
@@ -197,6 +207,8 @@ jobs:
 
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         # generate list of tests in json format for test-docker
         run: |
-          echo "::set-output name=matrix::{\"tests\":[\"$(cargo test -q --package nixpacks --test docker_run_tests -- --list --format=terse | sed -z 's/: test\n/\", \"/g' | sed 's/...$//')]}"
+          echo "matrix={\"tests\":[\"$(cargo test -q --package nixpacks --test docker_run_tests -- --list --format=terse | sed -z 's/: test\n/\", \"/g' | sed 's/...$//')]}" >> $GITHUB_OUTPUT
 
   test-docker:
     needs: test-plan

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Use Node
         uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +%s)"
+        run: echo "date=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Build and push [Ubuntu]
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -65,8 +67,10 @@ jobs:
       - name: Bump base image
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
-          sed -i 's/nixpacks:debian-.*/nixpacks:debian-${{ steps.date.outputs.date }}";/g' src/nixpacks/images.rs
-          sed -i 's/nixpacks:ubuntu-.*/nixpacks:ubuntu-${{ steps.date.outputs.date }}";/g' src/nixpacks/images.rs
+          sed -i 's/nixpacks:debian-.*/nixpacks:debian-${STEPS_DATE_OUTPUTS_DATE}";/g' src/nixpacks/images.rs
+          sed -i 's/nixpacks:ubuntu-.*/nixpacks:ubuntu-${STEPS_DATE_OUTPUTS_DATE}";/g' src/nixpacks/images.rs
+        env:
+          STEPS_DATE_OUTPUTS_DATE: ${{ steps.date.outputs.date }}
 
       - name: Create Pull Request
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
       if: matrix.config.os == 'macos-latest'
       id: shasum
       run: |
-        echo ::set-output name=sha::"$(shasum -a 256 ./release/gitui-mac.tar.gz | awk '{printf $1}')"
+        echo "sha=\"$(shasum -a 256 ./release/gitui-mac.tar.gz | awk '{printf $1}')\"" >> $GITHUB_OUTPUT
 
     - name: Update homebrew tap
       uses: mislav/bump-homebrew-formula-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,15 @@ jobs:
           #
           # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
           echo "NIXPACKS_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "version is: ${{ env.NIXPACKS_VERSION }}"
+          echo "version is: ${NIXPACKS_VERSION}"
+        env:
+          NIXPACKS_VERSION: ${{ env.NIXPACKS_VERSION }}
 
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Build Changelog
         id: build_changelog
@@ -103,6 +106,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        persist-credentials: false
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -124,16 +128,20 @@ jobs:
       run: |
         cd target/${{ matrix.target }}/release
         strip nixpacks.exe
-        7z a ../../../nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.target }}.zip nixpacks.exe
+        7z a ../../../nixpacks-${NEEDS_CREATE_RELEASE_OUTPUTS_NIXPACKS_VERSION}-${{ matrix.target }}.zip nixpacks.exe
         cd -
+      env:
+        NEEDS_CREATE_RELEASE_OUTPUTS_NIXPACKS_VERSION: ${{ needs.create-release.outputs.nixpacks_version }}
 
     - name: Prepare binaries [-linux]
       if: matrix.os != 'windows-latest'
       run: |
         cd target/${{ matrix.target }}/release
         strip nixpacks || true
-        tar czvf ../../../nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.target }}.tar.gz nixpacks
+        tar czvf ../../../nixpacks-${NEEDS_CREATE_RELEASE_OUTPUTS_NIXPACKS_VERSION}-${{ matrix.target }}.tar.gz nixpacks
         cd -
+      env:
+        NEEDS_CREATE_RELEASE_OUTPUTS_NIXPACKS_VERSION: ${{ needs.create-release.outputs.nixpacks_version }}
 
     # - name: Add Checksums
     #   run: for file in nixpacks-*/nixpacks-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done
@@ -152,7 +160,9 @@ jobs:
 
     - name: Generate .deb package file
       if: matrix.target == 'x86_64-unknown-linux-gnu'
-      run: cargo deb --target ${{ matrix.target }} --output nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-amd64.deb
+      run: cargo deb --target ${{ matrix.target }} --output nixpacks-${NEEDS_CREATE_RELEASE_OUTPUTS_NIXPACKS_VERSION}-amd64.deb
+      env:
+        NEEDS_CREATE_RELEASE_OUTPUTS_NIXPACKS_VERSION: ${{ needs.create-release.outputs.nixpacks_version }}
 
     - name: Upload .deb package file
       if: matrix.target == 'x86_64-unknown-linux-gnu'
@@ -177,7 +187,9 @@ jobs:
       run: >
         cargo wix -v --no-build --nocapture
         --target ${{ matrix.target }}
-        --output nixpacks-${{ needs.create-release.outputs.nixpacks_version }}-${{ matrix.target }}.msi
+        --output nixpacks-${NEEDS_CREATE_RELEASE_OUTPUTS_NIXPACKS_VERSION}-${{ matrix.target }}.msi
+      env:
+        NEEDS_CREATE_RELEASE_OUTPUTS_NIXPACKS_VERSION: ${{ needs.create-release.outputs.nixpacks_version }}
 
     - name: Upload windows installers
       continue-on-error: true

--- a/.github/workflows/update-nixpkgs-archive.yml
+++ b/.github/workflows/update-nixpkgs-archive.yml
@@ -38,8 +38,8 @@ jobs:
           sed -i "/\/\/ https:\/\/github.com\/NixOS\/nixpkgs\/commit/c\/\/ $URL" src/nixpacks/nix/mod.rs
           sed -i "/const NIXPKGS_ARCHIVE: &str/c\pub const NIXPKGS_ARCHIVE: &str = \"$SHA\";" src/nixpacks/nix/mod.rs
 
-          echo "::set-output name=sha::$SHA"
-          echo "::set-output name=url::$URL"
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "url=$URL" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/update-nixpkgs-archive.yml
+++ b/.github/workflows/update-nixpkgs-archive.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install jq
         run: sudo apt-get install -y jq


### PR DESCRIPTION
This PR focuses on updating the GitHub actions of this repo. There are two things I am targetting here.

* [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
* [Zizmor](https://github.com/zizmorcore/zizmor) (a GH action security audit tool) auto fixes
  * There are more "errors" pointed out, but the ones captured here are super low hanging, easy fixes.

<details><summary>A bit more on zizmor</summary>
<p>

Feel free to try it out with `uvx zizmor .` 

It is "Static analysis for GitHub Actions". You might want to opt into some of the more opinionated changes (no auto fixes for them).

</p>
</details> 