### PR TITLE
Add Node 24 support and refactor version-to-archive mapping

### DIFF
--- a/examples/node-24-pnpm-10/index.js
+++ b/examples/node-24-pnpm-10/index.js
@@ -1,0 +1,1 @@
+console.log("Hello from Node");

--- a/examples/node-24-pnpm-10/node_modules/.pnpm-workspace-state.json
+++ b/examples/node-24-pnpm-10/node_modules/.pnpm-workspace-state.json
@@ -1,0 +1,25 @@
+{
+  "lastValidatedTimestamp": 1761270935933,
+  "projects": {},
+  "pnpmfileExists": false,
+  "settings": {
+    "autoInstallPeers": true,
+    "dedupeDirectDeps": false,
+    "dedupeInjectedDeps": true,
+    "dedupePeerDependents": true,
+    "dev": true,
+    "excludeLinksFromLockfile": false,
+    "hoistPattern": [
+      "*"
+    ],
+    "hoistWorkspacePackages": true,
+    "injectWorkspacePackages": false,
+    "linkWorkspacePackages": false,
+    "nodeLinker": "isolated",
+    "optional": true,
+    "preferWorkspacePackages": false,
+    "production": true,
+    "publicHoistPattern": []
+  },
+  "filteredInstall": false
+}

--- a/examples/node-24-pnpm-10/package.json
+++ b/examples/node-24-pnpm-10/package.json
@@ -7,5 +7,6 @@
   },
   "engines": {
     "node": "24.x"
-  }
+  },
+  "packageManager": "pnpm@10.0.0"
 }

--- a/examples/node-24-pnpm-10/package.json
+++ b/examples/node-24-pnpm-10/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "node",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "engines": {
+    "node": "24.x"
+  }
+}

--- a/examples/node-24-pnpm-10/pnpm-lock.yaml
+++ b/examples/node-24-pnpm-10/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub mod nixpacks;
 pub mod providers;
 
 /// Supplies all currently-defined providers to build plan generators and image builders.
-pub fn get_providers() -> &'static [&'static (dyn Provider)] {
+pub fn get_providers() -> &'static [&'static dyn Provider] {
     &[
         &CrystalProvider {},
         &CSharpProvider {},

--- a/src/nixpacks/plan/generator.rs
+++ b/src/nixpacks/plan/generator.rs
@@ -26,7 +26,7 @@ pub struct GeneratePlanOptions {
 
 /// Holds plan options and providers for a build.
 pub struct NixpacksBuildPlanGenerator<'a> {
-    providers: &'a [&'a (dyn Provider)],
+    providers: &'a [&'a dyn Provider],
     config: GeneratePlanOptions,
 }
 
@@ -50,7 +50,7 @@ impl PlanGenerator for NixpacksBuildPlanGenerator<'_> {
 
 impl NixpacksBuildPlanGenerator<'_> {
     pub fn new<'a>(
-        providers: &'a [&'a (dyn Provider)],
+        providers: &'a [&'a dyn Provider],
         config: GeneratePlanOptions,
     ) -> NixpacksBuildPlanGenerator<'a> {
         NixpacksBuildPlanGenerator { providers, config }

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -26,14 +26,20 @@ mod turborepo;
 pub const NODE_OVERLAY: &str = "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz";
 
 // unlike package managers, {node,bun} versions are pinned to a particular nixpacks release
-const NODE_NIXPKGS_ARCHIVE: &str = "ffeebf0acf3ae8b29f8c7049cd911b9636efd7e7";
-const BUN_NIXPKGS_ARCHIVE: &str = "5a0711127cd8b916c3d3128f473388c8c79df0da";
-
-// We need to use a specific commit hash for Node versions <16 since it is EOL in the latest Nix packages
-const NODE_LT_16_ARCHIVE: &str = "bf744fe90419885eefced41b3e5ae442d732712d";
+const BUN_NIXPKGS_ARCHIVE: &str = "31fb21469e34b6b5c7be77b9a35bae43d0c598e9";
 
 const DEFAULT_NODE_VERSION: u32 = 18;
-const AVAILABLE_NODE_VERSIONS: &[u32] = &[14, 16, 18, 20, 22, 23];
+
+// From: https://lazamar.co.uk/nix-versions/?channel=nixpkgs-unstable&package=nodejs
+// Maps Node version to nixpkgs archive hash
+const AVAILABLE_NODE_VERSIONS: &[(u32, &str)] = &[
+    (14, "bf744fe90419885eefced41b3e5ae442d732712d"), // EOL version, older nixpkgs
+    (16, "bf744fe90419885eefced41b3e5ae442d732712d"), // EOL version, older nixpkgs
+    (18, "ffeebf0acf3ae8b29f8c7049cd911b9636efd7e7"),
+    (20, "ffeebf0acf3ae8b29f8c7049cd911b9636efd7e7"),
+    (22, "e6f23dc08d3624daab7094b701aa3954923c6bbb"),
+    (24, "23f9169c4ccce521379e602cc82ed873a1f1b52b"),
+];
 
 const YARN_CACHE_DIR: &str = "/usr/local/share/.cache/yarn/v6";
 const PNPM_CACHE_DIR: &str = "/root/.local/share/pnpm/store/v3";
@@ -502,15 +508,27 @@ impl NodeProvider {
         let package_json: PackageJson = app.read_json("package.json").unwrap_or_default();
         let package_manager = NodeProvider::get_package_manager(app);
         let node_pkg = NodeProvider::get_nix_node_pkg(&package_json, app, &Environment::default())?;
-        let uses_le_16 = node_pkg.name.contains("14") || node_pkg.name.contains("16");
 
-        if uses_le_16 {
-            Ok(NODE_LT_16_ARCHIVE.to_string())
-        } else if package_manager == "bun" {
-            Ok(BUN_NIXPKGS_ARCHIVE.to_string())
-        } else {
-            Ok(NODE_NIXPKGS_ARCHIVE.to_string())
+        // Bun uses a separate archive
+        if package_manager == "bun" {
+            return Ok(BUN_NIXPKGS_ARCHIVE.to_string());
         }
+
+        // Extract version number from package name (e.g., "nodejs_18" -> 18)
+        let version = node_pkg.name
+            .strip_prefix("nodejs_")
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(DEFAULT_NODE_VERSION);
+
+        // Look up the archive for this version
+        let archive = version_number_to_archive(version)
+            .unwrap_or_else(|| {
+                // Fallback to default version's archive
+                version_number_to_archive(DEFAULT_NODE_VERSION)
+                    .expect("Default node version must exist in AVAILABLE_NODE_VERSIONS")
+            });
+
+        Ok(archive.to_string())
     }
 
     /// Returns the nodejs nix package and the appropriate package manager nix image.
@@ -536,6 +554,8 @@ impl NodeProvider {
                 pm_pkg = Pkg::new("pnpm-7_x");
             } else if lockfile.starts_with("lockfileVersion: '6.0'") {
                 pm_pkg = Pkg::new("pnpm-8_x");
+            } else if lockfile.starts_with("lockfileVersion: '9.0'") {
+                pm_pkg = Pkg::new("pnpm-10_x");
             } else {
                 // Default to pnpm 9
                 pm_pkg = Pkg::new("pnpm-9_x");
@@ -682,8 +702,19 @@ impl NodeProvider {
     }
 }
 
+fn version_number_to_archive(version: u32) -> Option<&'static str> {
+    AVAILABLE_NODE_VERSIONS
+        .iter()
+        .find(|(ver, _archive)| *ver == version)
+        .map(|(_ver, archive)| *archive)
+}
+
 fn version_number_to_pkg(version: u32) -> String {
-    if AVAILABLE_NODE_VERSIONS.contains(&version) {
+    let version_exists = AVAILABLE_NODE_VERSIONS
+        .iter()
+        .any(|(ver, _archive)| *ver == version);
+
+    if version_exists {
         format!("nodejs_{version}")
     } else {
         format!("nodejs_{DEFAULT_NODE_VERSION}")
@@ -698,8 +729,9 @@ fn parse_node_version_into_pkg(node_version: &str) -> String {
     });
     let mut available_lts_node_versions = AVAILABLE_NODE_VERSIONS
         .iter()
-        .filter(|v| *v % 2 == 0)
-        .collect::<Vec<_>>();
+        .map(|(ver, _archive)| *ver)
+        .filter(|v| v % 2 == 0)
+        .collect::<Vec<u32>>();
 
     // use newest node version first
     available_lts_node_versions.sort_by(|a, b| b.cmp(a));
@@ -707,7 +739,7 @@ fn parse_node_version_into_pkg(node_version: &str) -> String {
         let version_range_string = format!("{version_number}.x.x");
         let version_range: Range = version_range_string.parse().unwrap();
         if version_range.allows_any(&range) {
-            return version_number_to_pkg(*version_number);
+            return version_number_to_pkg(version_number);
         }
     }
     default_node_pkg_name

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -515,18 +515,18 @@ impl NodeProvider {
         }
 
         // Extract version number from package name (e.g., "nodejs_18" -> 18)
-        let version = node_pkg.name
+        let version = node_pkg
+            .name
             .strip_prefix("nodejs_")
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(DEFAULT_NODE_VERSION);
 
         // Look up the archive for this version
-        let archive = version_number_to_archive(version)
-            .unwrap_or_else(|| {
-                // Fallback to default version's archive
-                version_number_to_archive(DEFAULT_NODE_VERSION)
-                    .expect("Default node version must exist in AVAILABLE_NODE_VERSIONS")
-            });
+        let archive = version_number_to_archive(version).unwrap_or_else(|| {
+            // Fallback to default version's archive
+            version_number_to_archive(DEFAULT_NODE_VERSION)
+                .expect("Default node version must exist in AVAILABLE_NODE_VERSIONS")
+        });
 
         Ok(archive.to_string())
     }
@@ -547,18 +547,35 @@ impl NodeProvider {
         pkgs.push(node_pkg);
 
         if package_manager == "pnpm" {
-            let lockfile = app.read_file("pnpm-lock.yaml").unwrap_or_default();
-            if lockfile.starts_with("lockfileVersion: 5.3") {
-                pm_pkg = Pkg::new("pnpm-6_x");
-            } else if lockfile.starts_with("lockfileVersion: 5.4") {
-                pm_pkg = Pkg::new("pnpm-7_x");
-            } else if lockfile.starts_with("lockfileVersion: '6.0'") {
-                pm_pkg = Pkg::new("pnpm-8_x");
-            } else if lockfile.starts_with("lockfileVersion: '9.0'") {
-                pm_pkg = Pkg::new("pnpm-10_x");
+            // First, try to determine version from packageManager field (for corepack)
+            if let Some(ref pkg_manager_field) = package_json.package_manager {
+                if let Some(version_str) = pkg_manager_field.strip_prefix("pnpm@") {
+                    // Parse major version from "pnpm@9.0.3" -> 9
+                    if let Some(major_version) = version_str.split('.').next() {
+                        if let Ok(major) = major_version.parse::<u32>() {
+                            pm_pkg = match major {
+                                6 => Pkg::new("pnpm-6_x"),
+                                7 => Pkg::new("pnpm-7_x"),
+                                8 => Pkg::new("pnpm-8_x"),
+                                9 => Pkg::new("pnpm-9_x"),
+                                10 => Pkg::new("pnpm-10_x"),
+                                _ => {
+                                    // For unknown versions, try lockfile detection
+                                    NodeProvider::get_pnpm_package_from_lockfile(app)
+                                }
+                            };
+                        } else {
+                            pm_pkg = NodeProvider::get_pnpm_package_from_lockfile(app);
+                        }
+                    } else {
+                        pm_pkg = NodeProvider::get_pnpm_package_from_lockfile(app);
+                    }
+                } else {
+                    pm_pkg = NodeProvider::get_pnpm_package_from_lockfile(app);
+                }
             } else {
-                // Default to pnpm 9
-                pm_pkg = Pkg::new("pnpm-9_x");
+                // Fall back to lockfile-based detection
+                pm_pkg = NodeProvider::get_pnpm_package_from_lockfile(app);
             }
         } else if package_manager == "yarn" {
             pm_pkg = Pkg::new("yarn-1_x");
@@ -665,6 +682,21 @@ impl NodeProvider {
         all_deps.extend(dev_deps);
 
         all_deps
+    }
+
+    fn get_pnpm_package_from_lockfile(app: &App) -> Pkg {
+        let lockfile = app.read_file("pnpm-lock.yaml").unwrap_or_default();
+        if lockfile.starts_with("lockfileVersion: 5.3") {
+            Pkg::new("pnpm-6_x")
+        } else if lockfile.starts_with("lockfileVersion: 5.4") {
+            Pkg::new("pnpm-7_x")
+        } else if lockfile.starts_with("lockfileVersion: '6.0'") {
+            Pkg::new("pnpm-8_x")
+        } else if lockfile.starts_with("lockfileVersion: '9.0'") {
+            Pkg::new("pnpm-9_x")
+        } else {
+            Pkg::new("pnpm-9_x")
+        }
     }
 
     pub fn cache_tsbuildinfo_file(app: &App, build: &mut Phase) {
@@ -831,7 +863,7 @@ mod test {
                 &App::new("examples/node")?,
                 &Environment::default()
             )?,
-            Pkg::new(version_number_to_pkg(22).as_str())
+            Pkg::new(version_number_to_pkg(24).as_str())
         );
 
         Ok(())

--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -692,9 +692,8 @@ impl NodeProvider {
             Pkg::new("pnpm-7_x")
         } else if lockfile.starts_with("lockfileVersion: '6.0'") {
             Pkg::new("pnpm-8_x")
-        } else if lockfile.starts_with("lockfileVersion: '9.0'") {
-            Pkg::new("pnpm-9_x")
         } else {
+            // lockfileVersion '9.0' and unknown versions default to pnpm 9
             Pkg::new("pnpm-9_x")
         }
     }

--- a/src/providers/node/nx.rs
+++ b/src/providers/node/nx.rs
@@ -45,16 +45,6 @@ pub struct Configuration {
     pub production: Option<Value>,
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq, Deserialize)]
-pub struct PackageJsonNx {
-    pub nx: Option<PackageJsonNxTargets>,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq, Deserialize)]
-pub struct PackageJsonNxTargets {
-    pub targets: Option<Targets>,
-}
-
 pub struct Nx {}
 
 const NX_APP_NAME_ENV_VAR: &str = "NX_APP_NAME";

--- a/tests/snapshots/generate_plan_tests__node_24_pnpm_10.snap
+++ b/tests/snapshots/generate_plan_tests__node_24_pnpm_10.snap
@@ -8,7 +8,6 @@ expression: plan
   "variables": {
     "CI": "true",
     "NIXPACKS_METADATA": "node",
-    "NIXPACKS_SPA_OUTPUT_DIR": "dist",
     "NODE_ENV": "production",
     "NPM_CONFIG_PRODUCTION": "false"
   },
@@ -17,9 +16,6 @@ expression: plan
       "name": "build",
       "dependsOn": [
         "install"
-      ],
-      "cmds": [
-        "npm run build"
       ],
       "cacheDirectories": [
         "node_modules/.cache"
@@ -31,10 +27,11 @@ expression: plan
         "setup"
       ],
       "cmds": [
-        "npm ci"
+        "npm install -g corepack@0.24.1 && corepack enable",
+        "pnpm i --frozen-lockfile"
       ],
       "cacheDirectories": [
-        "/root/.npm"
+        "/root/.local/share/pnpm/store/v3"
       ],
       "paths": [
         "/app/node_modules/.bin"
@@ -44,7 +41,7 @@ expression: plan
       "name": "setup",
       "nixPkgs": [
         "nodejs_24",
-        "npm-9_x"
+        "pnpm-10_x"
       ],
       "nixOverlays": [
         "https://github.com/railwayapp/nix-npm-overlay/archive/main.tar.gz"
@@ -53,6 +50,6 @@ expression: plan
     }
   },
   "start": {
-    "cmd": "npm run start"
+    "cmd": "pnpm run start"
   }
 }

--- a/tests/snapshots/generate_plan_tests__node_pnpm_corepack.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_corepack.snap
@@ -43,7 +43,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_22",
+        "nodejs_24",
         "pnpm-9_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_pnpm_monorepo.snap
+++ b/tests/snapshots/generate_plan_tests__node_pnpm_monorepo.snap
@@ -45,7 +45,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_22",
+        "nodejs_24",
         "pnpm-9_x"
       ],
       "nixOverlays": [

--- a/tests/snapshots/generate_plan_tests__node_turborepo.snap
+++ b/tests/snapshots/generate_plan_tests__node_turborepo.snap
@@ -44,7 +44,7 @@ expression: plan
     "setup": {
       "name": "setup",
       "nixPkgs": [
-        "nodejs_22",
+        "nodejs_24",
         "npm-8_x"
       ],
       "nixOverlays": [


### PR DESCRIPTION
Refactors Node version management to use a tuple array mapping versions to nix archive hashes, similar to the Swift and Go providers.

- Add Node 24 support with specific nix archive
- Remove Node 23 (was unreachable due to LTS filtering)
- Add Node 22-specific nix archive
- Update Bun nixpkgs archive (supports Bun 1.3)
- Refactor version management to use tuple array instead of separate constants
- Add pnpm 10 support

Closes https://github.com/railwayapp/nixpacks/issues/1359
Closes https://github.com/railwayapp/nixpacks/issues/1340
Closes https://github.com/railwayapp/nixpacks/issues/1326
Closes https://github.com/railwayapp/nixpacks/issues/1330