### PR TITLE
Update Gleam provider to install version chosen in main toml

### DIFF
--- a/docs/pages/docs/providers/gleam.md
+++ b/docs/pages/docs/providers/gleam.md
@@ -8,7 +8,7 @@ Gleam is detected if both `gleam.toml` and `manifest.toml` are found.
 
 ## Setup & Install
 
-Nixpacks will detect the Gleam version your project uses from your `manifest.toml`. It will also install Erlang, Elixir and Rebar3.
+Nixpacks will detect the Gleam version your project uses from your `gleam.toml` if you fill in the optional `gleam` field with just a version number like `1.12.0`. It will also install Erlang, Elixir and Rebar3.
 
 ## Build
 

--- a/examples/basic_gleam/gleam.toml
+++ b/examples/basic_gleam/gleam.toml
@@ -1,6 +1,8 @@
 name = "basic_gleam"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Gleam project"
+
+gleam = "1.12.0"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.
@@ -10,4 +12,4 @@ description = "A Gleam project"
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.28.0"
+gleam_stdlib = ">= 0.62.0 and < 2.0.0"

--- a/examples/basic_gleam/manifest.toml
+++ b/examples/basic_gleam/manifest.toml
@@ -2,8 +2,8 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.28.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "088E334A00C9530D4B194F31406E51B6E4E4697C6A380D11591E60CC2F239724" },
+  { name = "gleam_stdlib", version = "0.62.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0080706D3A5A9A36C40C68481D1D231D243AF602E6D2A2BE67BA8F8F4DFF45EC" },
 ]
 
 [requirements]
-gleam_stdlib = "~> 0.28.0"
+gleam_stdlib = { version = ">= 0.62.0 and < 2.0.0" }

--- a/src/providers/gleam/mod.rs
+++ b/src/providers/gleam/mod.rs
@@ -10,6 +10,8 @@ use crate::nixpacks::{
     },
 };
 
+const PKGS_ARCHIVE: &str = "bcc20cad1608fbbe08641e5106c0755cfd0154ad";
+
 use super::Provider;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -77,7 +79,10 @@ impl GleamProvider {
             "rebar3".into(),
         ];
 
-        Phase::setup(Some(pkgs))
+        let mut phase = Phase::setup(Some(pkgs));
+        phase.set_nix_archive(PKGS_ARCHIVE.to_string());
+
+        phase
     }
 
     fn get_install(&self, app: &App, _env: &Environment) -> Result<Phase> {

--- a/tests/snapshots/generate_plan_tests__basic_gleam.snap
+++ b/tests/snapshots/generate_plan_tests__basic_gleam.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/generate_plan_tests.rs
-assertion_line: 4
 expression: plan
 ---
 {
@@ -28,7 +27,7 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "sh /assets/get-gleam.sh 0.28.2",
+        "sh /assets/get-gleam.sh 1.12.0",
         "gleam deps download"
       ],
       "onlyIncludeFiles": [


### PR DESCRIPTION
This PR helps avoid the guesswork of basing the gleam version off the stdlib version which doesn't really work. Also updates the Nixpks archive version to install a more modern version of erlang dep which the current gleam stdlib requires

<!-- PR Checklist  -->
<!-- - [x] Tests are added/updated if needed  -->
<!-- - [x] Docs are updated if needed  -->
