### PR TITLE
Update Bun to stable status and nixpkgs archive

### DIFF
--- a/docs/pages/docs/providers/node.md
+++ b/docs/pages/docs/providers/node.md
@@ -105,7 +105,7 @@ Corepack will only be used on Node 16 and above.
 
 ## Bun Support
 
-We support Bun, but due to Bun being in alpha, it is unstable and very experimental.
+We support Bun as a stable package manager and runtime.
 
 ## SPA Application Support
 

--- a/examples/node-bun-prisma/package.json
+++ b/examples/node-bun-prisma/package.json
@@ -6,6 +6,9 @@
     "build": "bun run prisma generate",
     "start": "bunx prisma migrate deploy"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "devDependencies": {
     "bun-types": "latest",
     "prisma": "5.3.1"

--- a/examples/node-bun-web-server/package.json
+++ b/examples/node-bun-web-server/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "start": "bun index.ts"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "devDependencies": {
     "bun-types": "latest"
   },

--- a/examples/node-bun/package.json
+++ b/examples/node-bun/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "start": "bun index.ts"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "devDependencies": {
     "@types/figlet": "^1.5.6",
     "bun-types": "latest"

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -27,7 +27,7 @@ pub const NODE_OVERLAY: &str = "https://github.com/railwayapp/nix-npm-overlay/ar
 
 // unlike package managers, {node,bun} versions are pinned to a particular nixpacks release
 const NODE_NIXPKGS_ARCHIVE: &str = "ffeebf0acf3ae8b29f8c7049cd911b9636efd7e7";
-const BUN_NIXPKGS_ARCHIVE: &str = "f69ae4816bc1b501460ad2c0c63ed0cc4a9b876e";
+const BUN_NIXPKGS_ARCHIVE: &str = "5a0711127cd8b916c3d3128f473388c8c79df0da";
 
 // We need to use a specific commit hash for Node versions <16 since it is EOL in the latest Nix packages
 const NODE_LT_16_ARCHIVE: &str = "bf744fe90419885eefced41b3e5ae442d732712d";

--- a/tests/snapshots/generate_plan_tests__node_bun.snap
+++ b/tests/snapshots/generate_plan_tests__node_bun.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_18",
+        "nodejs_22",
         "bun"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_bun_prisma.snap
+++ b/tests/snapshots/generate_plan_tests__node_bun_prisma.snap
@@ -42,7 +42,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_18",
+        "nodejs_22",
         "bun",
         "openssl"
       ],

--- a/tests/snapshots/generate_plan_tests__node_bun_web_server.snap
+++ b/tests/snapshots/generate_plan_tests__node_bun_web_server.snap
@@ -39,7 +39,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_18",
+        "nodejs_22",
         "bun"
       ],
       "nixOverlays": [


### PR DESCRIPTION
Updated Bun support to reflect stable status and latest nixpkgs archive.

- Remove alpha/experimental status from Bun documentation  
- Update BUN_NIXPKGS_ARCHIVE to 5a0711127cd8b916c3d3128f473388c8c79df0da

Closes #1342