### PR TITLE
Add maintenance mode notices to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Crates.io](https://img.shields.io/crates/v/nixpacks)](https://crates.io/crates/nixpacks)
 [![Rust: 1.70+](https://img.shields.io/badge/rust-1.70+-93450a)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
 
+> **⚠️ Maintenance Mode:** This project is currently in maintenance mode and is not under active development. We recommend using [Railpack](https://github.com/railwayapp/railpack) as a replacement.
+
 **App source + Nix packages + Docker = Image**
 
 Nixpacks takes a source directory and produces an OCI compliant image that can be deployed anywhere. The project was started by the [Railway](https://railway.app) team as an alternative to [Buildpacks](https://buildpacks.io/) and attempts to address a lot of the shortcomings and issues that occurred when deploying thousands of user apps to the Railway platform. The biggest change is that system and language dependencies are pulled from the Nix ecosystem.

--- a/docs/pages/docs/index.md
+++ b/docs/pages/docs/index.md
@@ -4,6 +4,8 @@ title: Introduction
 
 # {% $markdoc.frontmatter.title %}
 
+> **Note:** Nixpacks is currently in maintenance mode and is not under active development.
+
 Nixpacks takes a source directory and produces an OCI compliant image that can be deployed anywhere. The project was started by [Railway](https://railway.app) and is open source on [GitHub](https://github.com/railwayapp/nixpacks).
 
 The core principles of Nixpacks are


### PR DESCRIPTION
Adds maintenance mode notices indicating that Nixpacks is not under active development, with a recommendation to use Railpack as a replacement.

Closes #1363