### PR TITLE
feat: add collectstatic to Django start

### DIFF
--- a/src/providers/python.rs
+++ b/src/providers/python.rs
@@ -387,7 +387,7 @@ impl PythonProvider {
             let app_name = PythonProvider::get_django_app_name(app, env)?;
 
             return Ok(Some(StartPhase::new(format!(
-                "python manage.py migrate && gunicorn {app_name}"
+                "python manage.py collectstatic --no-input && python manage.py migrate && gunicorn {app_name}"
             ))));
         }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
<!-- Please add a useful description explaining what this PR does -->

This PR adds the `collectstatic` Django management command to the `start` phase for Django apps.

This is extremely common for Django apps. See:
- https://docs.djangoproject.com/en/5.2/ref/contrib/staticfiles/#collectstatic 
- https://www.loopwerk.io/articles/2025/coolify-django/

<!-- PR Checklist  -->
<!-- - [ ] Tests are added/updated if needed  -->
<!-- - [ ] Docs are updated if needed  -->
