### PR TITLE
docs: add documentation on configuring phases with multiple providers

### DIFF
--- a/docs/pages/docs/configuration/file.md
+++ b/docs/pages/docs/configuration/file.md
@@ -108,6 +108,28 @@ However, there is no restriction on the names of phases or what they are named.
 # ...
 ```
 
+### Multiple Providers
+
+When using multiple providers, phases for the first specified provider can be referenced by their normal names. To configure phases for additional providers, prefix the phase name with the provider name and a colon using the `"provider:phase"` syntax (quotes are required for valid TOML).
+
+For example, with both Python and Node providers:
+
+```toml
+providers = ["python", "node"]
+
+# Targets the first provider's (python) install phase
+[phases.install]
+cmds = ["pip install -r requirements.txt"]
+
+# Targets the node provider's install phase
+[phases."node:install"]
+cmds = ["npm ci"]
+
+# Targets the node provider's build phase
+[phases."node:build"]
+cmds = ["npm run build"]
+```
+
 ### Commands
 
 Array of commands to run.


### PR DESCRIPTION
## Summary
- Document the `phases."provider:phase"` syntax for configuring provider-specific phases in multi-provider builds
- Added a "Multiple Providers" subsection under Phases in the configuration file reference

## Why this matters
[#1309](https://github.com/railwayapp/nixpacks/issues/1309) - The multi-provider phase syntax works but is undocumented, making it hard for users to discover how to customize phases when using multiple providers.

## Changes
- `docs/pages/docs/configuration/file.md`: Added "Multiple Providers" section with syntax explanation and example showing Python + Node provider configuration

Fixes #1309

This contribution was developed with AI assistance (Claude Code).