### PR TITLE
docs: add maintenance mode notice and recommend Railpack

### DIFF
--- a/docs/pages/docs/getting-started.md
+++ b/docs/pages/docs/getting-started.md
@@ -4,6 +4,8 @@ title: Getting Started
 
 # {% $markdoc.frontmatter.title %}
 
+> **⚠️ Maintenance Mode:** This project is currently in maintenance mode and is not under active development. We recommend using [Railpack](https://github.com/railwayapp/railpack) as a replacement.
+
 To get started with Nixpacks you need an app that you want to build and package. You can bring your own or use one of the [many examples on GitHub](https://github.com/railwayapp/nixpacks/tree/main/examples).
 
 ## 1. Install

--- a/docs/pages/docs/index.md
+++ b/docs/pages/docs/index.md
@@ -4,7 +4,7 @@ title: Introduction
 
 # {% $markdoc.frontmatter.title %}
 
-> **Note:** Nixpacks is currently in maintenance mode and is not under active development.
+> **⚠️ Maintenance Mode:** This project is currently in maintenance mode and is not under active development. We recommend using [Railpack](https://github.com/railwayapp/railpack) as a replacement.
 
 Nixpacks takes a source directory and produces an OCI compliant image that can be deployed anywhere. The project was started by [Railway](https://railway.app) and is open source on [GitHub](https://github.com/railwayapp/nixpacks).
 

--- a/docs/pages/docs/install.md
+++ b/docs/pages/docs/install.md
@@ -4,6 +4,8 @@ title: Installation
 
 # {% $markdoc.frontmatter.title %}
 
+> **⚠️ Maintenance Mode:** This project is currently in maintenance mode and is not under active development. We recommend using [Railpack](https://github.com/railwayapp/railpack) as a replacement.
+
 ## Homebrew
 
 Install Nixpacks with [Homebrew](https://brew.sh/) (macOS Only)

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -3,6 +3,8 @@ title: Nixpacks
 description: App source + Nix packages + Docker = Image
 ---
 
+> **⚠️ Maintenance Mode:** This project is currently in maintenance mode and is not under active development. We recommend using [Railpack](https://github.com/railwayapp/railpack) as a replacement.
+
 ## What is it?
 
 Nixpacks takes a source directory and produces an OCI compliant image that can be deployed anywhere. The project is open source on [GitHub](https://github.com/railwayapp/nixpacks).


### PR DESCRIPTION
Updated all high-traffic documentation pages to include a prominent maintenance mode warning that recommends Railpack as the replacement for Nixpacks. This ensures users are aware of the project's status and are directed to the actively maintained alternative.
