### PR TITLE
fix: remove unused clap arg import in main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{arg, Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 use nixpacks::{
     create_docker_image, generate_build_plan, get_plan_providers,
     nixpacks::{


### PR DESCRIPTION
Removes stale arg import left in the clap use statement — clippy unreadable/unused import warning.