### PR TITLE
fix(node): use real environment for nixpkgs archive resolution

### DIFF
--- a/src/providers/node/mod.rs
+++ b/src/providers/node/mod.rs
@@ -141,7 +141,7 @@ impl Provider for NodeProvider {
     fn get_build_plan(&self, app: &App, env: &Environment) -> Result<Option<BuildPlan>> {
         // Setup
         let mut setup = Phase::setup(Some(NodeProvider::get_nix_packages(app, env)?));
-        setup.set_nix_archive(NodeProvider::get_nix_archive(app)?);
+        setup.set_nix_archive(NodeProvider::get_nix_archive(app, env)?);
         if NodeProvider::uses_node_dependency(app, "prisma") {
             setup.add_nix_pkgs(&[Pkg::new("openssl")]);
         }
@@ -504,10 +504,10 @@ impl NodeProvider {
     }
 
     /// Returns the Nix archive to use for the Node and related packages
-    pub fn get_nix_archive(app: &App) -> Result<String> {
+    pub fn get_nix_archive(app: &App, env: &Environment) -> Result<String> {
         let package_json: PackageJson = app.read_json("package.json").unwrap_or_default();
         let package_manager = NodeProvider::get_package_manager(app);
-        let node_pkg = NodeProvider::get_nix_node_pkg(&package_json, app, &Environment::default())?;
+        let node_pkg = NodeProvider::get_nix_node_pkg(&package_json, app, env)?;
 
         // Bun uses a separate archive
         if package_manager == "bun" {


### PR DESCRIPTION
## Problem

`get_nix_archive()` uses `Environment::default()` to resolve the Node version for archive selection, while `get_nix_packages()` uses the real environment. This means `NIXPACKS_NODE_VERSION` is ignored when choosing the nixpkgs archive — only `.nvmrc` / `package.json` engines are consulted.

When `NIXPACKS_NODE_VERSION` and `.nvmrc` specify different major versions, the Node package is installed from the wrong major version's archive, silently giving a different patch version than intended.

### Concrete example

A project has:
- `NIXPACKS_NODE_VERSION=20` (set in hosting provider config)
- `.nvmrc=22.22.2` (for local dev tooling)

**Before this fix:**
- `get_nix_packages(app, env)` → resolves `NIXPACKS_NODE_VERSION=20` → installs `nodejs_20`
- `get_nix_archive(app)` → ignores `NIXPACKS_NODE_VERSION`, reads `.nvmrc=22` → selects Node 22's archive (`e6f23dc...`)
- Result: `nodejs_20` from the Node 22-era nixpkgs snapshot = **Node 20.19.2**

**Without `.nvmrc`** (e.g. production branch that predates its addition):
- `get_nix_archive(app)` → no `.nvmrc`, falls back to default (Node 18) → selects `ffeebf0...`
- Result: `nodejs_20` from that snapshot = **Node 20.18.1**

Same `NIXPACKS_NODE_VERSION=20`, different actual Node versions depending on whether `.nvmrc` exists — and which branch is being built.

### Real-world impact

This caused a production deploy failure for us. Effect v4 (an npm package) is ESM-only. `require()` of ESM modules works on Node 20.19.0+ but throws `ERR_REQUIRE_ESM` on earlier versions. Our preview environment got Node 20.19.2 (because `.nvmrc` pointed the archive to the Node 22 snapshot), while production got Node 20.18.1 (no `.nvmrc` on the production branch at the time). Preview passed, production crashed.

### Root cause

`get_nix_archive` was introduced in #1106 (May 2024) when there was only one archive for all modern Node versions — `Environment::default()` was a harmless shortcut since the archive was the same regardless of version. In #1373 (Oct 2025), archives became per-major-version, but the `Environment::default()` shortcut was carried forward. It became a bug when the archive selection started depending on which major version was resolved.

## Fix

Pass the real `Environment` through to `get_nix_archive()` so it uses the same version resolution as `get_nix_packages()`.

## Test plan

- All 57 existing node plan generation tests pass
- No other callers of `get_nix_archive` exist